### PR TITLE
Add common crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,9 +141,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642"
 
 [[package]]
+name = "compositor_common"
+version = "0.1.0"
+
+[[package]]
 name = "compositor_render"
 version = "0.1.0"
 dependencies = [
+ "compositor_common",
  "futures",
  "pollster",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [workspace]
 members = [
+    "compositor_common",
     "compositor_render",
 ]
 resolver = "2"

--- a/compositor_common/Cargo.toml
+++ b/compositor_common/Cargo.toml
@@ -1,13 +1,8 @@
 [package]
-name = "compositor_render"
+name = "compositor_common"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-futures = "0.3.28"
-pollster = "0.3.0"
-thiserror = "1.0.40"
-wgpu = "0.16.1"
-compositor_common = { path = "../compositor_common" }

--- a/compositor_common/src/lib.rs
+++ b/compositor_common/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod scene;

--- a/compositor_common/src/scene.rs
+++ b/compositor_common/src/scene.rs
@@ -1,10 +1,10 @@
-use std::{any::Any, collections::HashMap, rc::Rc};
+use std::{any::Any, collections::HashMap, sync::Arc};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct VideoId(usize);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TransformationRegistryKey(String);
+pub struct TransformationRegistryKey(pub String);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Resolution {
@@ -26,12 +26,12 @@ pub enum Node {
 
     Transformation {
         registry_key: TransformationRegistryKey,
-        inputs: HashMap<String, Rc<Node>>,
+        inputs: HashMap<String, Arc<Node>>,
         resolution: Resolution,
         params: Box<dyn Any>,
     },
 }
 
 pub struct Scene {
-    pub final_nodes: Vec<Rc<Node>>,
+    pub final_nodes: Vec<Arc<Node>>,
 }

--- a/compositor_common/src/scene.rs
+++ b/compositor_common/src/scene.rs
@@ -1,6 +1,4 @@
-use std::{collections::HashMap, rc::Rc};
-
-// TODO: Put those into different modules
+use std::{any::Any, collections::HashMap, rc::Rc};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct VideoId(usize);
@@ -30,9 +28,10 @@ pub enum Node {
         registry_key: TransformationRegistryKey,
         inputs: HashMap<String, Rc<Node>>,
         resolution: Resolution,
+        params: Box<dyn Any>,
     },
 }
 
 pub struct Scene {
-    pub final_node: Rc<Node>,
+    pub final_nodes: Vec<Rc<Node>>,
 }

--- a/compositor_common/src/scene.rs
+++ b/compositor_common/src/scene.rs
@@ -1,0 +1,38 @@
+use std::{collections::HashMap, rc::Rc};
+
+// TODO: Put those into different modules
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VideoId(usize);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TransformationRegistryKey(String);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Resolution {
+    width: usize,
+    height: usize,
+}
+
+#[derive(Debug)]
+pub enum Node {
+    Video {
+        id: VideoId,
+        resolution: Resolution,
+    },
+
+    Image {
+        data: Vec<u8>,
+        resolution: Resolution,
+    },
+
+    Transformation {
+        registry_key: TransformationRegistryKey,
+        inputs: HashMap<String, Rc<Node>>,
+        resolution: Resolution,
+    },
+}
+
+pub struct Scene {
+    pub final_node: Rc<Node>,
+}


### PR DESCRIPTION
For now I opted for every scene node to have a manually specified
resolution. I think we can add other ways of specifying resolution later
on.

The transformation hold their parameters as `Box<dyn Any>` for now. This will possibly change in the future, when we'll work on deserializing the scene from JSON.