### PR TITLE
Fix pts calculation in rtp sender/receiver

### DIFF
--- a/src/rtp_receiver.rs
+++ b/src/rtp_receiver.rs
@@ -96,7 +96,7 @@ fn frame_from_av(decoded: &mut Video, pts_offset: &mut Option<i64>) -> Result<Fr
     let pts = original_pts
         .map(|original_pts| original_pts + pts_offset.unwrap_or(0))
         .ok_or_else(|| anyhow!("missing pts"))?;
-    let pts = Duration::from_nanos(((pts as f64) * 10e9 / 90000.0) as u64);
+    let pts = Duration::from_secs_f64((pts as f64) / 90000.0);
     Ok(Frame {
         data: YuvData {
             y_plane: bytes::Bytes::copy_from_slice(decoded.data(0)),

--- a/src/rtp_sender.rs
+++ b/src/rtp_sender.rs
@@ -217,9 +217,7 @@ fn frame_into_av(frame: Frame, av_frame: &mut frame::Video) -> Result<()> {
         ));
     }
 
-    av_frame.set_pts(Some(
-        ((frame.pts.as_nanos() as f64) * 90000.0 / 10e9) as i64,
-    ));
+    av_frame.set_pts(Some((frame.pts.as_secs_f64() * 90000.0) as i64));
     av_frame.data_mut(0).copy_from_slice(&frame.data.y_plane);
     av_frame.data_mut(1).copy_from_slice(&frame.data.u_plane);
     av_frame.data_mut(2).copy_from_slice(&frame.data.v_plane);


### PR DESCRIPTION
Instead of using `10e9` I should have use `1e9` as a result pts passed to queue were 10x larger.

Initially I missed from_secs_f64 method on duration, using floats is easier in this case to define duration, so I decided to switch to it here.