### PR TITLE
Format conversion YUV <-> RGBA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,20 @@ name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
 
 [[package]]
 name = "byteorder"
@@ -270,6 +284,7 @@ dependencies = [
 name = "compositor_render"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "bytes",
  "compositor_common",
  "futures",

--- a/compositor_render/Cargo.toml
+++ b/compositor_render/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = { workspace = true }
 reqwest = { version = "0.11.18", features = ["blocking", "json"] }
 bytes = { workspace = true }
 log = { workspace = true }
+bytemuck = { version = "1.13.1", features = ["derive"] }

--- a/compositor_render/src/registry.rs
+++ b/compositor_render/src/registry.rs
@@ -20,7 +20,7 @@ pub enum RegistryType {
 }
 
 impl RegistryType {
-    pub(self) fn registry_item_name(&self) -> &'static str {
+    fn registry_item_name(&self) -> &'static str {
         match self {
             RegistryType::Shader => "shader transformation",
             RegistryType::WebRenderer => "web renderer instance",

--- a/compositor_render/src/renderer/color_converter_pipeline.rs
+++ b/compositor_render/src/renderer/color_converter_pipeline.rs
@@ -30,13 +30,13 @@ impl YUVToRGBAConverter {
         let buffers = RectangleRenderBuffers::new(device);
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("YUV to RGBA colour converter render pipeline layout"),
+            label: Some("YUV to RGBA color converter render pipeline layout"),
             bind_group_layouts: &[yuv_textures_bind_group_layout, &sampler.bind_group_layout],
             push_constant_ranges: &[],
         });
 
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("YUV to RGBA colour converter render pipeline"),
+            label: Some("YUV to RGBA color converter render pipeline"),
             layout: Some(&pipeline_layout),
             primitive: PRIMITIVE_STATE,
 
@@ -76,12 +76,12 @@ impl YUVToRGBAConverter {
         let mut encoder = ctx
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("YUV to RGBA colour converter encoder"),
+                label: Some("YUV to RGBA color converter encoder"),
             });
 
         {
             let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("YUV to RGBA colour converter render pass"),
+                label: Some("YUV to RGBA color converter render pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
@@ -125,7 +125,7 @@ impl RGBAToYUVConverter {
         let buffers = RectangleRenderBuffers::new(device);
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("RGBA to YUV colour converter pipeline layout"),
+            label: Some("RGBA to YUV color converter pipeline layout"),
             bind_group_layouts: &[
                 single_texture_bind_group_layout,
                 &sampler.bind_group_layout,
@@ -137,7 +137,7 @@ impl RGBAToYUVConverter {
         let shader_module = device.create_shader_module(wgpu::include_wgsl!("rgba_to_yuv.wgsl"));
 
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("RGBA to YUV colour converter pipeline"),
+            label: Some("RGBA to YUV color converter pipeline"),
             layout: Some(&pipeline_layout),
             primitive: PRIMITIVE_STATE,
 
@@ -184,12 +184,12 @@ impl RGBAToYUVConverter {
             let mut encoder = ctx
                 .device
                 .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                    label: Some("RGBA to YUV colour converter command encoder"),
+                    label: Some("RGBA to YUV color converter command encoder"),
                 });
 
             {
                 let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: Some("YUV to RGBA colour converter render pass"),
+                    label: Some("YUV to RGBA color converter render pass"),
                     color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                         ops: wgpu::Operations {
                             // We want the background to be black. Black in YUV is y = 0, u = 0.5, v = 0.5

--- a/compositor_render/src/renderer/color_converter_pipeline.rs
+++ b/compositor_render/src/renderer/color_converter_pipeline.rs
@@ -178,7 +178,7 @@ impl RGBAToYUVConverter {
             ctx.queue.write_buffer(
                 &self.plane_selector.buffer,
                 0,
-                bytemuck::cast_slice(&[plane]),
+                bytemuck::cast_slice(&[plane as u32]),
             );
 
             let mut encoder = ctx

--- a/compositor_render/src/renderer/color_converter_pipeline.rs
+++ b/compositor_render/src/renderer/color_converter_pipeline.rs
@@ -1,0 +1,236 @@
+use super::{
+    common_pipeline::{RectangleRenderBuffers, Sampler, U32Uniform, Vertex},
+    texture::{RGBATexture, YUVTextures},
+    WgpuCtx,
+};
+
+const PRIMITIVE_STATE: wgpu::PrimitiveState = wgpu::PrimitiveState {
+    polygon_mode: wgpu::PolygonMode::Fill,
+    topology: wgpu::PrimitiveTopology::TriangleList,
+    front_face: wgpu::FrontFace::Ccw,
+    cull_mode: Some(wgpu::Face::Back),
+    strip_index_format: None,
+    conservative: false,
+    unclipped_depth: false,
+};
+
+pub struct YUVToRGBAConverter {
+    pipeline: wgpu::RenderPipeline,
+    sampler: Sampler,
+    buffers: RectangleRenderBuffers,
+}
+
+impl YUVToRGBAConverter {
+    pub fn new(
+        device: &wgpu::Device,
+        yuv_textures_bind_group_layout: &wgpu::BindGroupLayout,
+    ) -> Self {
+        let shader_module = device.create_shader_module(wgpu::include_wgsl!("yuv_to_rgba.wgsl"));
+        let sampler = Sampler::new(device);
+        let buffers = RectangleRenderBuffers::new(device);
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("YUV to RGBA colour converter render pipeline layout"),
+            bind_group_layouts: &[yuv_textures_bind_group_layout, &sampler.bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("YUV to RGBA colour converter render pipeline"),
+            layout: Some(&pipeline_layout),
+            primitive: PRIMITIVE_STATE,
+
+            vertex: wgpu::VertexState {
+                module: &shader_module,
+                entry_point: "vs_main",
+                buffers: &[Vertex::LAYOUT],
+            },
+
+            fragment: Some(wgpu::FragmentState {
+                module: &shader_module,
+                entry_point: "fs_main",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: wgpu::TextureFormat::Rgba8Unorm,
+                    write_mask: wgpu::ColorWrites::all(),
+                    blend: None,
+                })],
+            }),
+
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview: None,
+            depth_stencil: None,
+        });
+
+        Self {
+            pipeline,
+            sampler,
+            buffers,
+        }
+    }
+
+    pub fn convert(&self, ctx: &WgpuCtx, src: (&YUVTextures, &wgpu::BindGroup), dst: &RGBATexture) {
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("YUV to RGBA colour converter encoder"),
+            });
+
+        {
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("YUV to RGBA colour converter render pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: true,
+                    },
+                    view: &dst.0.view,
+                    resolve_target: None,
+                })],
+                depth_stencil_attachment: None,
+            });
+
+            render_pass.set_pipeline(&self.pipeline);
+            render_pass.set_bind_group(0, src.1, &[]);
+            render_pass.set_bind_group(1, &self.sampler.bind_group, &[]);
+            render_pass.set_vertex_buffer(0, self.buffers.vertex.slice(..));
+            render_pass.set_index_buffer(
+                self.buffers.index.slice(..),
+                RectangleRenderBuffers::INDEX_FORMAT,
+            );
+            render_pass.draw_indexed(0..RectangleRenderBuffers::INDICES.len() as u32, 0, 0..1);
+        }
+
+        ctx.queue.submit(Some(encoder.finish()));
+    }
+}
+
+pub struct RGBAToYUVConverter {
+    pipeline: wgpu::RenderPipeline,
+    plane_selector: U32Uniform,
+    sampler: Sampler,
+    buffers: RectangleRenderBuffers,
+}
+
+impl RGBAToYUVConverter {
+    pub fn new(
+        device: &wgpu::Device,
+        single_texture_bind_group_layout: &wgpu::BindGroupLayout,
+    ) -> Self {
+        let plane_selector = U32Uniform::new(device);
+        let sampler = Sampler::new(device);
+        let buffers = RectangleRenderBuffers::new(device);
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("RGBA to YUV colour converter pipeline layout"),
+            bind_group_layouts: &[
+                single_texture_bind_group_layout,
+                &sampler.bind_group_layout,
+                &plane_selector.bind_group_layout,
+            ],
+            push_constant_ranges: &[],
+        });
+
+        let shader_module = device.create_shader_module(wgpu::include_wgsl!("rgba_to_yuv.wgsl"));
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("RGBA to YUV colour converter pipeline"),
+            layout: Some(&pipeline_layout),
+            primitive: PRIMITIVE_STATE,
+
+            vertex: wgpu::VertexState {
+                module: &shader_module,
+                entry_point: "vs_main",
+                buffers: &[Vertex::LAYOUT],
+            },
+
+            fragment: Some(wgpu::FragmentState {
+                module: &shader_module,
+                entry_point: "fs_main",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: wgpu::TextureFormat::R8Unorm,
+                    write_mask: wgpu::ColorWrites::all(),
+                    blend: None,
+                })],
+            }),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview: None,
+        });
+
+        Self {
+            pipeline,
+            sampler,
+            buffers,
+            plane_selector,
+        }
+    }
+
+    pub fn convert(&self, ctx: &WgpuCtx, src: (&RGBATexture, &wgpu::BindGroup), dst: &YUVTextures) {
+        for plane in [0, 1, 2] {
+            ctx.queue.write_buffer(
+                &self.plane_selector.buffer,
+                0,
+                bytemuck::cast_slice(&[plane]),
+            );
+
+            let mut encoder = ctx
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("RGBA to YUV colour converter command encoder"),
+                });
+
+            {
+                let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("YUV to RGBA colour converter render pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        ops: wgpu::Operations {
+                            // We want the background to be black. Black in YUV is y = 0, u = 0.5, v = 0.5
+                            // Therefore, we set the clear color to 0, 0, 0 when drawing the y plane
+                            // and to 0.5, 0.5, 0.5 when drawing the u and v planes.
+                            load: wgpu::LoadOp::Clear(if plane == 0 {
+                                wgpu::Color {
+                                    r: 0.0,
+                                    g: 0.0,
+                                    b: 0.0,
+                                    a: 1.0,
+                                }
+                            } else {
+                                wgpu::Color {
+                                    r: 0.5,
+                                    g: 0.5,
+                                    b: 0.5,
+                                    a: 1.0,
+                                }
+                            }),
+                            store: true,
+                        },
+                        view: &dst.0[plane].view,
+                        resolve_target: None,
+                    })],
+                    depth_stencil_attachment: None,
+                });
+
+                render_pass.set_pipeline(&self.pipeline);
+                render_pass.set_bind_group(0, src.1, &[]);
+                render_pass.set_bind_group(1, &self.sampler.bind_group, &[]);
+                render_pass.set_bind_group(2, &self.plane_selector.bind_group, &[]);
+                render_pass.set_vertex_buffer(0, self.buffers.vertex.slice(..));
+                render_pass.set_index_buffer(
+                    self.buffers.index.slice(..),
+                    RectangleRenderBuffers::INDEX_FORMAT,
+                );
+                render_pass.draw_indexed(0..RectangleRenderBuffers::INDICES.len() as u32, 0, 0..1);
+            }
+
+            ctx.queue.submit(Some(encoder.finish()));
+        }
+    }
+}

--- a/compositor_render/src/renderer/common_pipeline.rs
+++ b/compositor_render/src/renderer/common_pipeline.rs
@@ -1,0 +1,164 @@
+use wgpu::{util::DeviceExt, BindGroup, BindGroupLayout, Buffer};
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Vertex {
+    pub position: [f32; 3],
+    pub texture_coords: [f32; 2],
+}
+
+impl Vertex {
+    pub const LAYOUT: wgpu::VertexBufferLayout<'static> = wgpu::VertexBufferLayout {
+        array_stride: std::mem::size_of::<Vertex>() as u64,
+        step_mode: wgpu::VertexStepMode::Vertex,
+        attributes: &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x2],
+    };
+}
+
+pub struct RectangleRenderBuffers {
+    pub vertex: Buffer,
+    pub index: Buffer,
+}
+
+/// Vertex and index buffer that describe render area as an rectangle mapped to texture.
+impl RectangleRenderBuffers {
+    const VERTICES: [Vertex; 4] = [
+        Vertex {
+            position: [1.0, -1.0, 0.0],
+            texture_coords: [1.0, 1.0],
+        },
+        Vertex {
+            position: [1.0, 1.0, 0.0],
+            texture_coords: [1.0, 0.0],
+        },
+        Vertex {
+            position: [-1.0, 1.0, 0.0],
+            texture_coords: [0.0, 0.0],
+        },
+        Vertex {
+            position: [-1.0, -1.0, 0.0],
+            texture_coords: [0.0, 1.0],
+        },
+    ];
+
+    #[rustfmt::skip]
+    pub const INDICES: [u16; 6] = [
+        0, 1, 2,
+        2, 3, 0,
+    ];
+
+    pub const INDEX_FORMAT: wgpu::IndexFormat = wgpu::IndexFormat::Uint16;
+
+    pub fn new(device: &wgpu::Device) -> Self {
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("vertex buffer"),
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+            contents: bytemuck::cast_slice(&Self::VERTICES),
+        });
+
+        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("index buffer"),
+            usage: wgpu::BufferUsages::INDEX | wgpu::BufferUsages::COPY_DST,
+            contents: bytemuck::cast_slice(&Self::INDICES),
+        });
+
+        Self {
+            vertex: vertex_buffer,
+            index: index_buffer,
+        }
+    }
+}
+
+pub struct Sampler {
+    _sampler: wgpu::Sampler,
+    pub bind_group_layout: BindGroupLayout,
+    pub bind_group: BindGroup,
+}
+
+impl Sampler {
+    pub fn new(device: &wgpu::Device) -> Self {
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            min_filter: wgpu::FilterMode::Linear,
+            mag_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("sampler bind group layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                count: None,
+            }],
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("sampler bind group"),
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Sampler(&sampler),
+            }],
+        });
+
+        Self {
+            _sampler: sampler,
+            bind_group,
+            bind_group_layout,
+        }
+    }
+}
+
+pub struct U32Uniform {
+    pub buffer: Buffer,
+    pub bind_group: wgpu::BindGroup,
+    pub bind_group_layout: wgpu::BindGroupLayout,
+}
+
+impl U32Uniform {
+    pub fn new(device: &wgpu::Device) -> Self {
+        let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("uniform u32 buffer"),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            contents: bytemuck::cast_slice(&[0u32]),
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("uniform bind group layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                count: None,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+            }],
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("uniform bind group"),
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &buffer,
+                    offset: 0,
+                    size: std::num::NonZeroU64::new(std::mem::size_of::<u32>() as u64),
+                }),
+            }],
+        });
+        Self {
+            buffer,
+            bind_group_layout,
+            bind_group,
+        }
+    }
+}

--- a/compositor_render/src/renderer/common_pipeline.rs
+++ b/compositor_render/src/renderer/common_pipeline.rs
@@ -115,6 +115,7 @@ impl Sampler {
     }
 }
 
+// TODO: This should be done with push-constants, not with a buffer
 pub struct U32Uniform {
     pub buffer: Buffer,
     pub bind_group: wgpu::BindGroup,

--- a/compositor_render/src/renderer/rgba_to_yuv.wgsl
+++ b/compositor_render/src/renderer/rgba_to_yuv.wgsl
@@ -24,7 +24,7 @@ fn vs_main(input: VertexInput) -> VertexOutput {
 
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) f32 {
-    let colour = textureSample(texture, sampler_, input.tex_coords);
+    let color = textureSample(texture, sampler_, input.tex_coords);
     var conversion_weights: vec4<f32>;
     var conversion_bias: f32;
 
@@ -44,5 +44,5 @@ fn fs_main(input: VertexOutput) -> @location(0) f32 {
         conversion_weights = vec4<f32>();
     }
 
-    return clamp(dot(colour, conversion_weights) + conversion_bias, 0.0, 1.0);
+    return clamp(dot(color, conversion_weights) + conversion_bias, 0.0, 1.0);
 }

--- a/compositor_render/src/renderer/rgba_to_yuv.wgsl
+++ b/compositor_render/src/renderer/rgba_to_yuv.wgsl
@@ -1,0 +1,48 @@
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) tex_coords: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) tex_coords: vec2<f32>,
+}
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+    var output: VertexOutput;
+
+    output.position = vec4(input.position, 1.0);
+    output.tex_coords = input.tex_coords;
+
+    return output;
+}
+
+@group(0) @binding(0) var texture: texture_2d<f32>;
+@group(1) @binding(0) var sampler_: sampler;
+@group(2) @binding(0) var<uniform> plane_selector: u32;
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) f32 {
+    let colour = textureSample(texture, sampler_, input.tex_coords);
+    var conversion_weights: vec4<f32>;
+    var conversion_bias: f32;
+
+    if(plane_selector == 0u) {
+        // Y
+        conversion_weights = vec4<f32>(0.299, 0.587, 0.114, 0.0);
+        conversion_bias = 0.0;
+    } else if(plane_selector == 1u) {
+        // U
+        conversion_weights = vec4<f32>(-0.168736, -0.331264, 0.5, 0.0);
+        conversion_bias = 128.0 / 255.0;
+    } else if(plane_selector == 2u) {
+        // V
+        conversion_weights = vec4<f32>(0.5, -0.418688, -0.081312, 0.0);
+        conversion_bias = 128.0 / 255.0;
+    } else {
+        conversion_weights = vec4<f32>();
+    }
+
+    return clamp(dot(colour, conversion_weights) + conversion_bias, 0.0, 1.0);
+}

--- a/compositor_render/src/renderer/texture.rs
+++ b/compositor_render/src/renderer/texture.rs
@@ -114,11 +114,7 @@ impl YUVTextures {
         })
     }
 
-    pub(self) fn new_bind_group(
-        &self,
-        ctx: &WgpuCtx,
-        layout: &wgpu::BindGroupLayout,
-    ) -> wgpu::BindGroup {
+    fn new_bind_group(&self, ctx: &WgpuCtx, layout: &wgpu::BindGroupLayout) -> wgpu::BindGroup {
         ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("yuv all textures bind group"),
             layout,
@@ -172,11 +168,7 @@ impl RGBATexture {
         })
     }
 
-    pub(self) fn new_bind_group(
-        &self,
-        ctx: &WgpuCtx,
-        layout: &wgpu::BindGroupLayout,
-    ) -> wgpu::BindGroup {
+    fn new_bind_group(&self, ctx: &WgpuCtx, layout: &wgpu::BindGroupLayout) -> wgpu::BindGroup {
         ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("texture bind group"),
             layout,

--- a/compositor_render/src/renderer/texture.rs
+++ b/compositor_render/src/renderer/texture.rs
@@ -12,6 +12,11 @@ pub struct Texture {
 }
 
 impl Texture {
+    pub const DEFAULT_BINDING_TYPE: wgpu::BindingType = wgpu::BindingType::Texture {
+        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+        view_dimension: wgpu::TextureViewDimension::D2,
+        multisampled: false,
+    };
     pub fn new(
         ctx: &WgpuCtx,
         label: Option<&str>,
@@ -37,65 +42,6 @@ impl Texture {
 
     pub fn size(&self) -> wgpu::Extent3d {
         self.texture.size()
-    }
-
-    pub fn new_rgba(ctx: &WgpuCtx, resolution: &Resolution) -> Self {
-        Self::new(
-            ctx,
-            None,
-            wgpu::Extent3d {
-                width: resolution.width as u32,
-                height: resolution.height as u32,
-                depth_or_array_layers: 1,
-            },
-            wgpu::TextureFormat::Rgba8Unorm,
-            wgpu::TextureUsages::RENDER_ATTACHMENT
-                | wgpu::TextureUsages::TEXTURE_BINDING
-                | wgpu::TextureUsages::COPY_DST,
-        )
-    }
-
-    pub fn new_yuv_textures(ctx: &WgpuCtx, resolution: &Resolution) -> [Texture; 3] {
-        let y = Self::new(
-            ctx,
-            None,
-            wgpu::Extent3d {
-                width: resolution.width as u32,
-                height: resolution.height as u32,
-                depth_or_array_layers: 1,
-            },
-            wgpu::TextureFormat::R8Unorm,
-            wgpu::TextureUsages::RENDER_ATTACHMENT
-                | wgpu::TextureUsages::COPY_SRC
-                | wgpu::TextureUsages::COPY_DST,
-        );
-        let u = Self::new(
-            ctx,
-            None,
-            wgpu::Extent3d {
-                width: resolution.width as u32 / 2,
-                height: resolution.height as u32 / 2,
-                depth_or_array_layers: 1,
-            },
-            wgpu::TextureFormat::R8Unorm,
-            wgpu::TextureUsages::RENDER_ATTACHMENT
-                | wgpu::TextureUsages::COPY_SRC
-                | wgpu::TextureUsages::COPY_DST,
-        );
-        let v = Self::new(
-            ctx,
-            None,
-            wgpu::Extent3d {
-                width: resolution.width as u32 / 2,
-                height: resolution.height as u32 / 2,
-                depth_or_array_layers: 1,
-            },
-            wgpu::TextureFormat::R8Unorm,
-            wgpu::TextureUsages::RENDER_ATTACHMENT
-                | wgpu::TextureUsages::COPY_SRC
-                | wgpu::TextureUsages::COPY_DST,
-        );
-        [y, u, v]
     }
 
     pub fn upload_frame_to_textures(ctx: &WgpuCtx, textures: &[Texture; 3], frame: Arc<Frame>) {
@@ -126,8 +72,157 @@ impl Texture {
     }
 }
 
+pub struct YUVTextures(pub [Texture; 3]);
+
+impl YUVTextures {
+    pub fn new(ctx: &WgpuCtx, resolution: &Resolution) -> Self {
+        Self([
+            Self::new_plane(ctx, resolution.width, resolution.height),
+            Self::new_plane(ctx, resolution.width / 2, resolution.height / 2),
+            Self::new_plane(ctx, resolution.width / 2, resolution.height / 2),
+        ])
+    }
+
+    fn new_plane(ctx: &WgpuCtx, width: usize, height: usize) -> Texture {
+        Texture::new(
+            ctx,
+            None,
+            wgpu::Extent3d {
+                width: width as u32,
+                height: height as u32,
+                depth_or_array_layers: 1,
+            },
+            wgpu::TextureFormat::R8Unorm,
+            wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+        )
+    }
+
+    pub fn new_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+        let create_entry = |binding: u32| wgpu::BindGroupLayoutEntry {
+            binding,
+            ty: Texture::DEFAULT_BINDING_TYPE,
+            visibility: wgpu::ShaderStages::FRAGMENT,
+            count: None,
+        };
+        device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("yuv all textures bind group layout"),
+            entries: &[create_entry(0), create_entry(1), create_entry(2)],
+        })
+    }
+
+    pub(self) fn new_bind_group(
+        &self,
+        ctx: &WgpuCtx,
+        layout: &wgpu::BindGroupLayout,
+    ) -> wgpu::BindGroup {
+        ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("yuv all textures bind group"),
+            layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&self.0[0].view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&self.0[1].view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::TextureView(&self.0[2].view),
+                },
+            ],
+        })
+    }
+}
+
+pub struct RGBATexture(pub Texture);
+
+impl RGBATexture {
+    pub fn new(ctx: &WgpuCtx, resolution: &Resolution) -> Self {
+        Self(Texture::new(
+            ctx,
+            None,
+            wgpu::Extent3d {
+                width: resolution.width as u32,
+                height: resolution.height as u32,
+                depth_or_array_layers: 1,
+            },
+            wgpu::TextureFormat::Rgba8Unorm,
+            wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+        ))
+    }
+
+    pub fn new_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+        device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("single texture bind group layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                ty: Texture::DEFAULT_BINDING_TYPE,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                count: None,
+            }],
+        })
+    }
+
+    pub(self) fn new_bind_group(
+        &self,
+        ctx: &WgpuCtx,
+        layout: &wgpu::BindGroupLayout,
+    ) -> wgpu::BindGroup {
+        ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("texture bind group"),
+            layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&self.0.view),
+            }],
+        })
+    }
+}
+
+pub struct InputTexture {
+    pub textures: YUVTextures,
+    pub bind_group: wgpu::BindGroup,
+}
+
+impl InputTexture {
+    pub fn new(ctx: &WgpuCtx, resolution: &Resolution) -> Self {
+        let textures = YUVTextures::new(ctx, resolution);
+        let bind_group = textures.new_bind_group(ctx, &ctx.yuv_bind_group_layout);
+
+        Self {
+            textures,
+            bind_group,
+        }
+    }
+}
+
+pub struct NodeTexture {
+    pub texture: RGBATexture,
+    pub bind_group: wgpu::BindGroup,
+}
+
+impl NodeTexture {
+    pub fn new(ctx: &WgpuCtx, resolution: &Resolution) -> Self {
+        let texture = RGBATexture::new(ctx, resolution);
+        let bind_group = texture.new_bind_group(ctx, &ctx.rgba_bind_group_layout);
+
+        Self {
+            texture,
+            bind_group,
+        }
+    }
+}
 pub struct OutputTexture {
-    yuv_textures: [Texture; 3],
+    pub yuv_textures: YUVTextures,
     buffers: [wgpu::Buffer; 3],
     pub resolution: Resolution,
 }
@@ -159,7 +254,7 @@ impl OutputTexture {
             }),
         ];
         Self {
-            yuv_textures: Texture::new_yuv_textures(ctx, resolution),
+            yuv_textures: YUVTextures::new(ctx, resolution),
             buffers,
             resolution: *resolution,
         }
@@ -175,7 +270,7 @@ impl OutputTexture {
             v_plane: Bytes::new(),
         };
         {
-            let size = self.yuv_textures[0].texture.size();
+            let size = self.yuv_textures.0[0].texture.size();
             let buffer = BytesMut::with_capacity(size.width as usize * size.height as usize);
 
             self.buffers[0]
@@ -192,7 +287,7 @@ impl OutputTexture {
             result.y_plane = buffer.into_inner().into();
         }
         {
-            let size = self.yuv_textures[1].texture.size();
+            let size = self.yuv_textures.0[1].texture.size();
             let buffer = BytesMut::with_capacity(size.width as usize * size.height as usize);
 
             self.buffers[1]
@@ -209,7 +304,7 @@ impl OutputTexture {
             result.u_plane = buffer.into_inner().into();
         }
         {
-            let size = self.yuv_textures[2].texture.size();
+            let size = self.yuv_textures.0[2].texture.size();
             let buffer = BytesMut::with_capacity(size.width as usize * size.height as usize);
 
             self.buffers[2]
@@ -242,19 +337,19 @@ impl OutputTexture {
                     aspect: wgpu::TextureAspect::All,
                     mip_level: 0,
                     origin: wgpu::Origin3d::ZERO,
-                    texture: &self.yuv_textures[plane].texture,
+                    texture: &self.yuv_textures.0[plane].texture,
                 },
                 wgpu::ImageCopyBuffer {
                     buffer: &self.buffers[plane],
                     layout: wgpu::ImageDataLayout {
                         bytes_per_row: Some(Self::padded(
-                            self.yuv_textures[plane].texture.size().width as usize,
+                            self.yuv_textures.0[plane].texture.size().width as usize,
                         ) as u32),
-                        rows_per_image: Some(self.yuv_textures[plane].texture.size().height),
+                        rows_per_image: Some(self.yuv_textures.0[plane].texture.size().height),
                         offset: 0,
                     },
                 },
-                self.yuv_textures[plane].texture.size(),
+                self.yuv_textures.0[plane].texture.size(),
             )
         }
 

--- a/compositor_render/src/renderer/yuv_to_rgba.wgsl
+++ b/compositor_render/src/renderer/yuv_to_rgba.wgsl
@@ -1,0 +1,38 @@
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) tex_coords: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) tex_coords: vec2<f32>,
+}
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+    var output: VertexOutput;
+
+    output.position = vec4(input.position, 1.0);
+    output.tex_coords = input.tex_coords;
+
+    return output;
+}
+
+@group(0) @binding(0) var y_texture: texture_2d<f32>;
+@group(0) @binding(1) var u_texture: texture_2d<f32>;
+@group(0) @binding(2) var v_texture: texture_2d<f32>;
+
+@group(1) @binding(0) var sampler_: sampler;
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    let y = textureSample(y_texture, sampler_, input.tex_coords).x;
+    let u = textureSample(u_texture, sampler_, input.tex_coords).x;
+    let v = textureSample(v_texture, sampler_, input.tex_coords).x;
+
+    let r = y + 1.40200 * (v - 128.0 / 255.0);
+    let g = y - 0.34414 * (u - 128.0 / 255.0) - 0.71414 * (v - 128.0 / 255.0);
+    let b = y + 1.77200 * (u - 128.0 / 255.0);
+
+    return vec4(clamp(r, 0.0, 1.0), clamp(g, 0.0, 1.0), clamp(b, 0.0, 1.0), 1.0);
+}

--- a/compositor_render/src/transformations/web_renderer.rs
+++ b/compositor_render/src/transformations/web_renderer.rs
@@ -1,6 +1,9 @@
 use std::{sync::Arc, thread, time::Duration};
 
-use crate::renderer::{texture::Texture, RenderCtx};
+use crate::renderer::{
+    texture::{NodeTexture, Texture},
+    RenderCtx,
+};
 pub mod electron;
 mod electron_api;
 
@@ -43,13 +46,13 @@ impl WebRenderer {
     pub fn render(
         &self,
         ctx: &RenderCtx,
-        _sources: &[(&NodeId, &Texture)],
-        target: &Texture,
+        _sources: &[(&NodeId, &NodeTexture)],
+        target: &NodeTexture,
     ) -> Result<(), WebRendererRenderError> {
         let frame = ctx.electron.client.get_frame(&self.session_id)?;
         if !frame.is_empty() {
             info!("writing texture from chrome");
-            Self::write_texture(ctx, &frame, target)?;
+            Self::write_texture(ctx, &frame, &target.texture.0)?;
         }
 
         Ok(())

--- a/examples/long_ffmpeg.rs
+++ b/examples/long_ffmpeg.rs
@@ -96,7 +96,7 @@ fn start_example_client_code() -> Result<()> {
         "key": "example website",
         "transform": {
             "type": "web_renderer",
-            "url": "http://some-website", // or other way of providing source
+            "url": "https://www.twitch.tv/", // or other way of providing source
             "resolution": { "width": VIDEO_RESOLUTION.width, "height": VIDEO_RESOLUTION.height },
         }
     }))?;

--- a/examples/simple_ffmpeg.rs
+++ b/examples/simple_ffmpeg.rs
@@ -63,6 +63,7 @@ fn start_example_client_code() -> Result<()> {
     info!("[example] Send register output request.");
     common::post(&json!({
         "type": "register_output",
+        "id": "output 1",
         "port": 8002,
         "resolution": {
             "width": VIDEO_RESOLUTION.width,
@@ -76,7 +77,26 @@ fn start_example_client_code() -> Result<()> {
     info!("[example] Send register input request.");
     common::post(&json!({
         "type": "register_input",
+        "id": "input 1",
         "port": 8004
+    }))?;
+
+    info!("[example] Update scene");
+    common::post(&json!({
+        "type": "update_scene",
+        "inputs": [
+            {
+                "input_id": "input 1",
+                "resolution": { "width": VIDEO_RESOLUTION.width, "height": VIDEO_RESOLUTION.height },
+            }
+        ],
+        "transforms": [],
+        "outputs": [
+            {
+                "output_id": "output 1",
+                "input_pad": "input 1"
+            }
+        ]
     }))?;
 
     Command::new("ffmpeg")


### PR DESCRIPTION
This PR adds:
- conversion from YUV and RGBA
- conversion from RGBA to YUV
- some additional abstractions to wrap Textures
- fix simple_ffmpeg example

Code for interacting with wgpu is almost 1:1 from membrane plugin, only repackaged with some additional abstraction layers.

Tested on both examples:
- simple_ffmpeg (pass input into output)
- long_ffmpeg (use web renderer output)

Next steps:
- rework uploading and downloading between cpu<->gpu
- rescale frame on resolution change
- texture.rs is growing, so it's also time to brake it out into multiple modules
