### PR TITLE
Fix text text_renderer example

### DIFF
--- a/compositor_common/src/validators/test.rs
+++ b/compositor_common/src/validators/test.rs
@@ -40,16 +40,16 @@ fn scene_validation_finds_cycle() {
 
     let b = TransformNodeSpec {
         node_id: b_id.clone(),
-        input_pads: vec![a_id.clone()],
+        input_pads: vec![a_id],
         resolution: res,
         transform_params: trans_params.clone(),
     };
 
     let c = TransformNodeSpec {
         node_id: c_id.clone(),
-        input_pads: vec![b_id.clone()],
+        input_pads: vec![b_id],
         resolution: res,
-        transform_params: trans_params.clone(),
+        transform_params: trans_params,
     };
 
     let output = OutputSpec {
@@ -118,7 +118,7 @@ fn scene_validation_finds_unused_nodes() {
         node_id: c_id.clone(),
         input_pads: vec![b_id.clone()],
         resolution: res,
-        transform_params: trans_params.clone(),
+        transform_params: trans_params,
     };
 
     let output = OutputSpec {

--- a/examples/text_renderer.rs
+++ b/examples/text_renderer.rs
@@ -74,6 +74,21 @@ fn start_example_client_code() -> Result<()> {
         }
     }))?;
 
+    info!("[example] Send register output request.");
+    common::post(&json!({
+        "type": "register_output",
+        "id": "output 2",
+        "port": 8006,
+        "ip": "127.0.0.1",
+        "resolution": {
+            "width": VIDEO_RESOLUTION.width,
+            "height": VIDEO_RESOLUTION.height,
+        },
+        "encoder_settings": {
+            "preset": "ultrafast"
+        }
+    }))?;
+
     info!("[example] Send register input request.");
     common::post(&json!({
         "type": "register_input",
@@ -109,6 +124,10 @@ fn start_example_client_code() -> Result<()> {
             {
                 "output_id": "output 1",
                 "input_pad": "text_renderer"
+            },
+            {
+                "output_id": "output 2",
+                "input_pad": "input 1"
             }
         ]
     }))?;


### PR DESCRIPTION
Current validation does not allow unused inputs, but we need at least one input to start pipeline (until https://github.com/membraneframework/video_compositor/issues/47 is addressed)

So to fix the example I added second output that is there just to pass input through