### PR TITLE
Move texture buffer methods to base

### DIFF
--- a/compositor_render/src/renderer/texture.rs
+++ b/compositor_render/src/renderer/texture.rs
@@ -1,15 +1,10 @@
-use std::{
-    io::Write,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::Bytes;
 use compositor_common::{scene::Resolution, util::RGBColor, Frame};
-use crossbeam_channel::bounded;
-use log::error;
-use wgpu::{Buffer, BufferAsyncError, MapMode};
+use wgpu::BufferAsyncError;
 
-use self::{utils::pad_to_256, yuv::YUVPendingDownload};
+use self::yuv::YUVPendingDownload;
 
 use super::WgpuCtx;
 
@@ -167,37 +162,9 @@ impl OutputTexture {
         self.textures.copy_to_buffers(ctx, &self.buffers);
 
         YUVPendingDownload::new(
-            self.download_buffer(self.textures.planes[0].texture.size(), &self.buffers[0]),
-            self.download_buffer(self.textures.planes[1].texture.size(), &self.buffers[1]),
-            self.download_buffer(self.textures.planes[2].texture.size(), &self.buffers[2]),
+            self.textures.planes[0].prepare_download(&self.buffers[0]),
+            self.textures.planes[1].prepare_download(&self.buffers[1]),
+            self.textures.planes[2].prepare_download(&self.buffers[2]),
         )
-    }
-
-    fn download_buffer<'a>(
-        &'a self,
-        size: wgpu::Extent3d,
-        source: &'a Buffer,
-    ) -> impl FnOnce() -> Result<Bytes, BufferAsyncError> + 'a {
-        let buffer = BytesMut::with_capacity((size.width * size.height) as usize);
-        let (s, r) = bounded(1);
-        source.slice(..).map_async(MapMode::Read, move |result| {
-            if let Err(err) = s.send(result) {
-                error!("channel send error: {err}")
-            }
-        });
-
-        move || {
-            r.recv().unwrap()?;
-            let mut buffer = buffer.writer();
-            {
-                let range = source.slice(..).get_mapped_range();
-                let chunks = range.chunks(pad_to_256(size.width) as usize);
-                for chunk in chunks {
-                    buffer.write_all(&chunk[..size.width as usize]).unwrap();
-                }
-            };
-            source.unmap();
-            Ok(buffer.into_inner().into())
-        }
     }
 }

--- a/compositor_render/src/renderer/texture/base.rs
+++ b/compositor_render/src/renderer/texture/base.rs
@@ -1,9 +1,3 @@
-use std::io::Write;
-
-use bytes::{BufMut, Bytes, BytesMut};
-use crossbeam_channel::bounded;
-use log::error;
-
 use crate::renderer::WgpuCtx;
 
 use super::utils::pad_to_256;
@@ -79,43 +73,6 @@ impl Texture {
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             size: (block_size * pad_to_256(size.width) * size.height) as u64,
         })
-    }
-
-    /// Starts reading source buffer asynchronously and sends data via channel.
-    /// Returns function which reads data from source buffer channel and populates output buffer.
-    /// [`wgpu::Device::poll`] has to be called before returned function is called
-    pub(super) fn prepare_download<'a>(
-        &'a self,
-        source: &'a wgpu::Buffer,
-    ) -> impl FnOnce() -> Result<Bytes, wgpu::BufferAsyncError> + 'a {
-        let size = self.size();
-        let buffer = BytesMut::with_capacity((size.width * size.height) as usize);
-        let block_size = self.block_size().unwrap();
-
-        let (sender, receiver) = bounded(1);
-        source
-            .slice(..)
-            .map_async(wgpu::MapMode::Read, move |result| {
-                if let Err(err) = sender.send(result) {
-                    error!("channel send error: {err}")
-                }
-            });
-
-        move || {
-            receiver.recv().unwrap()?;
-            let mut buffer = buffer.writer();
-            {
-                let range = source.slice(..).get_mapped_range();
-                let chunks = range.chunks((block_size * pad_to_256(size.width)) as usize);
-                for chunk in chunks {
-                    buffer
-                        .write_all(&chunk[..(block_size * size.width) as usize])
-                        .unwrap();
-                }
-            };
-            source.unmap();
-            Ok(buffer.into_inner().into())
-        }
     }
 
     /// [`wgpu::Queue::submit`] has to be called afterwards

--- a/compositor_render/src/renderer/texture/base.rs
+++ b/compositor_render/src/renderer/texture/base.rs
@@ -1,4 +1,12 @@
+use std::io::Write;
+
+use bytes::{BufMut, Bytes, BytesMut};
+use crossbeam_channel::bounded;
+use log::error;
+
 use crate::renderer::WgpuCtx;
+
+use super::utils::pad_to_256;
 
 pub struct Texture {
     pub texture: wgpu::Texture,
@@ -53,6 +61,84 @@ impl Texture {
                 rows_per_image: Some(self.texture.height()),
             },
             self.texture.size(),
+        );
+    }
+
+    /// Returns `None` for some depth formats
+    pub(super) fn block_size(&self) -> Option<u32> {
+        self.texture.format().block_size(None)
+    }
+
+    pub(super) fn new_download_buffer(&self, ctx: &WgpuCtx) -> wgpu::Buffer {
+        let size = self.size();
+        let block_size = self.block_size().unwrap();
+
+        ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("texture buffer"),
+            mapped_at_creation: false,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            size: (block_size * pad_to_256(size.width) * size.height) as u64,
+        })
+    }
+
+    /// Starts reading source buffer asynchronously and sends data via channel.
+    /// Returns function which reads data from source buffer channel and populates output buffer.
+    /// [`wgpu::Device::poll`] has to be called before returned function is called
+    pub(super) fn prepare_download<'a>(
+        &'a self,
+        source: &'a wgpu::Buffer,
+    ) -> impl FnOnce() -> Result<Bytes, wgpu::BufferAsyncError> + 'a {
+        let size = self.size();
+        let buffer = BytesMut::with_capacity((size.width * size.height) as usize);
+        let block_size = self.block_size().unwrap();
+
+        let (sender, receiver) = bounded(1);
+        source
+            .slice(..)
+            .map_async(wgpu::MapMode::Read, move |result| {
+                if let Err(err) = sender.send(result) {
+                    error!("channel send error: {err}")
+                }
+            });
+
+        move || {
+            receiver.recv().unwrap()?;
+            let mut buffer = buffer.writer();
+            {
+                let range = source.slice(..).get_mapped_range();
+                let chunks = range.chunks((block_size * pad_to_256(size.width)) as usize);
+                for chunk in chunks {
+                    buffer
+                        .write_all(&chunk[..(block_size * size.width) as usize])
+                        .unwrap();
+                }
+            };
+            source.unmap();
+            Ok(buffer.into_inner().into())
+        }
+    }
+
+    /// [`wgpu::Queue::submit`] has to be called afterwards
+    pub(super) fn copy_to_buffer(&self, encoder: &mut wgpu::CommandEncoder, buffer: &wgpu::Buffer) {
+        let size = self.size();
+        let block_size = self.block_size().unwrap();
+
+        encoder.copy_texture_to_buffer(
+            wgpu::ImageCopyTexture {
+                aspect: wgpu::TextureAspect::All,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                texture: &self.texture,
+            },
+            wgpu::ImageCopyBuffer {
+                buffer,
+                layout: wgpu::ImageDataLayout {
+                    bytes_per_row: Some(block_size * pad_to_256(size.width)),
+                    rows_per_image: Some(size.height),
+                    offset: 0,
+                },
+            },
+            size,
         );
     }
 }

--- a/compositor_render/src/renderer/texture/yuv.rs
+++ b/compositor_render/src/renderer/texture/yuv.rs
@@ -6,7 +6,7 @@ use wgpu::Buffer;
 
 use crate::renderer::WgpuCtx;
 
-use super::{base::Texture, utils::pad_to_256};
+use super::base::Texture;
 
 pub struct YUVPendingDownload<'a, F, E>
 where
@@ -119,20 +119,10 @@ impl YUVTextures {
 
     pub(super) fn new_download_buffers(&self, ctx: &WgpuCtx) -> [Buffer; 3] {
         [
-            self.new_download_buffer(ctx, 0),
-            self.new_download_buffer(ctx, 1),
-            self.new_download_buffer(ctx, 2),
+            self.planes[0].new_download_buffer(ctx),
+            self.planes[1].new_download_buffer(ctx),
+            self.planes[2].new_download_buffer(ctx),
         ]
-    }
-
-    fn new_download_buffer(&self, ctx: &WgpuCtx, plane: usize) -> Buffer {
-        let size = self.planes[plane].size();
-        ctx.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("output texture buffer"),
-            mapped_at_creation: false,
-            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
-            size: (pad_to_256(size.width) * size.height) as u64,
-        })
     }
 
     pub(super) fn copy_to_buffers(&self, ctx: &WgpuCtx, buffers: &[Buffer; 3]) {
@@ -143,25 +133,7 @@ impl YUVTextures {
             });
 
         for plane in [0, 1, 2] {
-            let texture = &self.planes[plane].texture;
-            let size = texture.size();
-            encoder.copy_texture_to_buffer(
-                wgpu::ImageCopyTexture {
-                    aspect: wgpu::TextureAspect::All,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d::ZERO,
-                    texture,
-                },
-                wgpu::ImageCopyBuffer {
-                    buffer: &buffers[plane],
-                    layout: wgpu::ImageDataLayout {
-                        bytes_per_row: Some(pad_to_256(size.width)),
-                        rows_per_image: Some(size.height),
-                        offset: 0,
-                    },
-                },
-                size,
-            )
+            self.planes[plane].copy_to_buffer(&mut encoder, &buffers[plane]);
         }
 
         ctx.queue.submit(Some(encoder.finish()));


### PR DESCRIPTION
There are some methods for copying textures to buffers which are limited to YUV but could be useful for a RGBA texture too. I moved them to the base texture