### PR TITLE
Implement query API

### DIFF
--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -50,6 +50,14 @@ impl<Input: PipelineInput, Output: PipelineOutput> Pipeline<Input, Output> {
         })
     }
 
+    pub fn renderer(&self) -> &Renderer {
+        &self.renderer
+    }
+
+    pub fn queue(&self) -> &Queue {
+        &self.queue
+    }
+
     pub fn register_input(
         &mut self,
         input_id: InputId,

--- a/compositor_pipeline/src/queue.rs
+++ b/compositor_pipeline/src/queue.rs
@@ -1,17 +1,17 @@
 mod internal_queue;
+mod queue_thread;
 
 use std::{
     sync::{Arc, Mutex},
-    thread::{self, sleep},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use compositor_common::{scene::InputId, Frame, Framerate};
 use compositor_render::frame_set::FrameSet;
-use crossbeam_channel::{tick, unbounded, Receiver, Sender};
+use crossbeam_channel::{unbounded, Receiver, Sender};
 use thiserror::Error;
 
-use self::internal_queue::InternalQueue;
+use self::{internal_queue::InternalQueue, queue_thread::QueueThread};
 
 #[derive(Error, Debug)]
 pub enum QueueError {
@@ -22,7 +22,7 @@ pub enum QueueError {
 const DEFAULT_BUFFER_DURATION: Duration = Duration::from_millis(10);
 
 pub struct Queue {
-    internal_queue: Arc<Mutex<InternalQueue>>,
+    internal_queue: Mutex<InternalQueue>,
     check_queue_channel: (Sender<()>, Receiver<()>),
     output_framerate: Framerate,
     buffer_duration: Duration,
@@ -31,7 +31,7 @@ pub struct Queue {
 impl Queue {
     pub fn new(output_framerate: Framerate) -> Self {
         Queue {
-            internal_queue: Arc::new(Mutex::new(InternalQueue::new(output_framerate))),
+            internal_queue: Mutex::new(InternalQueue::new(output_framerate)),
             check_queue_channel: unbounded(),
             output_framerate,
             buffer_duration: DEFAULT_BUFFER_DURATION,
@@ -50,35 +50,20 @@ impl Queue {
         internal_queue.remove_input(input_id);
     }
 
-    pub fn start(&self, sender: Sender<FrameSet<InputId>>) {
-        let (check_queue_sender, check_queue_receiver) = self.check_queue_channel.clone();
-        let internal_queue = self.internal_queue.clone();
+    pub fn start(self: &Arc<Self>, sender: Sender<FrameSet<InputId>>) {
+        let queue = self.clone();
         let tick_duration = self.output_framerate.get_interval_duration();
         let buffer_duration = self.buffer_duration;
 
-        thread::spawn(move || {
-            // Wait for first frame
-            check_queue_receiver.recv().unwrap();
-            sleep(buffer_duration);
-
-            Self::start_ticker(tick_duration, check_queue_sender);
-
-            let start = Instant::now();
-            loop {
-                check_queue_receiver.recv().unwrap();
-
-                let mut internal_queue = internal_queue.lock().unwrap();
-                let buffer_pts = internal_queue.get_next_output_buffer_pts();
-
-                if start.elapsed() + buffer_duration > buffer_pts
-                    || internal_queue.check_all_inputs_ready(buffer_pts)
-                {
-                    let frames_batch = internal_queue.get_frames_batch(buffer_pts);
-                    sender.send(frames_batch).unwrap();
-                    internal_queue.drop_useless_frames();
-                }
-            }
-        });
+        QueueThread::new(
+            queue,
+            sender,
+            queue_thread::Options {
+                buffer_duration,
+                tick_duration,
+            },
+        )
+        .spawn();
     }
 
     pub fn enqueue_frame(&self, input_id: InputId, frame: Frame) -> Result<(), QueueError> {
@@ -92,14 +77,10 @@ impl Queue {
         Ok(())
     }
 
-    fn start_ticker(tick_duration: Duration, check_queue_sender: Sender<()>) {
-        thread::spawn(move || {
-            let ticker = tick(tick_duration);
-            check_queue_sender.send(()).unwrap();
-            loop {
-                ticker.recv().unwrap();
-                check_queue_sender.send(()).unwrap();
-            }
-        });
+    pub fn subscribe_input_listener(&self, input_id: InputId, callback: Box<dyn FnOnce() + Send>) {
+        self.internal_queue
+            .lock()
+            .unwrap()
+            .subscribe_input_listener(input_id, callback)
     }
 }

--- a/compositor_pipeline/src/queue/queue_thread.rs
+++ b/compositor_pipeline/src/queue/queue_thread.rs
@@ -1,0 +1,84 @@
+use std::{
+    sync::{Arc, MutexGuard},
+    thread::{self, JoinHandle},
+    time::{Duration, Instant},
+};
+
+use compositor_common::scene::InputId;
+use compositor_render::frame_set::FrameSet;
+use crossbeam_channel::{tick, Sender};
+
+use super::{internal_queue::InternalQueue, Queue};
+
+pub struct Options {
+    pub buffer_duration: Duration,
+    pub tick_duration: Duration,
+}
+
+pub struct QueueThread {
+    queue: Arc<Queue>,
+    sender: Sender<FrameSet<InputId>>,
+    opts: Options,
+}
+
+impl QueueThread {
+    pub fn new(queue: Arc<Queue>, sender: Sender<FrameSet<InputId>>, opts: Options) -> Self {
+        Self {
+            queue,
+            sender,
+            opts,
+        }
+    }
+
+    pub fn spawn(mut self) -> JoinHandle<()> {
+        thread::spawn(move || self.run())
+    }
+
+    fn run(&mut self) {
+        // Wait for first frame
+        self.queue.check_queue_channel.1.recv().unwrap();
+        thread::sleep(self.opts.buffer_duration);
+
+        self.start_ticker();
+
+        let start = Instant::now();
+        loop {
+            self.queue.check_queue_channel.1.recv().unwrap();
+
+            let mut internal_queue = self.queue.internal_queue.lock().unwrap();
+            let buffer_pts = internal_queue.get_next_output_buffer_pts();
+
+            if start.elapsed() + self.opts.buffer_duration > buffer_pts
+                || internal_queue.check_all_inputs_ready(buffer_pts)
+            {
+                let frames_batch = internal_queue.get_frames_batch(buffer_pts);
+                self.send_frames(frames_batch, &mut internal_queue);
+                internal_queue.drop_useless_frames();
+            }
+        }
+    }
+
+    fn send_frames(
+        &self,
+        frames_batch: FrameSet<InputId>,
+        internal_queue: &mut MutexGuard<InternalQueue>,
+    ) {
+        for input_id in frames_batch.frames.keys() {
+            internal_queue.call_input_listeners(input_id)
+        }
+        self.sender.send(frames_batch).unwrap();
+    }
+
+    fn start_ticker(&self) {
+        let check_queue_sender = self.queue.check_queue_channel.0.clone();
+        let tick_duration = self.opts.tick_duration;
+        thread::spawn(move || {
+            let ticker = tick(tick_duration);
+            check_queue_sender.send(()).unwrap();
+            loop {
+                ticker.recv().unwrap();
+                check_queue_sender.send(()).unwrap();
+            }
+        });
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -2,13 +2,14 @@ use anyhow::{anyhow, Result};
 use compositor_common::SpecValidationError;
 use compositor_pipeline::pipeline;
 use compositor_render::registry;
+use crossbeam_channel::RecvTimeoutError;
 use log::{error, info};
 
 use serde_json::json;
-use std::{error::Error, io::Cursor, net::SocketAddr, thread};
+use std::{error::Error, io::Cursor, net::SocketAddr, sync::Arc, thread, time::Duration};
 use tiny_http::{Header, Response, StatusCode};
 
-use crate::api::{Api, Request};
+use crate::api::{self, Api, Request, ResponseHandler};
 
 pub struct Server {
     server: tiny_http::Server,
@@ -16,21 +17,56 @@ pub struct Server {
 }
 
 impl Server {
-    pub fn new(port: u16) -> Self {
+    pub fn new(port: u16) -> Arc<Self> {
         Self {
             server: tiny_http::Server::http(SocketAddr::from(([0, 0, 0, 0], port))).unwrap(),
             content_type_json: Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
                 .unwrap(),
         }
+        .into()
     }
 
-    pub fn start(self) {
+    pub fn start(self: Arc<Self>) {
         info!("Listening on port {}", self.server.server_addr());
         let mut api = self.handle_init();
         thread::spawn(move || {
             for mut raw_request in self.server.incoming_requests() {
                 let result = Self::handle_request_after_init(&mut api, &mut raw_request);
-                self.send_response(raw_request, result);
+                match result {
+                    Ok(ResponseHandler::Ok) => {
+                        self.send_response(raw_request, api::Response::Ok {});
+                    }
+                    Ok(ResponseHandler::Response(response)) => {
+                        self.send_response(raw_request, response);
+                    }
+                    Ok(ResponseHandler::DeferredResponse(response)) => {
+                        let server = self.clone();
+                        thread::spawn(move || {
+                            let response = response.recv_timeout(Duration::from_secs(60));
+                            match response {
+                                Ok(Ok(response)) => {
+                                    server.send_response(raw_request, response);
+                                }
+                                Ok(Err(err)) => {
+                                    server.send_err_response(raw_request, err);
+                                }
+                                Err(RecvTimeoutError::Timeout) => {
+                                    server
+                                        .send_err_response(raw_request, anyhow!("query timed out"));
+                                }
+                                Err(RecvTimeoutError::Disconnected) => {
+                                    server.send_err_response(
+                                        raw_request,
+                                        anyhow!("internal server error"),
+                                    );
+                                }
+                            };
+                        });
+                    }
+                    Err(err) => {
+                        self.send_err_response(raw_request, err);
+                    }
+                }
             }
         });
     }
@@ -42,11 +78,11 @@ impl Server {
                 .and_then(Api::new);
             match result {
                 Ok(new_api) => {
-                    self.send_response(raw_request, Ok(()));
+                    self.send_response(raw_request, api::Response::Ok {});
                     return new_api;
                 }
                 Err(err) => {
-                    self.send_response(raw_request, Err(err));
+                    self.send_err_response(raw_request, err);
                 }
             }
         }
@@ -56,7 +92,7 @@ impl Server {
     fn handle_request_after_init(
         api: &mut Api,
         raw_request: &mut tiny_http::Request,
-    ) -> Result<()> {
+    ) -> Result<ResponseHandler> {
         let request = Server::parse_request(raw_request)?;
         api.handle_request(request)
     }
@@ -74,49 +110,49 @@ impl Server {
         }
     }
 
-    fn send_response(&self, raw_request: tiny_http::Request, response: Result<()>) {
-        let response_result = match response {
-            Ok(_) => {
-                let body = "{}".as_bytes().to_vec();
-                raw_request
-                    .respond(Response::new(
-                        StatusCode(200),
-                        vec![self.content_type_json.clone()],
-                        Cursor::new(&body),
-                        Some(body.len()),
-                        None,
-                    ))
-                    .map_err(Into::into)
-            }
-            Err(err) => self.handle_error(raw_request, err.as_ref()),
-        };
+    fn send_response(&self, raw_request: tiny_http::Request, response: api::Response) {
+        let response_result = serde_json::to_string(&response)
+            .map_err(Into::into)
+            .and_then(|body| {
+                raw_request.respond(Response::new(
+                    StatusCode(200),
+                    vec![self.content_type_json.clone()],
+                    Cursor::new(&body),
+                    Some(body.len()),
+                    None,
+                ))
+            });
         if let Err(err) = response_result {
             error!("Failed to send response {}.", err);
         }
     }
 
-    fn handle_error(
-        &self,
-        raw_request: tiny_http::Request,
-        err: &(dyn Error + 'static),
-    ) -> Result<()> {
-        let reason: Vec<String> = Sources(Some(err)).map(|e| format!("{e}")).collect();
-        let body = serde_json::to_string(&json!({
-            "msg": reason[0],
-            "reason": reason,
-        }))?;
+    fn send_err_response(&self, raw_request: tiny_http::Request, err: anyhow::Error) {
+        let reason: Vec<String> = Sources(Some(err.as_ref()))
+            .map(|e| format!("{e}"))
+            .collect();
         let status_code = match is_user_error(err) {
             true => 400,
             false => 500,
         };
-        raw_request.respond(Response::new(
-            StatusCode(status_code),
-            vec![self.content_type_json.clone()],
-            Cursor::new(&body),
-            Some(body.len()),
-            None,
-        ))?;
-        Ok(())
+
+        let response_result = serde_json::to_string(&json!({
+            "msg": reason[0],
+            "reason": reason,
+        }))
+        .map_err(Into::into)
+        .and_then(|body| {
+            raw_request.respond(Response::new(
+                StatusCode(status_code),
+                vec![self.content_type_json.clone()],
+                Cursor::new(&body),
+                Some(body.len()),
+                None,
+            ))
+        });
+        if let Err(err) = response_result {
+            error!("Failed to send response {}.", err);
+        }
     }
 
     fn parse_request(request: &mut tiny_http::Request) -> Result<Request> {
@@ -124,8 +160,8 @@ impl Server {
     }
 }
 
-fn is_user_error(err: &(dyn Error + 'static)) -> bool {
-    let opt = Some(err);
+fn is_user_error(err: anyhow::Error) -> bool {
+    let opt = Some(err.as_ref());
     let mut sources = Sources(opt);
     sources.any(|source| {
         source.is::<SpecValidationError>()

--- a/src/rtp_sender.rs
+++ b/src/rtp_sender.rs
@@ -15,7 +15,7 @@ use ffmpeg_next::{
 pub struct RtpSender {
     sender: Sender<Frame>,
     pub(crate) port: u16,
-    pub(crate) ip: Arc<String>,
+    pub(crate) ip: Arc<str>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -91,7 +91,7 @@ pub struct EncoderSettings {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Options {
     pub port: u16,
-    pub ip: Arc<String>,
+    pub ip: Arc<str>,
     pub resolution: Resolution,
     pub encoder_settings: EncoderSettings,
 }


### PR DESCRIPTION
Add some basic queries e.g.
- get scene
- get registered inputs
- get registered output
(we could add bunch of other queries like that, I just picked those for start)

Add blocking query:
- WaitForNextFrame will block the response until the next frame will not show up in the queue

Break out some queue code into separate files.

~~Currently, I'm responding when a frame is enqueued. I think at this point we know that next render will include a frame (but not necessarily that one). I'm open 2 suggestions, I also considered:~~
- ~~calling callback when pushing frames to the renderer~~
- ~~have 2 different types of callback (one when enqueueing and one when pushing to renderer)~~

Response for input listener is sent when we send a frame from queue to renderer

Few small changes:
- drop unnecessary Arc around internal_queue
- switch Arc<String> to Arc<str> in RtpSender