### PR TITLE
Add long running example

### DIFF
--- a/examples/common/common.rs
+++ b/examples/common/common.rs
@@ -22,6 +22,7 @@ pub fn write_example_sdp_file(port: u16) -> Result<String> {
                     m=video {} RTP/AVP 96\n\
                     a=rtpmap:96 H264/90000\n\
                     a=fmtp:96 packetization-mode=1\n\
+                    a=rtcp-mux\n\
                 ",
             port
         )

--- a/examples/common/common.rs
+++ b/examples/common/common.rs
@@ -43,6 +43,7 @@ pub fn post<T: Serialize + ?Sized>(json: &T) -> Result<Response> {
     Ok(response)
 }
 
+#[allow(dead_code)]
 pub fn download(url: &str, destination: &Path) -> Result<()> {
     let mut resp = reqwest::blocking::get(url)?;
     let mut out = File::create(destination)?;
@@ -50,6 +51,7 @@ pub fn download(url: &str, destination: &Path) -> Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)]
 pub fn ensure_downloaded(url: &str, destination: &Path) -> Result<()> {
     if destination.exists() {
         return Ok(());

--- a/examples/long_ffmpeg.rs
+++ b/examples/long_ffmpeg.rs
@@ -54,7 +54,7 @@ fn start_example_client_code() -> Result<()> {
             "height": 2160,
         },
         "encoder_settings": {
-            "preset": "medium"
+            "preset": "ultrafast"
         }
     }))?;
 
@@ -75,7 +75,7 @@ fn start_example_client_code() -> Result<()> {
             "libx264",
             "-f",
             "rtp",
-            "rtp://127.0.0.1:8004",
+            "rtp://127.0.0.1:8004?rtcpport=8004",
         ])
         .spawn()?;
     Ok(())

--- a/examples/long_ffmpeg.rs
+++ b/examples/long_ffmpeg.rs
@@ -1,0 +1,82 @@
+use anyhow::Result;
+use compositor_pipeline::Pipeline;
+use log::{error, info};
+use serde_json::json;
+use signal_hook::{consts, iterator::Signals};
+use std::{process::Command, sync::Arc, thread, time::Duration};
+use video_compositor::{http, state::State};
+
+use crate::common::write_example_sdp_file;
+
+#[path = "./common/common.rs"]
+mod common;
+
+fn main() {
+    env_logger::init_from_env(
+        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+    );
+    ffmpeg_next::format::network::init();
+    let pipeline = Arc::new(Pipeline::new());
+    let state = Arc::new(State::new(pipeline));
+
+    thread::spawn(|| {
+        if let Err(err) = start_example_client_code() {
+            error!("{err}")
+        }
+    });
+
+    http::Server::new(8001, state).start();
+
+    let mut signals = Signals::new([consts::SIGINT]).unwrap();
+    signals.forever().next();
+}
+
+fn start_example_client_code() -> Result<()> {
+    thread::sleep(Duration::from_secs(2));
+
+    info!("[example] Sending init request.");
+    common::post(&json!({
+        "type": "init",
+    }))?;
+
+    info!("[example] Start listening on output port.");
+    let output_sdp = write_example_sdp_file(8002)?;
+    Command::new("ffplay")
+        .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
+        .spawn()?;
+
+    info!("[example] Send register output request.");
+    common::post(&json!({
+        "type": "register_output",
+        "port": 8002,
+        "resolution": {
+            "width": 3840,
+            "height": 2160,
+        },
+        "encoder_settings": {
+            "preset": "medium"
+        }
+    }))?;
+
+    info!("[example] Send register input request.");
+    common::post(&json!({
+        "type": "register_input",
+        "port": 8004
+    }))?;
+
+    Command::new("ffmpeg")
+        .args([
+            "-re",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=s=3840x2160:r=30,format=yuv420p",
+            "-c:v",
+            "libx264",
+            "-f",
+            "rtp",
+            "rtp://127.0.0.1:8004",
+        ])
+        .spawn()?;
+    Ok(())
+}

--- a/examples/simple_ffmpeg.rs
+++ b/examples/simple_ffmpeg.rs
@@ -81,7 +81,7 @@ fn start_example_client_code() -> Result<()> {
             "libx264",
             "-f",
             "rtp",
-            "rtp://127.0.0.1:8004",
+            "rtp://127.0.0.1:8004?rtcpport=8004",
         ])
         .spawn()?;
     Ok(())

--- a/src/rtp_sender.rs
+++ b/src/rtp_sender.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use crossbeam_channel::{Receiver, Sender};
-use log::error;
+use log::{error, warn};
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, thread};
 
@@ -161,7 +161,11 @@ impl RtpSender {
             opts.resolution.width.try_into().unwrap(),
             opts.resolution.height.try_into().unwrap(),
         );
-        for frame in receiver.into_iter() {
+        for frame in receiver.iter() {
+            if receiver.len() > 100 {
+                warn!("Dropping frame: encoder queue is too long.",);
+                continue;
+            }
             if let Err(err) = frame_into_av(frame, &mut av_frame) {
                 error!("Failed to construct AVFrame: {err}");
                 continue;

--- a/src/rtp_sender.rs
+++ b/src/rtp_sender.rs
@@ -102,7 +102,10 @@ impl RtpSender {
 
     fn run(opts: Options, receiver: Receiver<Frame>) -> Result<()> {
         let mut output_ctx = format::output_as(
-            &PathBuf::from(format!("rtp://127.0.0.1:{}", opts.port)),
+            &PathBuf::from(format!(
+                "rtp://127.0.0.1:{}?rtcpport={}",
+                opts.port, opts.port
+            )),
             "rtp",
         )?;
         let h264_codec = codec::encoder::find(Id::H264).unwrap();


### PR DESCRIPTION
Added a long-running example to see how the compositor behaves when running for longer periods.

I  noticed one issue for 4K streams encoder is keeping up only on the ultrafast preset. In all the other cases the number of messages in a channel grows steadily increasing memory usage.

I decided to start dropping the oldest frames when a number of messages in the queue is over 100 as a stop-gap solution, but when queue and renderer will be implemented this needs to be handled better.

### Potential solutions I considered

1. Current approach (dropping frames in encoder): Easiest to implement and in most cases it gives the intended results, but it does not solve that issue for other places (e.g. what if renderer will not keep up). Also if new streams is pushing more data at the beginning we can stop dropping frames too early even if the encoder could handle the average traffic.

2. Using bound channel in encoder: This would just push the problem to the queue. It's hard to say now if this would be a good thing before queue is ready. 

3. Using bound channels(or other blocking mechanisms) before encoder and queue: It would block decoding if the rest of the pipeline can't handle new data, so it's most optimal because we would buffer data before decoding. The main problem is that buffering on udp channel is handled internally in libav, so we have no control over the buffer that stores received udp data and how it handles dropping them.

With approaches 2 and 3 we technically risking that we will stay more and more behind, but the queue will already handle frames that are too old, and drop them.