### PR TITLE
Setup general application skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "gimli",
 ]
@@ -38,10 +38,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "ash"
@@ -60,9 +72,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
@@ -113,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +141,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chunked_transfer"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a"
 
 [[package]]
 name = "codespan-reporting"
@@ -404,6 +428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +442,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aa48fab2893d8a49caa94082ae8488f4e1050d73b367881dcd2198f4199fd8"
 
 [[package]]
 name = "js-sys"
@@ -506,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -563,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.4"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "memchr",
 ]
@@ -596,14 +632,14 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -640,9 +676,9 @@ checksum = "332cd62e95873ea4f41f3dfd6bbbfc5b52aec892d7e8d534197c4720a0bbbab2"
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -687,10 +723,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "serde"
+version = "1.0.164"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.164"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -734,9 +826,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -773,6 +865,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,7 +904,13 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 name = "video_compositor"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "bytes",
  "compositor_render",
+ "serde",
+ "serde_json",
+ "signal-hook",
+ "tiny_http",
 ]
 
 [[package]]
@@ -1037,7 +1147,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -1057,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,9 @@ resolver = "2"
 
 [dependencies]
 compositor_render = { path = "compositor_render" }
+anyhow = "1.0.71"
+bytes = "1.4.0"
+serde = { version = "1.0.164", features = ["derive"] }
+serde_json = "1.0.99"
+signal-hook = "0.3.15"
+tiny_http = "0.12.0"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+
+pub struct Decoder {}
+
+impl Decoder {
+    pub fn new() -> Self {
+        Decoder {}
+    }
+
+    pub fn decode(&self, _buffer: bytes::Bytes) -> Result<Vec<bytes::Bytes>> {
+        todo!()
+    }
+}

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,0 +1,15 @@
+use anyhow::Result;
+
+pub struct Encoder {}
+
+impl Encoder {
+    pub fn new() -> Self {
+        Self {}
+    }
+    pub fn encode<I: IntoIterator<Item = bytes::Bytes>>(
+        &self,
+        _frames: I,
+    ) -> Result<Vec<bytes::Bytes>> {
+        todo!()
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,86 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::{
+    io::{Cursor, Read},
+    sync::Arc,
+    thread,
+};
+use tiny_http::{Response, Server, StatusCode};
+
+use super::state::State;
+
+#[derive(Serialize, Deserialize)]
+struct RegisterInputRequest {
+    pub port: u16,
+    pub input_id: u32,
+}
+
+#[derive(Serialize, Deserialize)]
+struct RegisterOutputRequest {
+    pub port: u16,
+    pub output_id: u32,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum Request {
+    RegisterInput(RegisterInputRequest),
+    RegisterOutput(RegisterOutputRequest),
+}
+
+fn handle_event(state: Arc<State>, event: Request) -> Result<()> {
+    match event {
+        Request::RegisterInput(RegisterInputRequest { port, input_id }) => {
+            state.add_input(port, input_id)?;
+            Ok(())
+        }
+        Request::RegisterOutput(RegisterOutputRequest { port, output_id }) => {
+            state.add_output(port, output_id)?;
+            Ok(())
+        }
+    }
+}
+
+fn handle_request(state: Arc<State>, request: &mut tiny_http::Request) -> Response<impl Read> {
+    let event = match serde_json::from_reader::<_, Request>(request.as_reader()) {
+        Ok(event) => event,
+        Err(err) => {
+            return Response::new(
+                StatusCode(500),
+                vec![],
+                Cursor::new(format!("{}", err).into_bytes()),
+                None,
+                None,
+            );
+        }
+    };
+    if let Err(err) = handle_event(state, event) {
+        return Response::new(
+            StatusCode(500),
+            vec![],
+            Cursor::new(format!("{}", err).into_bytes()),
+            None,
+            None,
+        );
+    }
+    Response::new(
+        StatusCode(200),
+        vec![],
+        Cursor::new("{}".as_bytes().to_vec()),
+        None,
+        None,
+    )
+}
+
+pub fn listen_for_events(state: Arc<State>) {
+    let server = Server::http("0.0.0.0:8001").unwrap();
+
+    thread::spawn(move || {
+        for mut request in server.incoming_requests() {
+            let response = handle_request(state.clone(), &mut request);
+            if let Err(err) = request.respond(response) {
+                eprintln!("{}", err)
+            }
+        }
+    });
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,27 @@
+use std::sync::Arc;
+
+use pipeline::Pipeline;
+use signal_hook::{consts::SIGINT, iterator::Signals};
+
+use crate::state::State;
+
+mod decoder;
+mod encoder;
+mod http;
+mod pipeline;
+mod rtp;
+mod state;
+mod tcp_connections;
+
 fn main() {
-    println!("Hello, world!");
+    let pipeline = Arc::new(Pipeline::new());
+    let state = Arc::new(State::new(pipeline.clone()));
+
+    tcp_connections::listen_for_new_connections(state.clone()).unwrap();
+    http::listen_for_events(state);
+
+    pipeline.start();
+
+    let mut signals = Signals::new([SIGINT]).unwrap();
+    signals.forever();
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::{
     decoder::Decoder,
     encoder::Encoder,
-    rtp::{RtpFrame, RtpPacker, RtpParser},
+    rtp::{RtpPacker, RtpPacket, RtpParser},
     state::{Frame, SyncHashMap},
 };
 
@@ -124,7 +124,7 @@ impl PipelineOutput {
 
         let raw_data = self
             .rtp_packer
-            .pack(encoded.into_iter().map(|i| RtpFrame { data: i }))?;
+            .pack(encoded.into_iter().map(|i| RtpPacket { data: i }))?;
         let raw_data = match raw_data {
             Some(data) => data,
             None => return Ok(()),

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,0 +1,136 @@
+use anyhow::{anyhow, Result};
+use std::{
+    sync::{mpsc::Sender, Arc, Mutex},
+    thread,
+    time::Duration,
+};
+
+use crate::{
+    decoder::Decoder,
+    encoder::Encoder,
+    rtp::{RtpFrame, RtpPacker, RtpParser},
+    state::{Frame, SyncHashMap},
+};
+
+pub struct Pipeline {
+    inputs: SyncHashMap<u32, Arc<PipelineInput>>,
+    outputs: SyncHashMap<u32, Arc<PipelineOutput>>,
+    //queue: LiveQueue,
+    //renderer: Renderer,
+}
+
+#[allow(dead_code)]
+pub struct PipelineOutput {
+    encoder: Encoder,
+    rtp_packer: RtpPacker,
+    transport: Mutex<Sender<bytes::Bytes>>,
+}
+
+pub struct PipelineInput {
+    decoder: Decoder,
+    rtp_parser: RtpParser,
+}
+
+// unpack rtp -> decode -> qeueue -> render -> endcode -> pack rtp
+// this code would be in a separate crate (render in this scenario would also separte crate)
+impl Pipeline {
+    pub fn new() -> Self {
+        Pipeline {
+            inputs: SyncHashMap::new(),
+            outputs: SyncHashMap::new(),
+        }
+    }
+
+    pub fn add_input(&self, input_id: u32) {
+        self.inputs.insert(
+            input_id,
+            Arc::new(PipelineInput {
+                decoder: Decoder::new(),
+                rtp_parser: RtpParser::new(),
+            }),
+        );
+    }
+
+    pub fn add_output(&self, input_id: u32, transport: Sender<bytes::Bytes>) {
+        self.outputs.insert(
+            input_id,
+            Arc::new(PipelineOutput {
+                encoder: Encoder::new(),
+                rtp_packer: RtpPacker::new(),
+                transport: Mutex::new(transport),
+            }),
+        );
+    }
+
+    pub fn push_input_data(&self, input_id: u32, buffer: bytes::Bytes) -> Result<()> {
+        let input = self
+            .inputs
+            .get_cloned(&input_id)
+            .ok_or_else(|| anyhow!("no input with id {}.", input_id))?;
+        input.process_input(buffer)?;
+        //self.queue.enqueue(input_id, frames);
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    fn on_output_data_received(&self, output_id: u32, frames: Vec<Frame>) {
+        let result = self
+            .outputs
+            .get_cloned(&output_id)
+            .ok_or_else(|| anyhow!("no output with id {}.", output_id))
+            .and_then(|output| output.process_output(frames));
+        if let Err(err) = result {
+            eprintln!("{}", err)
+        }
+    }
+
+    pub fn start(self: &Arc<Self>) {
+        let _pipeline = self.clone();
+        thread::spawn(|| {
+            loop {
+                // probablly sth like this
+                //
+                // let input_frames = pipeline.queue.next();
+                // let pipeline.render.render(output_frames);
+                // for let (output_id, frames) in input_frames {
+                //     self.on_output_data_received(output_id, frames)
+                // }
+                eprintln!("render loop");
+                thread::sleep(Duration::from_millis(1000));
+            }
+        });
+    }
+}
+
+impl PipelineInput {
+    fn process_input(&self, buffer: bytes::Bytes) -> Result<Vec<Frame>> {
+        self.rtp_parser
+            .parse(buffer)?
+            .into_iter()
+            .flat_map(|packet| match self.decoder.decode(packet.data) {
+                Ok(value) => value
+                    .into_iter()
+                    .map(|data| Ok(Frame { data }))
+                    .collect::<Vec<Result<Frame>>>(),
+                Err(e) => vec![Err(e)],
+            })
+            .collect()
+    }
+}
+
+impl PipelineOutput {
+    fn process_output(&self, frames: Vec<Frame>) -> Result<()> {
+        let encoded = self.encoder.encode(frames.into_iter().map(|i| i.data))?;
+
+        let raw_data = self
+            .rtp_packer
+            .pack(encoded.into_iter().map(|i| RtpFrame { data: i }))?;
+        let raw_data = match raw_data {
+            Some(data) => data,
+            None => return Ok(()),
+        };
+
+        self.transport.lock().unwrap().send(raw_data)?;
+        Ok(())
+    }
+}

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -31,8 +31,8 @@ pub struct PipelineInput {
     rtp_parser: RtpParser,
 }
 
-// unpack rtp -> decode -> qeueue -> render -> endcode -> pack rtp
-// this code would be in a separate crate (render in this scenario would also separte crate)
+// unpack rtp -> decode -> queue -> render -> encode -> pack rtp
+// this code would be in a separate crate (render in this scenario would also be a separate crate)
 impl Pipeline {
     pub fn new() -> Self {
         Pipeline {
@@ -88,7 +88,7 @@ impl Pipeline {
         let _pipeline = self.clone();
         thread::spawn(|| {
             loop {
-                // probablly sth like this
+                // probably sth like this
                 //
                 // let input_frames = pipeline.queue.next();
                 // let pipeline.render.render(output_frames);

--- a/src/rtp.rs
+++ b/src/rtp.rs
@@ -1,0 +1,32 @@
+use anyhow::Result;
+
+pub struct RtpFrame {
+    pub data: bytes::Bytes,
+}
+
+pub struct RtpPacker {}
+
+impl RtpPacker {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    #[allow(dead_code)]
+    pub fn pack<I: IntoIterator<Item = RtpFrame>>(
+        &self,
+        _frames: I,
+    ) -> Result<Option<bytes::Bytes>> {
+        todo!()
+    }
+}
+
+pub struct RtpParser {}
+
+impl RtpParser {
+    pub fn new() -> Self {
+        Self {}
+    }
+    pub fn parse(&self, _raw_data: bytes::Bytes) -> Result<Vec<RtpFrame>> {
+        todo!()
+    }
+}

--- a/src/rtp.rs
+++ b/src/rtp.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-pub struct RtpFrame {
+pub struct RtpPacket {
     pub data: bytes::Bytes,
 }
 
@@ -12,7 +12,7 @@ impl RtpPacker {
     }
 
     #[allow(dead_code)]
-    pub fn pack<I: IntoIterator<Item = RtpFrame>>(
+    pub fn pack<I: IntoIterator<Item = RtpPacket>>(
         &self,
         _frames: I,
     ) -> Result<Option<bytes::Bytes>> {
@@ -26,7 +26,7 @@ impl RtpParser {
     pub fn new() -> Self {
         Self {}
     }
-    pub fn parse(&self, _raw_data: bytes::Bytes) -> Result<Vec<RtpFrame>> {
+    pub fn parse(&self, _raw_data: bytes::Bytes) -> Result<Vec<RtpPacket>> {
         todo!()
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,6 +11,8 @@ use crate::{pipeline::Pipeline, tcp_connections};
 #[allow(dead_code)]
 pub struct Frame {
     pub data: bytes::Bytes,
+    // TODO: add timestmaps, resoultion and other usefull info
+    // TODO: move this type to renderer crate
 }
 
 #[allow(dead_code)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,106 @@
+use anyhow::{anyhow, Result};
+use std::{
+    collections::HashMap,
+    hash::Hash,
+    net::TcpStream,
+    sync::{Arc, Mutex},
+};
+
+use crate::{pipeline::Pipeline, tcp_connections};
+
+#[allow(dead_code)]
+pub struct Frame {
+    pub data: bytes::Bytes,
+}
+
+#[allow(dead_code)]
+pub struct Input {
+    port: u16,
+    input_id: u32,
+}
+
+#[allow(dead_code)]
+pub struct Output {
+    port: u16,
+    output_id: u32,
+}
+
+#[allow(dead_code)]
+pub struct PendingConnection {
+    pub port: u16,
+    pub tcp_stream: TcpStream,
+}
+
+pub struct SyncHashMap<K, V>(std::sync::Mutex<HashMap<K, V>>);
+
+impl<K, V> SyncHashMap<K, V>
+where
+    K: Eq + PartialEq + Hash,
+{
+    pub fn new() -> Self {
+        Self(Mutex::new(HashMap::new()))
+    }
+
+    pub fn insert(&self, key: K, value: V) {
+        let mut map = self.0.lock().unwrap();
+        map.insert(key, value);
+    }
+
+    pub fn remove(&self, key: &K) -> Option<V> {
+        let mut map = self.0.lock().unwrap();
+        map.remove(key)
+    }
+}
+
+impl<K, V> SyncHashMap<K, V>
+where
+    K: Eq + PartialEq + Hash,
+    V: Clone,
+{
+    pub fn get_cloned(&self, key: &K) -> Option<V> {
+        let map = self.0.lock().unwrap();
+        map.get(key).map(Clone::clone)
+    }
+}
+
+pub struct State {
+    pub inputs: SyncHashMap<u32, Input>,
+    pub outputs: SyncHashMap<u32, Output>,
+    pub pending_connections: SyncHashMap<u16, PendingConnection>,
+    pub pipeline: Arc<Pipeline>,
+}
+
+impl State {
+    pub fn new(pipeline: Arc<Pipeline>) -> State {
+        State {
+            inputs: SyncHashMap::new(),
+            outputs: SyncHashMap::new(),
+            pending_connections: SyncHashMap::new(),
+            pipeline,
+        }
+    }
+
+    pub fn add_output(&self, port: u16, output_id: u32) -> Result<()> {
+        let pending_output = self
+            .pending_connections
+            .remove(&port)
+            .ok_or_else(|| anyhow!("no pending connection for port {}", port))?;
+        self.outputs.insert(output_id, Output { port, output_id });
+
+        let sender = tcp_connections::listen_on_output(pending_output.tcp_stream);
+        self.pipeline.add_output(output_id, sender);
+        Ok(())
+    }
+
+    pub fn add_input(&self, port: u16, input_id: u32) -> Result<()> {
+        let pending_input = self
+            .pending_connections
+            .remove(&port)
+            .ok_or_else(|| anyhow!("no pending connection for port {}", port))?;
+        self.inputs.insert(input_id, Input { port, input_id });
+
+        self.pipeline.add_input(input_id);
+        tcp_connections::listen_on_input(pending_input.tcp_stream, self.pipeline.clone(), input_id);
+        Ok(())
+    }
+}

--- a/src/tcp_connections.rs
+++ b/src/tcp_connections.rs
@@ -1,0 +1,83 @@
+use anyhow::Result;
+use std::{
+    io::{Read, Write},
+    net::{Shutdown, TcpListener, TcpStream},
+    sync::{
+        mpsc::{self, Receiver, Sender},
+        Arc,
+    },
+    thread,
+};
+
+use crate::{pipeline::Pipeline, state::PendingConnection};
+
+use super::state::State;
+
+fn handle_connection(stream: TcpStream, state: Arc<State>) -> Result<()> {
+    let local_address = stream.local_addr()?;
+    if !local_address.ip().is_loopback() {
+        stream.shutdown(Shutdown::Both)?;
+        return Err(anyhow::anyhow!("Only local connections are supported."));
+    }
+    let port = local_address.port();
+    state.pending_connections.insert(
+        port,
+        PendingConnection {
+            port,
+            tcp_stream: stream,
+        },
+    );
+    Ok(())
+}
+
+pub fn listen_on_input(mut stream: TcpStream, pipeline: Arc<Pipeline>, input_id: u32) {
+    thread::spawn(move || {
+        let mut packet = vec![0; 65535];
+        loop {
+            let result: Result<()> = stream
+                .read(packet.as_mut_slice())
+                .map_err(|err| err.into())
+                .and_then(|size| {
+                    pipeline.push_input_data(
+                        input_id,
+                        bytes::Bytes::copy_from_slice(&packet[0..size]),
+                    )?;
+                    Ok(())
+                });
+            if let Err(err) = result {
+                eprintln!("{}", err);
+            }
+        }
+    });
+}
+
+pub fn listen_on_output(mut stream: TcpStream) -> Sender<bytes::Bytes> {
+    let (tx, rx): (Sender<bytes::Bytes>, Receiver<bytes::Bytes>) = mpsc::channel();
+    thread::spawn(move || loop {
+        let data = match rx.recv() {
+            Ok(data) => data,
+            Err(_) => return,
+        };
+        if let Err(err) = stream.write_all(&data) {
+            eprintln!("{}", err)
+        }
+    });
+    tx
+}
+
+pub fn listen_for_new_connections(state: Arc<State>) -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:8000")?;
+
+    thread::spawn(move || {
+        for stream in listener.incoming() {
+            let state = state.clone();
+            let result = stream
+                .map_err(|err| err.into())
+                .and_then(|s| handle_connection(s, state));
+            if let Err(err) = result {
+                eprintln!("{}", err)
+            }
+        }
+    });
+    Ok(())
+}


### PR DESCRIPTION
Minimal application skeleton

- Add HTTP server that listens for API calls
- Add TCP socket that can be used to connect input and output connections
  - one thread to listen for new connections
  - one thread for each input to listen for incoming data from tcp connection
  - one thread for each output to listen on a channel and write data to tcp connection
- Add Pipeline abstraction that is responsible for processing video (from rtp on input to rtp on output, excluding transport layer)
  - Passing data to the pipeline is done just via a function call (all the processing before the queue will be done synchronously)
  - Passing output data from the pipeline is done via the channel (but when we implement everything I suspect we can remove that)

Not tested in any way,
