### PR TITLE
Pass missing frame through pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "serde",
+ "serde_with",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bytes = "1.4.0"
 env_logger = "0.10.0"
 serde_json = "1.0.99"
 serde = { version = "1.0.164", features = ["derive", "rc"] }
+serde_with = "3.2.0"
 log = "0.4.19"
 thiserror = "1.0.40"
 crossbeam-channel = "0.5.8"

--- a/compositor_common/Cargo.toml
+++ b/compositor_common/Cargo.toml
@@ -11,4 +11,4 @@ serde = { workspace = true }
 thiserror = { workspace = true } 
 log = { workspace = true } 
 glyphon = "0.3.0"
-serde_with = "3.2.0"
+serde_with = { workspace = true }

--- a/compositor_common/src/util.rs
+++ b/compositor_common/src/util.rs
@@ -6,6 +6,8 @@ use serde_with::{DeserializeFromStr, SerializeDisplay};
 pub struct RGBColor(pub u8, pub u8, pub u8);
 
 impl RGBColor {
+    pub const BLACK: Self = Self(255, 255, 255);
+
     pub fn to_yuv(&self) -> (f32, f32, f32) {
         let r = self.0 as f32 / 255.0;
         let g = self.1 as f32 / 255.0;

--- a/compositor_pipeline/Cargo.toml
+++ b/compositor_pipeline/Cargo.toml
@@ -15,3 +15,4 @@ anyhow = "1.0.71"
 thiserror = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
+serde_with = { workspace = true }

--- a/compositor_render/examples/silly.rs
+++ b/compositor_render/examples/silly.rs
@@ -6,7 +6,9 @@ use compositor_common::{
     scene::{NodeId, NodeSpec, OutputSpec, Resolution, SceneSpec},
     Frame, Framerate,
 };
-use compositor_render::{frame_set::FrameSet, Renderer, WebRendererOptions};
+use compositor_render::{
+    frame_set::FrameSet, renderer::RendererOptions, Renderer, WebRendererOptions,
+};
 
 const FRAMERATE: Framerate = Framerate(30);
 
@@ -82,13 +84,14 @@ fn main() {
     let frame = get_image("./examples/silly/crab.jpg");
     let resolution = frame.resolution;
 
-    let (mut renderer, _) = Renderer::new(
-        WebRendererOptions {
+    let (mut renderer, _) = Renderer::new(RendererOptions {
+        web_renderer: WebRendererOptions {
             init: false,
             ..Default::default()
         },
-        FRAMERATE,
-    )
+        framerate: FRAMERATE,
+        stream_fallback_timeout: Duration::from_secs(1),
+    })
     .expect("create renderer");
     let shader_key = RendererId("silly shader".into());
 

--- a/compositor_render/src/renderer/texture/utils.rs
+++ b/compositor_render/src/renderer/texture/utils.rs
@@ -1,3 +1,12 @@
+use compositor_common::scene::Resolution;
+
 pub(super) fn pad_to_256(value: u32) -> u32 {
     value + (256 - (value % 256))
+}
+
+pub fn texture_size_to_resolution(size: &wgpu::Extent3d) -> Resolution {
+    Resolution {
+        width: size.width as usize,
+        height: size.height as usize,
+    }
 }

--- a/compositor_render/src/renderer/texture/yuv.rs
+++ b/compositor_render/src/renderer/texture/yuv.rs
@@ -45,6 +45,7 @@ where
 
 pub struct YUVTextures {
     pub(super) planes: [Texture; 3],
+    pub(super) resolution: Resolution,
 }
 
 impl YUVTextures {
@@ -55,6 +56,7 @@ impl YUVTextures {
                 Self::new_plane(ctx, resolution.width / 2, resolution.height / 2),
                 Self::new_plane(ctx, resolution.width / 2, resolution.height / 2),
             ],
+            resolution,
         }
     }
 

--- a/compositor_render/src/sync_renderer.rs
+++ b/compositor_render/src/sync_renderer.rs
@@ -3,28 +3,24 @@ use std::sync::{Arc, Mutex};
 use compositor_common::{
     renderer_spec::RendererSpec,
     scene::{InputId, OutputId, SceneSpec},
-    Framerate,
 };
 
 use crate::{
     event_loop::EventLoop,
     frame_set::FrameSet,
     renderer::{
-        scene::SceneUpdateError, RenderError, Renderer, RendererInitError, RendererRegisterError,
+        scene::SceneUpdateError, RenderError, Renderer, RendererInitError, RendererOptions,
+        RendererRegisterError,
     },
     transformations::{image_renderer::Image, shader::Shader, web_renderer::WebRenderer},
-    WebRendererOptions,
 };
 
 #[derive(Clone)]
 pub struct SyncRenderer(Arc<Mutex<Renderer>>);
 
 impl SyncRenderer {
-    pub fn new(
-        web_renderer_opts: WebRendererOptions,
-        web_renderer_framerate: Framerate,
-    ) -> Result<(Self, EventLoop), RendererInitError> {
-        let renderer = Renderer::new(web_renderer_opts, web_renderer_framerate)?;
+    pub fn new(opts: RendererOptions) -> Result<(Self, EventLoop), RendererInitError> {
+        let renderer = Renderer::new(opts)?;
         let event_loop = EventLoop::new(renderer.chromium_context.cef_context());
 
         Ok((Self(Arc::new(Mutex::new(renderer))), event_loop))

--- a/compositor_render/src/transformations/image_renderer.rs
+++ b/compositor_render/src/transformations/image_renderer.rs
@@ -153,30 +153,7 @@ impl BitmapAsset {
             return;
         }
 
-        let mut encoder = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("copy static image asset to texture"),
-            });
-
-        let size = self.texture.size();
-        encoder.copy_texture_to_texture(
-            wgpu::ImageCopyTexture {
-                aspect: wgpu::TextureAspect::All,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                texture: &self.texture.texture().texture,
-            },
-            wgpu::ImageCopyTexture {
-                aspect: wgpu::TextureAspect::All,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                texture: &target.rgba_texture().texture().texture,
-            },
-            size,
-        );
-
-        ctx.queue.submit(Some(encoder.finish()));
+        copy_texture_to_node_texture(ctx, &self.texture, target);
         state.was_rendered = true;
     }
 
@@ -245,30 +222,7 @@ impl SvgAsset {
             return;
         }
 
-        let mut encoder = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("copy static image asset to texture"),
-            });
-
-        let size = self.texture.size();
-        encoder.copy_texture_to_texture(
-            wgpu::ImageCopyTexture {
-                aspect: wgpu::TextureAspect::All,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                texture: &self.texture.texture().texture,
-            },
-            wgpu::ImageCopyTexture {
-                aspect: wgpu::TextureAspect::All,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                texture: &target.rgba_texture().texture().texture,
-            },
-            size,
-        );
-
-        ctx.queue.submit(Some(encoder.finish()));
+        copy_texture_to_node_texture(ctx, &self.texture, target);
         state.was_rendered = true;
     }
 
@@ -380,30 +334,7 @@ impl AnimatedAsset {
             .iter()
             .min_by_key(|frame| u128::abs_diff(frame.pts.as_nanos(), animation_pts.as_nanos()))
             .unwrap();
-        let mut encoder = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("copy static image asset to texture"),
-            });
-
-        let size = closest_frame.texture.size();
-        encoder.copy_texture_to_texture(
-            wgpu::ImageCopyTexture {
-                aspect: wgpu::TextureAspect::All,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                texture: &closest_frame.texture.texture().texture,
-            },
-            wgpu::ImageCopyTexture {
-                aspect: wgpu::TextureAspect::All,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                texture: &target.rgba_texture().texture().texture,
-            },
-            size,
-        );
-
-        ctx.queue.submit(Some(encoder.finish()));
+        copy_texture_to_node_texture(ctx, &closest_frame.texture, target)
     }
 
     fn resolution(&self) -> Resolution {
@@ -413,6 +344,41 @@ impl AnimatedAsset {
             height: size.height as usize,
         }
     }
+}
+
+fn copy_texture_to_node_texture(ctx: &WgpuCtx, source: &RGBATexture, target: &NodeTexture) {
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("copy static image asset to texture"),
+        });
+
+    let size = source.size();
+    let target = target.ensure_size(
+        ctx,
+        Resolution {
+            width: size.width as usize,
+            height: size.height as usize,
+        },
+    );
+
+    encoder.copy_texture_to_texture(
+        wgpu::ImageCopyTexture {
+            aspect: wgpu::TextureAspect::All,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            texture: &source.texture().texture,
+        },
+        wgpu::ImageCopyTexture {
+            aspect: wgpu::TextureAspect::All,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            texture: &target.rgba_texture().texture().texture,
+        },
+        size,
+    );
+
+    ctx.queue.submit(Some(encoder.finish()));
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/compositor_render/src/transformations/shader/node.rs
+++ b/compositor_render/src/transformations/shader/node.rs
@@ -75,10 +75,11 @@ impl ShaderNode {
     }
 
     pub fn render(&self, sources: &[(&NodeId, &NodeTexture)], target: &NodeTexture, pts: Duration) {
+        let target = target.ensure_size(&self.shader.wgpu_ctx, self.resolution);
         self.shader.render(
             &self.params_bind_group,
             sources,
-            target,
+            &target,
             pts,
             self.clear_color,
         )

--- a/compositor_render/src/transformations/text_renderer.rs
+++ b/compositor_render/src/transformations/text_renderer.rs
@@ -124,8 +124,8 @@ impl TextRendererNode {
                 font_system,
                 &mut atlas,
                 glyphon::Resolution {
-                    width: target.resolution().width as u32,
-                    height: target.resolution().height as u32,
+                    width: self.resolution.width as u32,
+                    height: self.resolution.height as u32,
                 },
                 [TextArea {
                     buffer: &self.buffer,
@@ -135,8 +135,8 @@ impl TextRendererNode {
                     bounds: TextBounds {
                         left: 0,
                         top: 0,
-                        right: target.resolution().width as i32,
-                        bottom: target.resolution().height as i32,
+                        right: self.resolution.width as i32,
+                        bottom: self.resolution.height as i32,
                     },
                     default_color: Color::rgb(255, 255, 255),
                 }],
@@ -152,8 +152,8 @@ impl TextRendererNode {
                     label: Some("Text renderer encoder"),
                 });
 
-        let target_texture = &target.rgba_texture();
-        let view = &target_texture.texture().view;
+        let target_state = target.ensure_size(renderer_ctx.wgpu_ctx, self.resolution);
+        let view = &target_state.rgba_texture().texture().view;
         {
             let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
                 label: None,

--- a/compositor_render/src/transformations/web_renderer.rs
+++ b/compositor_render/src/transformations/web_renderer.rs
@@ -79,11 +79,12 @@ impl WebRenderer {
     ) {
         let mut state = self.state.lock().unwrap();
         if let Some(frame) = state.retrieve_frame() {
+            let target = target.ensure_size(ctx.wgpu_ctx, self.params.resolution);
             self.bgra_texture.upload(ctx.wgpu_ctx, frame);
             self.bgra_to_rgba.convert(
                 ctx.wgpu_ctx,
                 (&self.bgra_texture, &self.bgra_bind_group),
-                &target.rgba_texture(),
+                target.rgba_texture(),
             );
         }
     }

--- a/examples/long_ffmpeg.rs
+++ b/examples/long_ffmpeg.rs
@@ -45,6 +45,7 @@ fn start_example_client_code() -> Result<()> {
             "init": false
         },
         "framerate": FRAMERATE,
+        "stream_fallback_timeout_ms": 2000
     }))?;
 
     info!("[example] Start listening on output port.");

--- a/src/api.rs
+++ b/src/api.rs
@@ -208,7 +208,7 @@ impl Api {
 
     fn register_output(&mut self, request: RegisterOutputRequest) -> Result<()> {
         let RegisterOutputRequest {
-            output_id: id,
+            output_id,
             port,
             resolution,
             encoder_settings,
@@ -218,14 +218,14 @@ impl Api {
         self.pipeline.with_outputs(|mut iter| {
             if let Some((node_id, _)) = iter.find(|(_, output)| output.port == port && output.ip == ip) {
                 return Err(anyhow!(
-                    "Failed to register output with id \"{id}\". Combination of port {port} and IP {ip} is already used by node \"{node_id}\""
+                    "Failed to register output with id \"{output_id}\". Combination of port {port} and IP {ip} is already used by node \"{node_id}\""
                 ));
             };
             Ok(())
         })?;
 
         self.pipeline.register_output(
-            id,
+            output_id,
             rtp_sender::Options {
                 port,
                 ip,

--- a/src/rtp_receiver.rs
+++ b/src/rtp_receiver.rs
@@ -153,7 +153,7 @@ fn frame_from_av(decoded: &mut Video, pts_offset: &mut Option<i64>) -> Result<Fr
     let pts = original_pts
         .map(|original_pts| original_pts + pts_offset.unwrap_or(0))
         .ok_or_else(|| anyhow!("missing pts"))?;
-    let pts = Duration::from_secs_f64((pts as f64) / 90000.0);
+    let pts = Duration::from_secs_f64(f64::max((pts as f64) / 90000.0, 0.0));
     Ok(Frame {
         data: YuvData {
             y_plane: bytes::Bytes::copy_from_slice(decoded.data(0)),


### PR DESCRIPTION
- Instead of generating fake 2x2 texture make texture "Optional". The intention is that each component should decide how to handle missing frame e.g. shaders will convert mising frame to 1x1, but in the future we can e.g. change that behavior if there is only one input.
- If an empty frame is passed all the way to the output, we are filling it with black color
- If frame pts are older by more than the specified time (default 1 second) stop passing old frames to the pipeline. 
- Fix scene update: If scene update failed in old implementation it could break an old scene by removing all the input nodes. Now if scene update fails, old scene is not affected.

### Hacky part

- InputTexture and NodeTexture now have  a method sate that returns Texture and BindingGroup.
- I wanted to avoid dealing with multiple optional values when user needs both of them. For the same reason resize already returns non opional value because at that time we already know that there will be a texture there
- In case of InputTexture it's fine because it's a reference
- In case of NodeTexture it's a bit unsafe because technically caller could take that value and store it somehow. The main reason for that issue is that NodeTexture have internal mutability, so we can either 
  - return copy as it is done in this PR
  - expose mutex so calling code can lock it on it's own
  - use sth like owning-ref crate to return "refernce" to sth that owns a guard
  - Ideally we could rewrite scene to not wrap Nodes into Arcs and all of those issues would go away
  
 ### Follow up PR
 
- implement fallback mechanism
- maybe consider rewriting scene to stop using Arc<Node>