### PR TITLE
Improve errors returned from API

### DIFF
--- a/compositor_common/src/lib.rs
+++ b/compositor_common/src/lib.rs
@@ -6,6 +6,7 @@ pub mod transformation;
 mod validators;
 
 pub type Frame = frame::Frame;
+pub type SpecValidationError = validators::SpecValidationError;
 
 /// TODO: This should be a rational.
 #[derive(Debug, Clone, Copy)]

--- a/compositor_render/src/lib.rs
+++ b/compositor_render/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod frame_set;
+pub mod registry;
 pub mod renderer;
 
-pub(crate) mod registry;
 pub(crate) mod render_loop;
 pub(crate) mod transformations;
 

--- a/compositor_render/src/registry.rs
+++ b/compositor_render/src/registry.rs
@@ -28,13 +28,13 @@ impl RegistryType {
     }
 }
 
-pub struct TransformationRegistry<T: Clone> {
+pub(crate) struct TransformationRegistry<T: Clone> {
     registry: HashMap<TransformationRegistryKey, T>,
     registry_type: RegistryType,
 }
 
 impl<T: Clone> TransformationRegistry<T> {
-    pub fn new(registry_type: RegistryType) -> Self {
+    pub(crate) fn new(registry_type: RegistryType) -> Self {
         Self {
             registry: HashMap::new(),
             registry_type,
@@ -42,7 +42,7 @@ impl<T: Clone> TransformationRegistry<T> {
     }
 
     #[allow(dead_code)]
-    pub fn get(&self, key: &TransformationRegistryKey) -> Result<T, GetError> {
+    pub(crate) fn get(&self, key: &TransformationRegistryKey) -> Result<T, GetError> {
         match self.registry.get(key) {
             Some(val) => Ok(val.clone()),
             None => Err(GetError::KeyNotFound(
@@ -52,7 +52,7 @@ impl<T: Clone> TransformationRegistry<T> {
         }
     }
 
-    pub fn register(
+    pub(crate) fn register(
         &mut self,
         key: &TransformationRegistryKey,
         transformation: T,

--- a/compositor_render/src/renderer.rs
+++ b/compositor_render/src/renderer.rs
@@ -40,16 +40,16 @@ pub struct Renderer {
     pub text_renderer_ctx: Mutex<TextRendererCtx>,
     pub electron_instance: Arc<ElectronInstance>,
     pub scene: Scene,
-    pub shader_transforms: TransformationRegistry<Arc<Shader>>,
-    pub web_renderers: TransformationRegistry<Arc<WebRenderer>>,
+    pub(crate) shader_transforms: TransformationRegistry<Arc<Shader>>,
+    pub(crate) web_renderers: TransformationRegistry<Arc<WebRenderer>>,
 }
 
 pub struct RenderCtx<'a> {
     pub wgpu_ctx: &'a Arc<WgpuCtx>,
     pub text_renderer_ctx: &'a Mutex<TextRendererCtx>,
     pub electron: &'a Arc<ElectronInstance>,
-    pub shader_transforms: &'a TransformationRegistry<Arc<Shader>>,
-    pub web_renderers: &'a TransformationRegistry<Arc<WebRenderer>>,
+    pub(crate) shader_transforms: &'a TransformationRegistry<Arc<Shader>>,
+    pub(crate) web_renderers: &'a TransformationRegistry<Arc<WebRenderer>>,
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
- better error serialization (and pretty print in example)

![20230804_13h46m28s_grim](https://github.com/membraneframework/video_compositor/assets/9753141/2aa2f216-a11f-473e-ba3c-826052d3f4a4)

- detect user errors and respond with 400 errors instead
- send proper Content-Type and Content-Lenght