### PR TITLE
Adjust encoder settings and add config options to API

### DIFF
--- a/examples/common/common.rs
+++ b/examples/common/common.rs
@@ -38,7 +38,7 @@ pub fn post<T: Serialize + ?Sized>(json: &T) -> Result<Response> {
     let client = reqwest::blocking::Client::new();
     let response = client.post("http://127.0.0.1:8001").json(json).send()?;
     if response.status() >= StatusCode::BAD_REQUEST {
-        return Err(anyhow!("Request failed: {:?}", response));
+        return Err(anyhow!("Request failed: {:?}", response.text()));
     }
     Ok(response)
 }

--- a/examples/simple_ffmpeg.rs
+++ b/examples/simple_ffmpeg.rs
@@ -61,6 +61,9 @@ fn start_example_client_code() -> Result<()> {
             "width": 1280,
             "height": 720,
         },
+        "encoder_settings": {
+            "preset": "medium"
+        }
     }))?;
 
     info!("[example] Send register input request.");

--- a/src/http.rs
+++ b/src/http.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::{io::Cursor, net::SocketAddr, sync::Arc, thread};
 use tiny_http::{Response, StatusCode};
 
+use crate::rtp_sender::EncoderSettings;
+
 use super::state::State;
 
 #[derive(Serialize, Deserialize)]
@@ -13,9 +15,10 @@ struct RegisterInputRequest {
 }
 
 #[derive(Serialize, Deserialize)]
-struct RegisterOutputRequest {
+pub struct RegisterOutputRequest {
     pub port: u16,
     pub resolution: Resolution,
+    pub encoder_settings: EncoderSettings,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -66,9 +69,7 @@ impl Server {
             Request::RegisterInput(RegisterInputRequest { port }) => {
                 self.state.register_input(port)
             }
-            Request::RegisterOutput(RegisterOutputRequest { port, resolution }) => {
-                self.state.register_output(port, resolution)
-            }
+            Request::RegisterOutput(request) => self.state.register_output(request),
             Request::Start => todo!(),
         }
     }

--- a/src/rtp_sender.rs
+++ b/src/rtp_sender.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use crossbeam_channel::{Receiver, Sender};
 use log::error;
+use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, thread};
 
 use compositor_common::{scene::Resolution, Frame};
@@ -12,22 +13,98 @@ use ffmpeg_next::{
 };
 
 pub struct RtpSender {
-    #[allow(dead_code)]
-    port: u16,
     sender: Sender<Frame>,
 }
 
-impl RtpSender {
-    pub fn new(port: u16, resolution: Resolution) -> Self {
-        let port_clone = port;
-        let (sender, receiver) = crossbeam_channel::unbounded();
-        thread::spawn(move || RtpSender::run(port_clone, resolution, receiver).unwrap());
-        Self { port, sender }
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(Default)]
+pub enum EncoderPreset {
+    Ultrafast,
+    Superfast,
+    Veryfast,
+    Faster,
+    Fast,
+    #[default]
+    Medium,
+    Slow,
+    Slower,
+    Veryslow,
+    Placebo,
+}
+
+impl EncoderPreset {
+    fn to_str(&self) -> &'static str {
+        match self {
+            EncoderPreset::Ultrafast => "ultrafast",
+            EncoderPreset::Superfast => "superfast",
+            EncoderPreset::Veryfast => "veryfast",
+            EncoderPreset::Faster => "faster",
+            EncoderPreset::Fast => "fast",
+            EncoderPreset::Medium => "medium",
+            EncoderPreset::Slow => "slow",
+            EncoderPreset::Slower => "slower",
+            EncoderPreset::Veryslow => "veryslow",
+            EncoderPreset::Placebo => "placebo",
+        }
     }
 
-    fn run(port: u16, resolution: Resolution, receiver: Receiver<Frame>) -> Result<()> {
-        let mut output_ctx =
-            format::output_as(&PathBuf::from(format!("rtp://127.0.0.1:{}", port)), "rtp")?;
+    fn default_partitions(&self) -> &'static str {
+        match self {
+            EncoderPreset::Ultrafast => "none",
+            EncoderPreset::Superfast => "i8x8,i4x4",
+            EncoderPreset::Veryfast => "p8x8,b8x8,i8x8,i4x4",
+            EncoderPreset::Faster => "p8x8,b8x8,i8x8,i4x4",
+            EncoderPreset::Fast => "p8x8,b8x8,i8x8,i4x4",
+            EncoderPreset::Medium => "p8x8,b8x8,i8x8,i4x4",
+            EncoderPreset::Slow => "all",
+            EncoderPreset::Slower => "all",
+            EncoderPreset::Veryslow => "all",
+            EncoderPreset::Placebo => "all",
+        }
+    }
+
+    fn default_subq_mode(&self) -> &'static str {
+        match self {
+            EncoderPreset::Ultrafast => "0",
+            EncoderPreset::Superfast => "1",
+            EncoderPreset::Veryfast => "2",
+            EncoderPreset::Faster => "4",
+            EncoderPreset::Fast => "6",
+            EncoderPreset::Medium => "7",
+            EncoderPreset::Slow => "8",
+            EncoderPreset::Slower => "9",
+            EncoderPreset::Veryslow => "10",
+            EncoderPreset::Placebo => "11",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EncoderSettings {
+    #[serde(default)]
+    preset: EncoderPreset,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Options {
+    pub port: u16,
+    pub resolution: Resolution,
+    pub encoder_settings: EncoderSettings,
+}
+
+impl RtpSender {
+    pub fn new(options: Options) -> Self {
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        thread::spawn(move || RtpSender::run(options, receiver).unwrap());
+        Self { sender }
+    }
+
+    fn run(opts: Options, receiver: Receiver<Frame>) -> Result<()> {
+        let mut output_ctx = format::output_as(
+            &PathBuf::from(format!("rtp://127.0.0.1:{}", opts.port)),
+            "rtp",
+        )?;
         let h264_codec = codec::encoder::find(Id::H264).unwrap();
         let mut stream = output_ctx.add_stream(h264_codec)?;
         unsafe {
@@ -38,8 +115,8 @@ impl RtpSender {
         let pts_unit_secs = Rational::new(1, 90000);
         encoder.set_time_base(pts_unit_secs);
         encoder.set_format(Pixel::YUV420P);
-        encoder.set_width(resolution.width.try_into().unwrap());
-        encoder.set_height(resolution.height.try_into().unwrap());
+        encoder.set_width(opts.resolution.width.try_into().unwrap());
+        encoder.set_height(opts.resolution.height.try_into().unwrap());
 
         let mut encoder = encoder.open_as_with(
             h264_codec,
@@ -47,21 +124,42 @@ impl RtpSender {
             // Those values are copied from somewhere, they have to be set because libx264
             // is throwing an error if it detects default ffmpeg settings.
             Dictionary::from_iter([
-                ("preset", "ultrafast"),
-                ("tune", "zerolatency"),
+                ("preset", opts.encoder_settings.preset.to_str()),
+                // Quality-based VBR (0-51)
+                ("crf", "23"),
+                // Override ffmpeg defaults from https://github.com/mirror/x264/blob/eaa68fad9e5d201d42fde51665f2d137ae96baf0/encoder/encoder.c#L674
+                // QP curve compression - libx264 defaults to 0.6 (in case of tune=grain to 0.8)
                 ("qcomp", "0.6"),
-                ("i_qfactor", "0.71"),
-                ("g", "250"),
+                //  Maximum motion vector search range - libx264 defaults to 16 (in case of placebo
+                //  or veryslow preset to 24)
                 ("me_range", "16"),
-                ("partitions", "+parti8x8+parti4x4+partp8x8+partb8x8"),
+                // Max QP step - libx264 defaults to 4
+                ("qdiff", "4"),
+                // Min QP - libx264 defaults to 0
+                ("qmin", "0"),
+                // Max QP - libx264 defaults to QP_MAX = 69
+                ("qmax", "69"),
+                //  Maximum GOP (Group of Pictures) size - libx264 defaults to 250
+                ("g", "250"),
+                // QP factor between I and P frames - libx264 defaults to 1.4 (in case of tune=grain to 1.1)
+                ("i_qfactor", "1.4"),
+                // QP factor between P and B frames - libx264 defaults to 1.4 (in case of tune=grain to 1.1)
+                ("f_pb_factor", "1.3"),
+                // A comma-separated list of partitions to consider. Possible values: p8x8, p4x4, b8x8, i8x8, i4x4, none, all
+                (
+                    "partitions",
+                    opts.encoder_settings.preset.default_partitions(),
+                ),
+                // Subpixel motion estimation and mode decision (decision quality: 1=fast, 11=best)
+                ("subq", opts.encoder_settings.preset.default_subq_mode()),
             ]),
         )?;
         output_ctx.write_header()?;
         let mut packet = codec::packet::Packet::empty();
         let mut av_frame = frame::Video::new(
             Pixel::YUV420P,
-            resolution.width.try_into().unwrap(),
-            resolution.height.try_into().unwrap(),
+            opts.resolution.width.try_into().unwrap(),
+            opts.resolution.height.try_into().unwrap(),
         );
         for frame in receiver.into_iter() {
             if let Err(err) = frame_into_av(frame, &mut av_frame) {


### PR DESCRIPTION
I went through https://github.com/mirror/x264/blob/eaa68fad9e5d201d42fde51665f2d137ae96baf0/encoder/encoder.c#L674 and for each field that is part of that check overridden ffmpeg defaults with libx264 defaults. I took the best-effort approach, the logic there is not straightforward, so I'm not 100% sure if I identified those defaults correctly.

Added preset as part of the API when creating and outputs. I'm also considering adding crf there(I'm open to suggestions).