### PR TITLE
Add proper error handling for wgpu.

### DIFF
--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -158,7 +158,12 @@ impl<Input: PipelineInput, Output: PipelineOutput> Pipeline<Input, Output> {
                     warn!("Dropping frame: render queue is too long.",);
                     continue;
                 }
-                let output_frames = renderer.render(input_frames);
+
+                let output = renderer.render(input_frames);
+                let Ok(output_frames) = output else {
+                    error!("Error while rendering: {}", output.unwrap_err());
+                    continue;
+                };
 
                 for (id, frame) in output_frames.frames {
                     let output = outputs.lock().get(&id).map(Clone::clone);

--- a/compositor_render/examples/silly.rs
+++ b/compositor_render/examples/silly.rs
@@ -121,7 +121,7 @@ fn main() {
 
     let mut frame_set = FrameSet::new(Duration::from_secs_f32(std::f32::consts::FRAC_PI_2));
     frame_set.frames.insert(input_id.into(), frame);
-    let output = renderer.render(frame_set);
+    let output = renderer.render(frame_set).expect("render");
     let output = output.frames.get(&output_id.into()).expect("extract frame");
     let mut output_data = Vec::with_capacity(resolution.width * resolution.height * 3 / 2);
     output_data.extend_from_slice(&output.data.y_plane);

--- a/compositor_render/src/renderer.rs
+++ b/compositor_render/src/renderer.rs
@@ -196,7 +196,7 @@ impl From<wgpu::Error> for WgpuError {
     fn from(value: wgpu::Error) -> Self {
         match value {
             wgpu::Error::OutOfMemory { .. } => Self::OutOfMemory(format!("{value}")),
-            wgpu::Error::Validation { .. } => Self::OutOfMemory(format!("{value}")),
+            wgpu::Error::Validation { .. } => Self::Validation(format!("{value}")),
         }
     }
 }

--- a/compositor_render/src/renderer.rs
+++ b/compositor_render/src/renderer.rs
@@ -73,6 +73,9 @@ pub enum RendererRegisterTransformationError {
     #[error("failed to register a transformation in the transformation registry")]
     TransformationRegistry(#[from] registry::RegisterError),
 
+    #[error("failed to to initialize the shader")]
+    Shader(#[from] WgpuError),
+
     #[error("failed to create web renderer transformation")]
     WebRendererTransformation(#[from] WebRendererNewError),
 
@@ -105,7 +108,10 @@ impl Renderer {
         }
     }
 
-    pub fn render(&mut self, mut inputs: FrameSet<InputId>) -> FrameSet<OutputId> {
+    pub fn render(
+        &mut self,
+        mut inputs: FrameSet<InputId>,
+    ) -> Result<FrameSet<OutputId>, RenderError> {
         let ctx = &mut RenderCtx {
             wgpu_ctx: &self.wgpu_ctx,
             electron: &self.electron_instance,
@@ -115,14 +121,18 @@ impl Renderer {
             image_registry: &self.image_registry,
         };
 
+        let scope = WgpuErrorScope::push(&ctx.wgpu_ctx.device);
+
         populate_inputs(ctx, &mut self.scene, &mut inputs.frames);
         run_transforms(ctx, &self.scene, inputs.pts);
         let frames = read_outputs(ctx, &self.scene, inputs.pts);
 
-        FrameSet {
+        scope.pop(&ctx.wgpu_ctx.device)?;
+
+        Ok(FrameSet {
             frames,
             pts: inputs.pts,
-        }
+        })
     }
 
     pub fn update_scene(&mut self, scene_specs: Arc<SceneSpec>) -> Result<(), SceneUpdateError> {
@@ -140,6 +150,12 @@ impl Renderer {
         self.scene_spec = scene_specs;
         Ok(())
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RenderError {
+    #[error("wgpu error encountered while rendering")]
+    WgpuError(#[from] WgpuError),
 }
 
 pub struct WgpuCtx {
@@ -163,6 +179,26 @@ pub enum WgpuCtxNewError {
 
     #[error("failed to get a wgpu device")]
     NoDevice(#[from] wgpu::RequestDeviceError),
+
+    #[error("wgpu error")]
+    WgpuError(#[from] WgpuError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WgpuError {
+    #[error("wgpu validation error: {0}")]
+    Validation(String),
+    #[error("wgpu out of memory error: {0}")]
+    OutOfMemory(String),
+}
+
+impl From<wgpu::Error> for WgpuError {
+    fn from(value: wgpu::Error) -> Self {
+        match value {
+            wgpu::Error::OutOfMemory { .. } => Self::OutOfMemory(format!("{value}")),
+            wgpu::Error::Validation { .. } => Self::OutOfMemory(format!("{value}")),
+        }
+    }
 }
 
 impl WgpuCtx {
@@ -192,6 +228,8 @@ impl WgpuCtx {
             None,
         ))?;
 
+        let scope = WgpuErrorScope::push(&device);
+
         let format = TextureFormat::new(&device);
         let utils = TextureUtils::new(&device);
 
@@ -204,9 +242,8 @@ impl WgpuCtx {
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
         });
 
-        // this is temporary until we implement proper error handling in the wgpu renderer
-        // it's important to overwrite this though, because the default uncaptured error
-        // handler panics
+        scope.pop(&device)?;
+
         device.on_uncaptured_error(Box::new(|e| {
             error!("wgpu error: {:?}", e);
         }));
@@ -247,5 +284,27 @@ impl CommonShaderParameters {
 
     pub fn push_constant(&self) -> &[u8] {
         bytemuck::bytes_of(self)
+    }
+}
+
+#[must_use]
+pub(crate) struct WgpuErrorScope;
+
+impl WgpuErrorScope {
+    pub(crate) fn push(device: &wgpu::Device) -> Self {
+        device.push_error_scope(wgpu::ErrorFilter::Validation);
+        device.push_error_scope(wgpu::ErrorFilter::OutOfMemory);
+
+        Self
+    }
+
+    pub(crate) fn pop(self, device: &wgpu::Device) -> Result<(), WgpuError> {
+        for _ in 0..2 {
+            if let Some(error) = pollster::block_on(device.pop_error_scope()) {
+                return Err(error.into());
+            }
+        }
+
+        Ok(())
     }
 }

--- a/compositor_render/src/renderer/scene.rs
+++ b/compositor_render/src/renderer/scene.rs
@@ -19,7 +19,7 @@ use crate::{
 
 use super::{
     texture::{InputTexture, NodeTexture, OutputTexture},
-    RenderCtx,
+    RenderCtx, WgpuError, WgpuErrorScope,
 };
 
 pub struct InputNode {}
@@ -148,7 +148,10 @@ pub enum SceneUpdateError {
     NoNodeWithIdError(NodeId),
 
     #[error("Scene definition is invalid")]
-    InvalidSpec(#[source] SpecValidationError),
+    InvalidSpec(#[from] SpecValidationError),
+
+    #[error("Wgpu error")]
+    WgpuError(#[from] WgpuError),
 }
 
 impl Scene {
@@ -162,6 +165,8 @@ impl Scene {
     pub fn update(&mut self, ctx: &RenderCtx, spec: &SceneSpec) -> Result<(), SceneUpdateError> {
         // TODO: If we want nodes to be stateful we could try reusing nodes instead
         //       of recreating them on every scene update
+        let scope = WgpuErrorScope::push(&ctx.wgpu_ctx.device);
+
         let mut new_nodes = HashMap::new();
         self.inputs = HashMap::new();
         self.outputs = spec
@@ -172,7 +177,10 @@ impl Scene {
                 let buffers = OutputTexture::new(ctx.wgpu_ctx, node.resolution);
                 Ok((output.output_id.clone(), (node, buffers)))
             })
-            .collect::<Result<_, _>>()?;
+            .collect::<Result<_, SceneUpdateError>>()?;
+
+        scope.pop(&ctx.wgpu_ctx.device)?;
+
         Ok(())
     }
 

--- a/compositor_render/src/sync_renderer.rs
+++ b/compositor_render/src/sync_renderer.rs
@@ -8,7 +8,8 @@ use compositor_common::{
 use crate::{
     frame_set::FrameSet,
     renderer::{
-        scene::SceneUpdateError, Renderer, RendererNewError, RendererRegisterTransformationError,
+        scene::SceneUpdateError, RenderError, Renderer, RendererNewError,
+        RendererRegisterTransformationError,
     },
     transformations::{image_renderer::Image, shader::Shader, web_renderer::WebRenderer},
 };
@@ -29,7 +30,7 @@ impl SyncRenderer {
         let ctx = self.0.lock().unwrap().register_transformation_ctx();
         match spec {
             TransformationSpec::Shader { source } => {
-                let shader = Arc::new(Shader::new(&ctx, source));
+                let shader = Arc::new(Shader::new(&ctx, source)?);
 
                 let mut guard = self.0.lock().unwrap();
                 guard.shader_transforms.register(&key, shader)?
@@ -50,7 +51,7 @@ impl SyncRenderer {
         Ok(())
     }
 
-    pub fn render(&self, input: FrameSet<InputId>) -> FrameSet<OutputId> {
+    pub fn render(&self, input: FrameSet<InputId>) -> Result<FrameSet<OutputId>, RenderError> {
         self.0.lock().unwrap().render(input)
     }
 

--- a/compositor_render/src/transformations/shader.rs
+++ b/compositor_render/src/transformations/shader.rs
@@ -1,4 +1,7 @@
-use crate::renderer::{texture::NodeTexture, CommonShaderParameters, RegisterTransformationCtx, WgpuErrorScope, WgpuError};
+use crate::renderer::{
+    texture::NodeTexture, CommonShaderParameters, RegisterTransformationCtx, WgpuError,
+    WgpuErrorScope,
+};
 
 use std::{sync::Arc, time::Duration};
 


### PR DESCRIPTION
This PR may be a bit weird, I cannot seem to find a place to put these scopes in that would feel good.

A quick explanation of how these error scopes work:
- you push an error scope to the device error scopes stack
- if an error happens it is caught by the scope
- you pop the error scope from the device stack and it returns one of the errors that it captured (if any)
- errors are captured only by the scope that is the highest on the stack and matches it's type (validation/oom)