### PR TITLE
[ci] Trigger checks only when needed

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,13 @@
 name: lint and test
-on: [push]
+on:
+    push:
+        branches: [master]
+    pull_request:
+        types: [opened, synchronize]
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
     rust:


### PR DESCRIPTION
Trigger checks on PR to any branch or push to master. (push to branch without PR will not trigger CI now)
When some checks are in progress and new changes are pushed the old workflow will be cancelled (it does not apply to commits on master)