### PR TITLE
Add an initial implementation of the transformation registry

### DIFF
--- a/compositor_common/src/scene.rs
+++ b/compositor_common/src/scene.rs
@@ -24,7 +24,7 @@ pub enum Node {
         resolution: Resolution,
     },
 
-    Transformation {
+    Transformer {
         registry_key: TransformationRegistryKey,
         inputs: HashMap<String, Arc<Node>>,
         resolution: Resolution,

--- a/compositor_common/src/scene.rs
+++ b/compositor_common/src/scene.rs
@@ -12,6 +12,9 @@ pub struct Resolution {
     height: usize,
 }
 
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct InputId(pub String);
+
 #[derive(Debug)]
 pub enum Node {
     Video {
@@ -26,7 +29,7 @@ pub enum Node {
 
     Transformer {
         registry_key: TransformationRegistryKey,
-        inputs: HashMap<String, Arc<Node>>,
+        inputs: HashMap<InputId, Arc<Node>>,
         resolution: Resolution,
         params: Box<dyn Any>,
     },

--- a/compositor_render/src/lib.rs
+++ b/compositor_render/src/lib.rs
@@ -1,1 +1,2 @@
+pub(crate) mod registry;
 pub mod renderer;

--- a/compositor_render/src/registry.rs
+++ b/compositor_render/src/registry.rs
@@ -1,0 +1,52 @@
+use std::collections::HashMap;
+
+use compositor_common::scene::TransformationRegistryKey;
+
+use crate::renderer::transformation::Transformation;
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetError {
+    #[error("a transformation with a key {0} could not be found")]
+    KeyNotFound(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RegisterError {
+    #[error("a transformation with a key {0} is already registered")]
+    KeyTaken(String),
+}
+
+pub struct TransformationRegistry {
+    registry: HashMap<TransformationRegistryKey, Box<dyn Transformation>>,
+}
+
+impl TransformationRegistry {
+    pub fn new() -> Self {
+        Self {
+            registry: HashMap::new(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn get(&self, key: &TransformationRegistryKey) -> Result<&dyn Transformation, GetError> {
+        match self.registry.get(key) {
+            Some(val) => Ok(&**val),
+            None => Err(GetError::KeyNotFound(key.0.clone())),
+        }
+    }
+
+    pub fn register(
+        &mut self,
+        transformation: Box<dyn Transformation>,
+    ) -> Result<(), RegisterError> {
+        let key = transformation.registry_key();
+
+        if self.registry.contains_key(&key) {
+            return Err(RegisterError::KeyTaken(key.0));
+        }
+
+        self.registry.insert(key, transformation);
+
+        Ok(())
+    }
+}

--- a/compositor_render/src/renderer.rs
+++ b/compositor_render/src/renderer.rs
@@ -1,6 +1,15 @@
+use std::rc::Rc;
+
+use crate::registry::{self, TransformationRegistry};
+
+use self::transformation::Transformation;
+
+pub mod texture;
+pub mod transformation;
+
 pub struct Renderer {
-    #[allow(dead_code)]
-    wgpu_ctx: WgpuCtx,
+    wgpu_ctx: Rc<WgpuCtx>,
+    registry: TransformationRegistry,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -9,15 +18,32 @@ pub enum RendererNewError {
     FailedToInitWgpuCtx(#[from] WgpuCtxNewError),
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum RendererRegisterTransformationError {
+    #[error("failed to register a transformation in the transformation registry")]
+    TransformationRegistryError(#[from] registry::RegisterError),
+}
+
 impl Renderer {
     pub fn new() -> Result<Self, RendererNewError> {
         Ok(Self {
-            wgpu_ctx: WgpuCtx::new()?,
+            wgpu_ctx: Rc::new(WgpuCtx::new()?),
+            registry: TransformationRegistry::new(),
         })
+    }
+
+    pub fn register_transformation<T: Transformation>(
+        &mut self,
+        provider: fn(Rc<WgpuCtx>) -> T,
+    ) -> Result<(), RendererRegisterTransformationError> {
+        self.registry
+            .register(Box::new(provider(self.wgpu_ctx.clone())))?;
+
+        Ok(())
     }
 }
 
-struct WgpuCtx {
+pub struct WgpuCtx {
     #[allow(dead_code)]
     device: wgpu::Device,
 

--- a/compositor_render/src/renderer.rs
+++ b/compositor_render/src/renderer.rs
@@ -45,10 +45,10 @@ impl Renderer {
 
 pub struct WgpuCtx {
     #[allow(dead_code)]
-    device: wgpu::Device,
+    pub device: wgpu::Device,
 
     #[allow(dead_code)]
-    queue: wgpu::Queue,
+    pub queue: wgpu::Queue,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/compositor_render/src/renderer/texture.rs
+++ b/compositor_render/src/renderer/texture.rs
@@ -1,0 +1,2 @@
+// TODO: stub struct for now
+pub struct Texture {}

--- a/compositor_render/src/renderer/texture.rs
+++ b/compositor_render/src/renderer/texture.rs
@@ -1,2 +1,31 @@
-// TODO: stub struct for now
-pub struct Texture {}
+use super::WgpuCtx;
+
+pub struct Texture {
+    pub texture: wgpu::Texture,
+    pub view: wgpu::TextureView,
+}
+
+impl Texture {
+    pub fn new(
+        ctx: &WgpuCtx,
+        label: Option<&str>,
+        size: wgpu::Extent3d,
+        format: wgpu::TextureFormat,
+        usage: wgpu::TextureUsages,
+    ) -> Self {
+        let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label,
+            size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage,
+            view_formats: &[format],
+        });
+
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        Self { texture, view }
+    }
+}

--- a/compositor_render/src/renderer/transformation.rs
+++ b/compositor_render/src/renderer/transformation.rs
@@ -1,0 +1,20 @@
+use std::{error::Error, rc::Rc};
+
+use compositor_common::scene::TransformationRegistryKey;
+
+use super::{texture::Texture, WgpuCtx};
+
+pub trait Transformation: 'static {
+    fn apply(
+        &self,
+        params: &[u8],
+        source: &Texture,
+        target: &Texture,
+    ) -> Result<(), Box<dyn Error>>;
+
+    fn registry_key(&self) -> TransformationRegistryKey;
+
+    fn new(ctx: Rc<WgpuCtx>) -> Result<Self, Box<dyn Error>>
+    where
+        Self: Sized;
+}

--- a/compositor_render/src/renderer/transformation.rs
+++ b/compositor_render/src/renderer/transformation.rs
@@ -4,10 +4,16 @@ use compositor_common::scene::TransformationRegistryKey;
 
 use super::{texture::Texture, WgpuCtx};
 
+#[derive(Debug)]
+pub enum TransformationParams {
+    String(String),
+    Binary(Vec<u8>),
+}
+
 pub trait Transformation: 'static {
     fn apply(
         &self,
-        params: &[u8],
+        params: &TransformationParams,
         sources: &HashMap<String, Texture>,
         target: &Texture,
     ) -> Result<(), Box<dyn Error>>;

--- a/compositor_render/src/renderer/transformation.rs
+++ b/compositor_render/src/renderer/transformation.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, rc::Rc};
+use std::{collections::HashMap, error::Error, rc::Rc};
 
 use compositor_common::scene::TransformationRegistryKey;
 
@@ -8,7 +8,7 @@ pub trait Transformation: 'static {
     fn apply(
         &self,
         params: &[u8],
-        source: &Texture,
+        sources: &HashMap<String, Texture>,
         target: &Texture,
     ) -> Result<(), Box<dyn Error>>;
 

--- a/compositor_render/src/renderer/transformation.rs
+++ b/compositor_render/src/renderer/transformation.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, error::Error, rc::Rc};
+use std::{collections::HashMap, error::Error};
 
 use compositor_common::scene::TransformationRegistryKey;
 
-use super::{texture::Texture, WgpuCtx};
+use super::texture::Texture;
 
 #[derive(Debug)]
 pub enum TransformationParams {
@@ -19,8 +19,4 @@ pub trait Transformation: 'static {
     ) -> Result<(), Box<dyn Error>>;
 
     fn registry_key(&self) -> TransformationRegistryKey;
-
-    fn new(ctx: Rc<WgpuCtx>) -> Result<Self, Box<dyn Error>>
-    where
-        Self: Sized;
 }


### PR DESCRIPTION
This patch adds an initial implementation of the transformation registry. It also defines a `Transformation` trait. implementing it allows adding custom transformations.

Since we only accept manually defined resolutions, the API is quite simple.

Closes #8 .