### PR TITLE
Add fallback nodes

### DIFF
--- a/compositor_common/src/scene.rs
+++ b/compositor_common/src/scene.rs
@@ -89,6 +89,7 @@ pub struct NodeSpec {
     pub node_id: NodeId,
     #[serde(default)]
     pub input_pads: Vec<NodeId>,
+    pub fallback_id: Option<NodeId>,
     #[serde(flatten)]
     pub params: NodeParams,
 }

--- a/compositor_common/src/validators.rs
+++ b/compositor_common/src/validators.rs
@@ -133,10 +133,10 @@ impl SceneSpec {
 
         fn visit<'a>(
             node_id: &'a NodeId,
-            transform_nodes: &'a HashMap<&NodeId, &NodeSpec>,
+            nodes: &'a HashMap<&NodeId, &NodeSpec>,
             visited: &mut HashMap<&'a NodeId, NodeState>,
         ) -> Result<(), SpecValidationError> {
-            let Some(node) = transform_nodes.get(node_id) else {
+            let Some(node) = nodes.get(node_id) else {
                 return Ok(());
             };
 
@@ -149,7 +149,10 @@ impl SceneSpec {
             visited.insert(node_id, NodeState::BeingVisited);
 
             for child in &node.input_pads {
-                visit(child, transform_nodes, visited)?;
+                visit(child, nodes, visited)?;
+            }
+            if let Some(fallback_id) = &node.fallback_id {
+                visit(fallback_id, nodes, visited)?;
             }
 
             visited.insert(node_id, NodeState::Visited);
@@ -187,6 +190,9 @@ impl SceneSpec {
 
             for child in &node.input_pads {
                 visit(child, nodes, visited);
+            }
+            if let Some(fallback_id) = &node.fallback_id {
+                visit(fallback_id, nodes, visited);
             }
 
             visited.insert(node_id);

--- a/compositor_common/src/validators/test.rs
+++ b/compositor_common/src/validators/test.rs
@@ -28,18 +28,21 @@ fn scene_validation_finds_cycle() {
         node_id: a_id.clone(),
         input_pads: vec![input_id.clone(), c_id.clone()],
         params: trans_params.clone(),
+        fallback_id: None,
     };
 
     let b = NodeSpec {
         node_id: b_id.clone(),
         input_pads: vec![a_id],
         params: trans_params.clone(),
+        fallback_id: None,
     };
 
     let c = NodeSpec {
         node_id: c_id.clone(),
         input_pads: vec![b_id],
         params: trans_params,
+        fallback_id: None,
     };
 
     let output = OutputSpec {
@@ -78,24 +81,35 @@ fn scene_validation_finds_unused_nodes() {
     let a_id = NodeId(Arc::from("a"));
     let b_id = NodeId(Arc::from("b"));
     let c_id = NodeId(Arc::from("c"));
+    let d_id = NodeId(Arc::from("d"));
     let output_id = NodeId(Arc::from("output"));
 
     let a = NodeSpec {
         node_id: a_id.clone(),
         input_pads: vec![input_id.clone()],
         params: trans_params.clone(),
+        fallback_id: Some(d_id.clone()),
     };
 
     let b = NodeSpec {
         node_id: b_id.clone(),
         input_pads: vec![c_id.clone()],
         params: trans_params.clone(),
+        fallback_id: None,
     };
 
     let c = NodeSpec {
         node_id: c_id.clone(),
         input_pads: vec![b_id.clone()],
+        params: trans_params.clone(),
+        fallback_id: None,
+    };
+
+    let d = NodeSpec {
+        node_id: d_id,
+        input_pads: vec![],
         params: trans_params,
+        fallback_id: None,
     };
 
     let output = OutputSpec {
@@ -104,7 +118,7 @@ fn scene_validation_finds_unused_nodes() {
     };
 
     let scene_spec = SceneSpec {
-        nodes: vec![a, b, c],
+        nodes: vec![a, b, c, d],
         outputs: vec![output],
     };
 

--- a/compositor_render/examples/silly.rs
+++ b/compositor_render/examples/silly.rs
@@ -116,6 +116,7 @@ fn main() {
                     shader_params: None,
                     resolution,
                 },
+                fallback_id: None,
             }],
             outputs: vec![OutputSpec {
                 input_pad: shader_id,

--- a/compositor_render/src/renderer/texture.rs
+++ b/compositor_render/src/renderer/texture.rs
@@ -164,6 +164,10 @@ impl NodeTexture {
         self.0.state()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.0.state().is_none()
+    }
+
     pub fn resolution(&self) -> Option<Resolution> {
         self.0.state().map(NodeTextureState::resolution)
     }

--- a/compositor_render/src/transformations/shader/node.rs
+++ b/compositor_render/src/transformations/shader/node.rs
@@ -80,6 +80,11 @@ impl ShaderNode {
         target: &mut NodeTexture,
         pts: Duration,
     ) {
+        // TODO: temporary hack until builtins are stateless
+        if sources.len() == 1 && sources[0].1.is_empty() {
+            target.clear();
+            return;
+        }
         let target = target.ensure_size(&self.shader.wgpu_ctx, self.resolution);
         self.shader.render(
             &self.params_bind_group,

--- a/examples/long_ffmpeg.rs
+++ b/examples/long_ffmpeg.rs
@@ -89,6 +89,15 @@ fn start_example_client_code() -> Result<()> {
         "source": shader_source,
     }))?;
 
+    info!("[example] Register static image");
+    common::post(&json!({
+        "type": "register",
+        "entity_type": "image",
+        "image_id": "example_image",
+        "asset_type": "jpeg",
+        "url": "https://i.postimg.cc/NfkxF1SV/wp5220836.jpg",
+    }))?;
+
     info!("[example] Start pipeline");
     common::post(&json!({
         "type": "start",
@@ -118,15 +127,21 @@ fn start_example_client_code() -> Result<()> {
     common::post(&json!({
         "type": "update_scene",
         "nodes": [
-           {
-               "type": "shader",
-               "node_id": "shader_1",
-               "shader_id": "example_shader",
-               "input_pads": [
-                   "input_1",
-               ],
-               "resolution": { "width": VIDEO_RESOLUTION.width, "height": VIDEO_RESOLUTION.height },
-           },
+            {
+                "node_id": "image",
+                "type": "image",
+                "image_id": "example_image",
+            },
+            {
+                "type": "shader",
+                "node_id": "shader_1",
+                "shader_id": "example_shader",
+                "fallback_id": "image",
+                "input_pads": [
+                    "input_1",
+                ],
+                "resolution": { "width": VIDEO_RESOLUTION.width, "height": VIDEO_RESOLUTION.height },
+            },
         ],
         "outputs": [
             {


### PR DESCRIPTION
Add fallback nodes:
- Fallback can be defined via fallback_id field in the nodes list in the scene_update request
- There is no way currently to define fallback for input explicitly, you need to have some pass-through transformation.
- There is no way to define fallback on output directly, you need to set it on the last node.
- Currently, we do not have any nodes that can result in missing texture, even if the input is missing, so for now I just added hack to the shader node that clears texture if input is empty and only one.
- Replaced node iterator in render_loop with a recursive walk through the scene, we can't use old approach because without knowledge whether render worked or not we do not know whether we need to render fallback nodes at all.