### PR TITLE
Decouple transform registration from render thread

### DIFF
--- a/compositor_render/src/sync_renderer.rs
+++ b/compositor_render/src/sync_renderer.rs
@@ -10,6 +10,7 @@ use crate::{
     renderer::{
         scene::SceneUpdateError, Renderer, RendererNewError, RendererRegisterTransformationError,
     },
+    transformations::{shader::Shader, web_renderer::WebRenderer},
 };
 
 #[derive(Clone)]
@@ -19,12 +20,28 @@ impl SyncRenderer {
     pub fn new(init_web: bool) -> Result<Self, RendererNewError> {
         Ok(Self(Arc::new(Mutex::new(Renderer::new(init_web)?))))
     }
+
     pub fn register_transformation(
         &self,
         key: TransformationRegistryKey,
         spec: TransformationSpec,
     ) -> Result<(), RendererRegisterTransformationError> {
-        self.0.lock().unwrap().register_transformation(key, spec)
+        let ctx = self.0.lock().unwrap().register_transformation_ctx();
+        match spec {
+            TransformationSpec::Shader { source } => {
+                let shader = Arc::new(Shader::new(&ctx, source));
+
+                let mut guard = self.0.lock().unwrap();
+                guard.shader_transforms.register(&key, shader)?
+            }
+            TransformationSpec::WebRenderer(params) => {
+                let web = Arc::new(WebRenderer::new(&ctx, params)?);
+
+                let mut guard = self.0.lock().unwrap();
+                guard.web_renderers.register(&key, web)?
+            }
+        }
+        Ok(())
     }
 
     pub fn render(&self, input: FrameSet<InputId>) -> FrameSet<OutputId> {

--- a/compositor_render/src/transformations/shader.rs
+++ b/compositor_render/src/transformations/shader.rs
@@ -1,4 +1,4 @@
-use crate::renderer::{texture::NodeTexture, RenderCtx};
+use crate::renderer::{texture::NodeTexture, RegisterTransformationCtx};
 
 use std::{collections::HashMap, sync::Arc};
 
@@ -27,7 +27,7 @@ pub struct Shader {
 }
 
 impl Shader {
-    pub fn new(ctx: &RenderCtx, shader_src: String) -> Self {
+    pub fn new(ctx: &RegisterTransformationCtx, shader_src: String) -> Self {
         // TODO: Error handling
         let pipeline = Pipeline::new(
             &ctx.wgpu_ctx.device,

--- a/compositor_render/src/transformations/web_renderer.rs
+++ b/compositor_render/src/transformations/web_renderer.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, thread, time::Duration};
 
 use crate::renderer::{
     texture::{NodeTexture, RGBATexture},
-    RenderCtx,
+    RegisterTransformationCtx, RenderCtx,
 };
 pub mod electron;
 mod electron_api;
@@ -30,7 +30,7 @@ pub struct WebRenderer {
 
 impl WebRenderer {
     pub fn new(
-        ctx: &RenderCtx,
+        ctx: &RegisterTransformationCtx,
         params: WebRendererTransformationParams,
     ) -> Result<Self, WebRendererNewError> {
         // TODO: wait electron api by checking tcp connection on that port


### PR DESCRIPTION
Currently, transform registrations are blocking the render thread, this PR separates it out, so registering long transforms does not affect rendering piepline