### PR TITLE
Add process message handler to `cef::Client`

### DIFF
--- a/compositor_chromium/src/client.rs
+++ b/compositor_chromium/src/client.rs
@@ -18,6 +18,8 @@ pub trait Client {
         None
     }
 
+    /// Called when new process message is received.
+    /// Return `true` if message was handled, `false` otherwise
     fn on_process_message_received(
         &mut self,
         _browser: &Browser,


### PR DESCRIPTION
Process message handler in `cef::Client` allows receiving messages back from the renderer subprocess