### PR TITLE
Improve error handling - part 2

### DIFF
--- a/compositor_common/src/lib.rs
+++ b/compositor_common/src/lib.rs
@@ -9,7 +9,7 @@ pub mod util;
 mod validators;
 
 pub type Frame = frame::Frame;
-pub type SpecValidationError = validators::SpecValidationError;
+pub type SpecValidationError = validators::SceneSpecValidationError;
 
 /// TODO: This should be a rational.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]

--- a/compositor_common/src/renderer_spec.rs
+++ b/compositor_common/src/renderer_spec.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{fmt::Display, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 
@@ -6,6 +6,12 @@ use crate::scene::Resolution;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RendererId(pub Arc<str>);
+
+impl Display for RendererId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 /// RendererSpec provides configuration necessary to construct Renderer. Renderers
 /// are entities like shader, image or chromium_instance and can be used by nodes

--- a/compositor_common/src/validators.rs
+++ b/compositor_common/src/validators.rs
@@ -10,9 +10,9 @@ use crate::scene::{
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum SceneSpecValidationError {
-    #[error("Unknown node \"{missing_node}\" used as an input in the node {node}. Node is not defined in the scene and it was not registered as an input.")]
+    #[error("Unknown node \"{missing_node}\" used as an input in the node \"{node}\". Node is not defined in the scene and it was not registered as an input.")]
     UnknownInputPadOnNode { missing_node: NodeId, node: NodeId },
-    #[error("Unknown node \"{missing_node}\" is connected to the output stream {output}.")]
+    #[error("Unknown node \"{missing_node}\" is connected to the output stream \"{output}\".")]
     UnknownInputPadOnOutput {
         missing_node: NodeId,
         output: OutputId,
@@ -142,17 +142,14 @@ impl SceneSpec {
 
         for node_id in defined_node_ids {
             if !nodes_ids.insert(node_id) {
-                match registered_inputs.contains(node_id) {
-                    true => {
-                        return Err(SceneSpecValidationError::DuplicateNodeAndInputNames(
-                            node_id.clone(),
-                        ))
-                    }
-                    false => {
-                        return Err(SceneSpecValidationError::DuplicateNodeNames(
-                            node_id.clone(),
-                        ))
-                    }
+                if registered_inputs.contains(node_id) {
+                    return Err(SceneSpecValidationError::DuplicateNodeAndInputNames(
+                        node_id.clone(),
+                    ));
+                } else {
+                    return Err(SceneSpecValidationError::DuplicateNodeNames(
+                        node_id.clone(),
+                    ));
                 }
             }
         }

--- a/compositor_common/src/validators/test.rs
+++ b/compositor_common/src/validators/test.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, sync::Arc};
 use crate::{
     renderer_spec::RendererId,
     scene::{NodeId, NodeParams, NodeSpec, OutputId, OutputSpec, Resolution, SceneSpec},
-    validators::SpecValidationError,
+    validators::{SceneSpecValidationError, UnusedNodesError},
 };
 
 #[test]
@@ -47,7 +47,7 @@ fn scene_validation_finds_cycle() {
 
     let output = OutputSpec {
         output_id: OutputId(output_id.clone()),
-        input_pad: c_id,
+        input_pad: c_id.clone(),
     };
 
     let scene_spec = SceneSpec {
@@ -58,10 +58,10 @@ fn scene_validation_finds_cycle() {
     let registered_inputs = HashSet::from([&input_id]);
     let registered_outputs = HashSet::from([&output_id]);
 
-    assert!(matches!(
+    assert_eq!(
         scene_spec.validate(&registered_inputs, &registered_outputs),
-        Err(SpecValidationError::CycleDetected)
-    ));
+        Err(SceneSpecValidationError::CycleDetected(c_id.clone()))
+    );
 }
 
 #[test]
@@ -129,6 +129,6 @@ fn scene_validation_finds_unused_nodes() {
 
     assert_eq!(
         scene_spec.validate(&registered_inputs, &registered_outputs),
-        Err(SpecValidationError::UnusedNodes(unused_nodes))
+        Err(UnusedNodesError(unused_nodes).into())
     );
 }

--- a/compositor_pipeline/src/error.rs
+++ b/compositor_pipeline/src/error.rs
@@ -174,7 +174,7 @@ impl From<RegisterRendererError> for PipelineError {
     fn from(err: RegisterRendererError) -> Self {
         match err {
             RegisterRendererError::RendererRegistry(err) => match err {
-                RegisterError::KeyTaken(_, _) => {
+                RegisterError::KeyTaken { .. } => {
                     PipelineError::new(ENTITY_ALREADY_REGISTERED, err, ErrorType::UserError)
                 }
             },

--- a/compositor_pipeline/src/error.rs
+++ b/compositor_pipeline/src/error.rs
@@ -1,46 +1,40 @@
 use compositor_common::scene::{InputId, OutputId};
-use compositor_render::renderer::{
-    scene::SceneUpdateError, RendererInitError, RendererRegisterError,
+use compositor_render::{
+    error::{InitRendererEngineError, RegisterRendererError},
+    registry::RegisterError,
+    renderer::{scene::UpdateSceneError, WgpuError},
 };
-
-const INPUT_STREAM_ALREADY_REGISTERED: &str = "INPUT_STREAM_ALREADY_REGISTERED";
-
-const OUTPUT_STREAM_ALREADY_REGISTERED: &str = "OUTPUT_STREAM_ALREADY_REGISTERED";
-
-const INPUT_STREAM_STILL_IN_USE: &str = "INPUT_STREAM_STILL_IN_USE";
-const INPUT_STREAM_NOT_FOUND: &str = "INPUT_STREAM_NOT_FOUND";
-
-const OUTPUT_STREAM_STILL_IN_USE: &str = "OUTPUT_STREAM_STILL_IN_USE";
-const OUTPUT_STREAM_NOT_FOUND: &str = "OUTPUT_STREAM_NOT_FOUND";
 
 #[derive(Debug, thiserror::Error)]
 pub enum RegisterInputError {
-    #[error("Failed to register input stream. Stream with id \"{0}\" is already registered.")]
+    #[error("Failed to register input stream. Stream \"{0}\" is already registered.")]
     AlreadyRegistered(InputId),
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum RegisterOutputError {
-    #[error("Failed to register output stream. Stream with id \"{0}\" is already registered.")]
+    #[error("Failed to register output stream. Stream \"{0}\" is already registered.")]
     AlreadyRegistered(OutputId),
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum UnregisterInputError {
-    #[error("Failed to unregister input stream. Stream with id \"{0}\" does not exist.")]
+    #[error("Failed to unregister input stream. Stream \"{0}\" does not exist.")]
     NotFound(InputId),
 
-    #[error("Failed to unregister input stream. Stream with id \"{0}\" is still used in the current scene.")]
+    #[error(
+        "Failed to unregister input stream. Stream \"{0}\" is still used in the current scene."
+    )]
     StillInUse(InputId),
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum UnregisterOutputError {
-    #[error("Failed to unregister output stream. Stream with id \"{0}\" does not exist.")]
+    #[error("Failed to unregister output stream. Stream \"{0}\" does not exist.")]
     NotFound(OutputId),
 
     #[error(
-        "Failed to unregister output stream. Stream with id \"{0}\" is still used in the current scene."
+        "Failed to unregister output stream. Stream \"{0}\" is still used in the current scene."
     )]
     StillInUse(OutputId),
 }
@@ -67,6 +61,8 @@ impl PipelineError {
     }
 }
 
+const INPUT_STREAM_ALREADY_REGISTERED: &str = "INPUT_STREAM_ALREADY_REGISTERED";
+
 impl From<RegisterInputError> for PipelineError {
     fn from(err: RegisterInputError) -> Self {
         match err {
@@ -77,6 +73,8 @@ impl From<RegisterInputError> for PipelineError {
     }
 }
 
+const OUTPUT_STREAM_ALREADY_REGISTERED: &str = "OUTPUT_STREAM_ALREADY_REGISTERED";
+
 impl From<RegisterOutputError> for PipelineError {
     fn from(err: RegisterOutputError) -> Self {
         match err {
@@ -86,6 +84,9 @@ impl From<RegisterOutputError> for PipelineError {
         }
     }
 }
+
+const INPUT_STREAM_STILL_IN_USE: &str = "INPUT_STREAM_STILL_IN_USE";
+const INPUT_STREAM_NOT_FOUND: &str = "INPUT_STREAM_NOT_FOUND";
 
 impl From<UnregisterInputError> for PipelineError {
     fn from(err: UnregisterInputError) -> Self {
@@ -100,6 +101,9 @@ impl From<UnregisterInputError> for PipelineError {
     }
 }
 
+const OUTPUT_STREAM_STILL_IN_USE: &str = "OUTPUT_STREAM_STILL_IN_USE";
+const OUTPUT_STREAM_NOT_FOUND: &str = "OUTPUT_STREAM_NOT_FOUND";
+
 impl From<UnregisterOutputError> for PipelineError {
     fn from(err: UnregisterOutputError) -> Self {
         match err {
@@ -113,34 +117,94 @@ impl From<UnregisterOutputError> for PipelineError {
     }
 }
 
-// placeholders for now
+const FAILED_TO_CREATE_NODE: &str = "FAILED_TO_CREATE_NODE";
+const SCENE_SPEC_VALIDATION_ERROR: &str = "SCENE_SPEC_VALIDATION_ERROR";
+const MISSING_NODE_WITH_ID: &str = "MISSING_NODE_WITH_ID";
+const UNKNOWN_RESOLUTION_ON_OUTPUT_NODE: &str = "UNKNOWN_RESOLUTION_ON_OUTPUT_NODE";
 
-impl From<RendererInitError> for PipelineError {
-    fn from(err: RendererInitError) -> Self {
-        PipelineError {
-            error_code: "UNKNOWN_INIT_ERROR",
-            error_type: ErrorType::ServerError,
-            message: err.to_string(),
+impl From<UpdateSceneError> for PipelineError {
+    fn from(err: UpdateSceneError) -> Self {
+        match err {
+            UpdateSceneError::CreateNodeError(_, _) => {
+                PipelineError::new(FAILED_TO_CREATE_NODE, err, ErrorType::UserError)
+            }
+            UpdateSceneError::InvalidSpec(_) => {
+                PipelineError::new(SCENE_SPEC_VALIDATION_ERROR, err, ErrorType::UserError)
+            }
+            UpdateSceneError::NoNodeWithIdError(_) => {
+                // ServerError because it should be validated is spec validation
+                PipelineError::new(MISSING_NODE_WITH_ID, err, ErrorType::ServerError)
+            }
+            UpdateSceneError::WgpuError(err) => err.into(),
+            UpdateSceneError::UnknownResolutionOnOutput(_) => PipelineError::new(
+                UNKNOWN_RESOLUTION_ON_OUTPUT_NODE,
+                err,
+                ErrorType::ServerError,
+            ),
         }
     }
 }
 
-impl From<SceneUpdateError> for PipelineError {
-    fn from(err: SceneUpdateError) -> Self {
-        PipelineError {
-            error_code: "UNKNOWN_SCENE_UPDATE_ERROR",
-            error_type: ErrorType::ServerError,
-            message: format!("{:?}", err),
+const WGPU_INIT_ERROR: &str = "WGPU_INIT_ERROR";
+const WEB_RENDERER_INIT_ERROR: &str = "WEB_RENDERER_INIT_ERROR";
+const BUILTIN_INIT_ERROR: &str = "BUILTIN_INIT_ERROR";
+
+impl From<InitRendererEngineError> for PipelineError {
+    fn from(err: InitRendererEngineError) -> Self {
+        match err {
+            InitRendererEngineError::FailedToInitWgpuCtx(_) => {
+                PipelineError::new(WGPU_INIT_ERROR, err, ErrorType::ServerError)
+            }
+            InitRendererEngineError::FailedToInitChromiumCtx(_) => {
+                PipelineError::new(WEB_RENDERER_INIT_ERROR, err, ErrorType::ServerError)
+            }
+            InitRendererEngineError::BuiltInTransformationsInitError(_) => {
+                PipelineError::new(BUILTIN_INIT_ERROR, err, ErrorType::ServerError)
+            }
         }
     }
 }
 
-impl From<RendererRegisterError> for PipelineError {
-    fn from(err: RendererRegisterError) -> Self {
-        PipelineError {
-            error_code: "UNKNOWN_RENDERER_REGISTER_ERROR",
-            error_type: ErrorType::ServerError,
-            message: err.to_string(),
+const ENTITY_ALREADY_REGISTERED: &str = "ENTITY_ALREADY_REGISTERED";
+const INVALID_SHADER: &str = "INVALID_SHADER";
+const REGISTER_WEB_RENDERER_INSTANCE_ERROR: &str = "REGISTER_WEB_RENDERER_INSTANCE_ERROR";
+const REGISTER_IMAGE_ERROR: &str = "REGISTER_IMAGE_ERROR";
+
+impl From<RegisterRendererError> for PipelineError {
+    fn from(err: RegisterRendererError) -> Self {
+        match err {
+            RegisterRendererError::RendererRegistry(err) => match err {
+                RegisterError::KeyTaken(_, _) => {
+                    PipelineError::new(ENTITY_ALREADY_REGISTERED, err, ErrorType::UserError)
+                }
+            },
+            RegisterRendererError::Shader(_) => {
+                PipelineError::new(INVALID_SHADER, err, ErrorType::UserError)
+            }
+            RegisterRendererError::WebRendererInstance(_) => PipelineError::new(
+                REGISTER_WEB_RENDERER_INSTANCE_ERROR,
+                err,
+                ErrorType::ServerError,
+            ),
+            RegisterRendererError::Image(_) => {
+                PipelineError::new(REGISTER_IMAGE_ERROR, err, ErrorType::UserError)
+            }
+        }
+    }
+}
+
+const WGPU_VALIDATION_ERROR: &str = "WGPU_VALIDATION_ERROR";
+const WGPU_OUT_OF_MEMORY_ERROR: &str = "WGPU_OUT_OF_MEMORY_ERROR";
+
+impl From<WgpuError> for PipelineError {
+    fn from(err: WgpuError) -> Self {
+        match err {
+            WgpuError::Validation(_) => {
+                PipelineError::new(WGPU_VALIDATION_ERROR, err, ErrorType::UserError)
+            }
+            WgpuError::OutOfMemory(_) => {
+                PipelineError::new(WGPU_OUT_OF_MEMORY_ERROR, err, ErrorType::ServerError)
+            }
         }
     }
 }

--- a/compositor_render/examples/silly/silly.wgsl
+++ b/compositor_render/examples/silly/silly.wgsl
@@ -1,6 +1,7 @@
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) tex_coords: vec2<f32>,
+    @location(2) video_id: i32,
 }
 
 struct VertexOutput {
@@ -18,16 +19,16 @@ fn vs_main(input: VertexInput) -> VertexOutput {
     return output;
 }
 
-struct CommonParams {
+struct CommonShaderParameters {
     time: f32,
     textures_count: u32,
-    output_texture_size: vec2<u32>,
+    output_resolution: vec2<u32>,
 }
 
 @group(0) @binding(0) var textures: binding_array<texture_2d<f32>, 16>;
 @group(2) @binding(0) var sampler_: sampler;
 
-var<push_constant> common_params: CommonParams;
+var<push_constant> common_params: CommonShaderParameters;
 
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {

--- a/compositor_render/examples/silly/silly.wgsl
+++ b/compositor_render/examples/silly/silly.wgsl
@@ -1,7 +1,7 @@
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) tex_coords: vec2<f32>,
-    @location(2) video_id: i32,
+    @location(2) texture_id: i32,
 }
 
 struct VertexOutput {

--- a/compositor_render/src/error.rs
+++ b/compositor_render/src/error.rs
@@ -1,0 +1,43 @@
+use crate::{
+    registry,
+    renderer::{CreateWgpuCtxError, WgpuError},
+    transformations::{
+        builtin::transformations::InitBuiltinError,
+        image_renderer::ImageError,
+        shader::CreateShaderError,
+        web_renderer::{chromium::WebRendererContextError, CreateWebRendererError},
+    },
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum InitRendererEngineError {
+    #[error("Failed to initialize a wgpu context. {0}")]
+    FailedToInitWgpuCtx(#[from] CreateWgpuCtxError),
+
+    #[error("Failed to initialize chromium context. {0}")]
+    FailedToInitChromiumCtx(#[from] WebRendererContextError),
+
+    #[error(transparent)]
+    BuiltInTransformationsInitError(#[from] InitBuiltinError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RegisterRendererError {
+    #[error(transparent)]
+    RendererRegistry(#[from] registry::RegisterError),
+
+    #[error(transparent)]
+    Shader(#[from] CreateShaderError),
+
+    #[error("Failed to create web renderer instance. {0}")]
+    WebRendererInstance(#[from] CreateWebRendererError),
+
+    #[error("Failed to prepare image.")]
+    Image(#[from] ImageError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RenderSceneError {
+    #[error(transparent)]
+    WgpuError(#[from] WgpuError),
+}

--- a/compositor_render/src/lib.rs
+++ b/compositor_render/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod event_loop;
 pub mod frame_set;
 pub mod registry;

--- a/compositor_render/src/registry.rs
+++ b/compositor_render/src/registry.rs
@@ -3,14 +3,8 @@ use std::{collections::HashMap, sync::Arc};
 use compositor_common::renderer_spec::RendererId;
 
 #[derive(Debug, thiserror::Error)]
-pub enum GetError {
-    #[error("a {0} with a key {1} could not be found")]
-    KeyNotFound(&'static str, Arc<str>),
-}
-
-#[derive(Debug, thiserror::Error)]
 pub enum RegisterError {
-    #[error("a {0} with a key {1} is already registered")]
+    #[error("Failed to register a {0}, The \"{1}\" {0} was already registered.")]
     KeyTaken(&'static str, Arc<str>),
 }
 
@@ -23,7 +17,7 @@ pub enum RegistryType {
 impl RegistryType {
     fn registry_item_name(&self) -> &'static str {
         match self {
-            RegistryType::Shader => "shader transformation",
+            RegistryType::Shader => "shader",
             RegistryType::WebRenderer => "web renderer instance",
             RegistryType::Image => "image",
         }
@@ -43,15 +37,8 @@ impl<T: Clone> RendererRegistry<T> {
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn get(&self, key: &RendererId) -> Result<T, GetError> {
-        match self.registry.get(key) {
-            Some(val) => Ok(val.clone()),
-            None => Err(GetError::KeyNotFound(
-                self.registry_type.registry_item_name(),
-                key.0.clone(),
-            )),
-        }
+    pub(crate) fn get(&self, key: &RendererId) -> Option<T> {
+        self.registry.get(key).map(Clone::clone)
     }
 
     pub(crate) fn register(&mut self, id: RendererId, renderer: T) -> Result<(), RegisterError> {

--- a/compositor_render/src/render_loop.rs
+++ b/compositor_render/src/render_loop.rs
@@ -13,7 +13,7 @@ use log::error;
 use crate::{
     frame_set::FrameSet,
     renderer::{
-        scene::{Node, Scene, SceneError, SceneNodesSet},
+        scene::{InternalSceneError, Node, Scene, SceneNodesSet},
         RenderCtx,
     },
 };
@@ -22,7 +22,7 @@ pub(super) fn populate_inputs(
     ctx: &RenderCtx,
     scene: &mut Scene,
     frame_set: &mut FrameSet<InputId>,
-) -> Result<(), SceneError> {
+) -> Result<(), InternalSceneError> {
     for (input_id, input_textures) in &mut scene.inputs {
         let Some(frame) = frame_set.frames.remove(input_id) else {
             input_textures.clear();
@@ -60,7 +60,7 @@ pub(super) fn read_outputs(
     ctx: &RenderCtx,
     scene: &mut Scene,
     pts: Duration,
-) -> Result<HashMap<OutputId, Frame>, SceneError> {
+) -> Result<HashMap<OutputId, Frame>, InternalSceneError> {
     let mut pending_downloads = Vec::with_capacity(scene.outputs.len());
     for (output_id, (node_id, output_texture)) in &scene.outputs {
         let node = scene.nodes.node_or_fallback(node_id)?;
@@ -125,7 +125,7 @@ pub(super) fn run_transforms(
     ctx: &mut RenderCtx,
     scene: &mut Scene,
     pts: Duration,
-) -> Result<(), SceneError> {
+) -> Result<(), InternalSceneError> {
     let mut already_rendered = HashSet::new();
     for (node_id, _) in scene.outputs.values() {
         render_node(ctx, &mut scene.nodes, pts, node_id, &mut already_rendered)?;
@@ -139,7 +139,7 @@ pub(super) fn render_node(
     pts: Duration,
     node_id: &NodeId,
     already_rendered: &mut HashSet<NodeId>,
-) -> Result<(), SceneError> {
+) -> Result<(), InternalSceneError> {
     if already_rendered.contains(node_id) {
         return Ok(());
     }

--- a/compositor_render/src/renderer/node.rs
+++ b/compositor_render/src/renderer/node.rs
@@ -1,0 +1,15 @@
+use compositor_common::renderer_spec::RendererId;
+
+// TODO: move here Node and RenderNode types
+
+#[derive(Debug, thiserror::Error)]
+pub enum CreateNodeError {
+    #[error("Shader \"{0}\" does not exist. You have to register it first before using it in the scene definition.")]
+    ShaderNotFound(RendererId),
+
+    #[error("Instance of web renderer \"{0}\" does not exist. You have to register it first before using it in the scene definition.")]
+    WebRendererNotFound(RendererId),
+
+    #[error("Image \"{0}\" does not exist. You have to register it first before using it in the scene definition.")]
+    ImageNotFound(RendererId),
+}

--- a/compositor_render/src/renderer/renderers.rs
+++ b/compositor_render/src/renderer/renderers.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use crate::{
     registry::{RegistryType, RendererRegistry},
     transformations::{
-        builtin::transformations::BuiltinTransformations,
+        builtin::transformations::{BuiltinTransformations, InitBuiltinError},
         image_renderer::Image,
-        shader::{Shader, ShaderNewError},
+        shader::Shader,
         web_renderer::WebRenderer,
     },
 };
@@ -20,7 +20,7 @@ pub(crate) struct Renderers {
 }
 
 impl Renderers {
-    pub(crate) fn new(wgpu_ctx: Arc<WgpuCtx>) -> Result<Self, ShaderNewError> {
+    pub(crate) fn new(wgpu_ctx: Arc<WgpuCtx>) -> Result<Self, InitBuiltinError> {
         Ok(Self {
             shaders: RendererRegistry::new(RegistryType::Shader),
             web_renderers: RendererRegistry::new(RegistryType::WebRenderer),

--- a/compositor_render/src/renderer/scene.rs
+++ b/compositor_render/src/renderer/scene.rs
@@ -358,6 +358,6 @@ impl SceneNodesSet {
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum InternalSceneError {
-    #[error("Missing node {0}")]
+    #[error("Missing node \"{0}\"")]
     MissingNode(NodeId),
 }

--- a/compositor_render/src/renderer/scene.rs
+++ b/compositor_render/src/renderer/scene.rs
@@ -7,7 +7,6 @@ use compositor_common::{
 use log::error;
 
 use crate::{
-    registry::GetError,
     render_loop::NodeRenderPass,
     transformations::{
         builtin::transformations::BuiltinTransformations, image_renderer::ImageNode,
@@ -16,6 +15,7 @@ use crate::{
 };
 
 use super::{
+    node::CreateNodeError,
     texture::{InputTexture, NodeTexture, OutputTexture},
     RenderCtx, WgpuError, WgpuErrorScope,
 };
@@ -30,33 +30,48 @@ pub enum RenderNode {
 }
 
 impl RenderNode {
-    fn new(ctx: &RenderCtx, spec: &NodeParams) -> Result<Self, GetError> {
-        match spec {
+    fn new(ctx: &RenderCtx, spec: &NodeSpec) -> Result<Self, CreateNodeError> {
+        match &spec.params {
             NodeParams::WebRenderer { instance_id } => {
-                let renderer = ctx.renderers.web_renderers.get(instance_id)?;
+                let renderer = ctx
+                    .renderers
+                    .web_renderers
+                    .get(instance_id)
+                    .ok_or_else(|| CreateNodeError::WebRendererNotFound(instance_id.clone()))?;
                 Ok(Self::Web { renderer })
             }
             NodeParams::Shader {
                 shader_id,
                 shader_params,
                 resolution,
-            } => Ok(Self::Shader(ShaderNode::new(
-                ctx.wgpu_ctx,
-                ctx.renderers.shaders.get(shader_id)?,
-                shader_params.as_ref(),
-                None,
-                *resolution,
-            ))),
+            } => {
+                let shader = ctx
+                    .renderers
+                    .shaders
+                    .get(shader_id)
+                    .ok_or_else(|| CreateNodeError::ShaderNotFound(shader_id.clone()))?;
+                let node = ShaderNode::new(
+                    ctx.wgpu_ctx,
+                    shader,
+                    shader_params.as_ref(),
+                    None,
+                    *resolution,
+                );
+                Ok(Self::Shader(node))
+            }
             NodeParams::Builtin {
                 transformation,
                 resolution,
-            } => Ok(Self::Builtin(ShaderNode::new(
-                ctx.wgpu_ctx,
-                ctx.renderers.builtin.shader(transformation),
-                BuiltinTransformations::params(transformation, resolution).as_ref(),
-                BuiltinTransformations::clear_color(transformation),
-                *resolution,
-            ))),
+            } => {
+                let node = ShaderNode::new(
+                    ctx.wgpu_ctx,
+                    ctx.renderers.builtin.shader(transformation),
+                    BuiltinTransformations::params(transformation, resolution).as_ref(),
+                    BuiltinTransformations::clear_color(transformation),
+                    *resolution,
+                );
+                Ok(Self::Builtin(node))
+            }
             NodeParams::TextRenderer {
                 text_params,
                 resolution,
@@ -65,7 +80,12 @@ impl RenderNode {
                 Ok(Self::Text(renderer))
             }
             NodeParams::Image { image_id } => {
-                let node = ImageNode::new(ctx.renderers.images.get(image_id)?);
+                let image = ctx
+                    .renderers
+                    .images
+                    .get(image_id)
+                    .ok_or_else(|| CreateNodeError::ImageNotFound(image_id.clone()))?;
+                let node = ImageNode::new(image);
                 Ok(Self::Image(node))
             }
         }
@@ -116,8 +136,8 @@ pub struct Node {
 }
 
 impl Node {
-    pub fn new(ctx: &RenderCtx, spec: &NodeSpec) -> Result<Self, GetError> {
-        let node = RenderNode::new(ctx, &spec.params)?;
+    pub fn new(ctx: &RenderCtx, spec: &NodeSpec) -> Result<Self, CreateNodeError> {
+        let node = RenderNode::new(ctx, spec)?;
         let mut output = NodeTexture::new();
         if let Some(resolution) = node.resolution() {
             output.ensure_size(ctx.wgpu_ctx, resolution);
@@ -131,16 +151,16 @@ impl Node {
         })
     }
 
-    pub fn new_input(node_id: &NodeId) -> Result<Self, GetError> {
+    pub fn new_input(node_id: &NodeId) -> Self {
         let output = NodeTexture::new();
 
-        Ok(Self {
+        Self {
             node_id: node_id.clone(),
             renderer: RenderNode::InputStream,
             inputs: vec![],
             fallback: None,
             output,
-        })
+        }
     }
 }
 
@@ -151,23 +171,20 @@ pub struct Scene {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum SceneUpdateError {
-    #[error("Failed to construct render node")]
-    RenderNodeError(#[source] GetError),
+pub enum UpdateSceneError {
+    #[error("Failed to create node \"{1}\". {0}")]
+    CreateNodeError(#[source] CreateNodeError, NodeId),
 
-    #[error("Failed to construct input node")]
-    InputNodeError(#[source] GetError),
-
-    #[error("No spec for node with id {0}")]
-    NoNodeWithIdError(NodeId),
-
-    #[error("Scene definition is invalid")]
+    #[error("Invalid scene: {0}")]
     InvalidSpec(#[from] SpecValidationError),
 
-    #[error("Wgpu error")]
+    #[error("Unknown node \"{0}\" used in scene.")]
+    NoNodeWithIdError(NodeId),
+
+    #[error(transparent)]
     WgpuError(#[from] WgpuError),
 
-    #[error("Unknown resolution in the output node")]
+    #[error("Unknown resolution on the output node. Nodes that are declared as outputs need to have constant resolution that is the same as resolution of the output stream.")]
     UnknownResolutionOnOutput(NodeId),
 }
 
@@ -180,7 +197,7 @@ impl Scene {
         }
     }
 
-    pub fn update(&mut self, ctx: &RenderCtx, spec: &SceneSpec) -> Result<(), SceneUpdateError> {
+    pub fn update(&mut self, ctx: &RenderCtx, spec: &SceneSpec) -> Result<(), UpdateSceneError> {
         // TODO: If we want nodes to be stateful we could try reusing nodes instead
         //       of recreating them on every scene update
         let scope = WgpuErrorScope::push(&ctx.wgpu_ctx.device);
@@ -194,9 +211,9 @@ impl Scene {
                 Self::ensure_node(ctx, &output.input_pad, spec, &mut inputs, &mut new_nodes)?;
                 let node = new_nodes
                     .get(&output.input_pad)
-                    .ok_or_else(|| SceneUpdateError::NoNodeWithIdError(output.input_pad.clone()))?;
+                    .ok_or_else(|| UpdateSceneError::NoNodeWithIdError(output.input_pad.clone()))?;
                 let resolution = node.renderer.resolution().ok_or_else(|| {
-                    SceneUpdateError::UnknownResolutionOnOutput(node.node_id.clone())
+                    UpdateSceneError::UnknownResolutionOnOutput(node.node_id.clone())
                 })?;
                 let output_texture = OutputTexture::new(ctx.wgpu_ctx, resolution);
                 Ok((
@@ -204,7 +221,7 @@ impl Scene {
                     (node.node_id.clone(), output_texture),
                 ))
             })
-            .collect::<Result<_, SceneUpdateError>>()?;
+            .collect::<Result<_, UpdateSceneError>>()?;
 
         scope.pop(&ctx.wgpu_ctx.device)?;
 
@@ -221,7 +238,7 @@ impl Scene {
         spec: &SceneSpec,
         inputs: &mut HashMap<InputId, InputTexture>,
         new_nodes: &mut HashMap<NodeId, Node>,
-    ) -> Result<(), SceneUpdateError> {
+    ) -> Result<(), UpdateSceneError> {
         // check if node already exists
         if new_nodes.get(node_id).is_some() {
             return Ok(());
@@ -237,7 +254,8 @@ impl Scene {
                 if let Some(fallback_id) = &node_spec.fallback_id {
                     Self::ensure_node(ctx, fallback_id, spec, inputs, new_nodes)?;
                 }
-                let node = Node::new(ctx, node_spec).map_err(SceneUpdateError::RenderNodeError)?;
+                let node = Node::new(ctx, node_spec)
+                    .map_err(|err| UpdateSceneError::CreateNodeError(err, node_id.clone()))?;
                 new_nodes.insert(node_id.clone(), node);
                 return Ok(());
             }
@@ -245,7 +263,7 @@ impl Scene {
 
         // If there is no node with id node_id, assume it's an input. Pipeline validation should
         // make sure that scene does not refer to missing entities.
-        let node = Node::new_input(node_id).map_err(SceneUpdateError::InputNodeError)?;
+        let node = Node::new_input(node_id);
         new_nodes.insert(node_id.clone(), node);
         inputs.insert(InputId(node_id.clone()), InputTexture::new());
         Ok(())
@@ -264,19 +282,22 @@ impl SceneNodesSet {
         }
     }
 
-    pub fn node(&self, node_id: &NodeId) -> Result<&Node, SceneError> {
+    pub fn node(&self, node_id: &NodeId) -> Result<&Node, InternalSceneError> {
         self.nodes
             .get(node_id)
-            .ok_or_else(|| SceneError::MissingNode(node_id.clone()))
+            .ok_or_else(|| InternalSceneError::MissingNode(node_id.clone()))
     }
 
-    pub fn node_mut(&mut self, node_id: &NodeId) -> Result<&mut Node, SceneError> {
+    pub fn node_mut(&mut self, node_id: &NodeId) -> Result<&mut Node, InternalSceneError> {
         self.nodes
             .get_mut(node_id)
-            .ok_or_else(|| SceneError::MissingNode(node_id.clone()))
+            .ok_or_else(|| InternalSceneError::MissingNode(node_id.clone()))
     }
 
-    pub fn node_or_fallback<'a>(&'a self, node_id: &NodeId) -> Result<&'a Node, SceneError> {
+    pub fn node_or_fallback<'a>(
+        &'a self,
+        node_id: &NodeId,
+    ) -> Result<&'a Node, InternalSceneError> {
         let nodes: HashMap<&NodeId, &Node> = self.nodes.iter().collect();
         Self::find_fallback_node(&nodes, node_id)
     }
@@ -285,7 +306,7 @@ impl SceneNodesSet {
     pub(crate) fn node_render_pass<'a>(
         &'a mut self,
         node_id: &NodeId,
-    ) -> Result<NodeRenderPass<'a>, SceneError> {
+    ) -> Result<NodeRenderPass<'a>, InternalSceneError> {
         let input_ids: Vec<NodeId> = self.node(node_id)?.inputs.to_vec();
 
         // Borrow all the references, Fallback technically can be applied on every
@@ -295,7 +316,7 @@ impl SceneNodesSet {
         // Extract mutable borrow for the node we will render.
         let node = nodes_mut
             .remove(&node_id)
-            .ok_or_else(|| SceneError::MissingNode(node_id.clone()))?;
+            .ok_or_else(|| InternalSceneError::MissingNode(node_id.clone()))?;
 
         // Convert mutable borrows on rest of the nodes into immutable.
         // One input might be used multiple times, so we might need to
@@ -314,29 +335,29 @@ impl SceneNodesSet {
                 // input_id and node.node_id are different if fallback is triggered
                 Ok((input_id, node))
             })
-            .collect::<Result<Vec<_>, SceneError>>()?;
+            .collect::<Result<Vec<_>, InternalSceneError>>()?;
         Ok(NodeRenderPass { node, inputs })
     }
 
     fn find_fallback_node<'a>(
         nodes: &HashMap<&NodeId, &'a Node>,
         node_id: &NodeId,
-    ) -> Result<&'a Node, SceneError> {
+    ) -> Result<&'a Node, InternalSceneError> {
         let mut node: &Node = nodes
             .get(node_id)
-            .ok_or_else(|| SceneError::MissingNode(node_id.clone()))?;
+            .ok_or_else(|| InternalSceneError::MissingNode(node_id.clone()))?;
         while node.output.is_empty() && node.fallback.is_some() {
             let fallback_id = node.fallback.clone().unwrap();
             node = nodes
                 .get(&fallback_id)
-                .ok_or_else(|| SceneError::MissingNode(fallback_id.clone()))?
+                .ok_or_else(|| InternalSceneError::MissingNode(fallback_id.clone()))?
         }
         Ok(node)
     }
 }
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
-pub enum SceneError {
-    #[error("Missing node with id {0}")]
+pub enum InternalSceneError {
+    #[error("Missing node {0}")]
     MissingNode(NodeId),
 }

--- a/compositor_render/src/sync_renderer.rs
+++ b/compositor_render/src/sync_renderer.rs
@@ -6,12 +6,10 @@ use compositor_common::{
 };
 
 use crate::{
+    error::{InitRendererEngineError, RegisterRendererError, RenderSceneError},
     event_loop::EventLoop,
     frame_set::FrameSet,
-    renderer::{
-        scene::SceneUpdateError, RenderError, Renderer, RendererInitError, RendererOptions,
-        RendererRegisterError,
-    },
+    renderer::{scene::UpdateSceneError, Renderer, RendererOptions},
     transformations::{image_renderer::Image, shader::Shader, web_renderer::WebRenderer},
 };
 
@@ -19,14 +17,14 @@ use crate::{
 pub struct SyncRenderer(Arc<Mutex<Renderer>>);
 
 impl SyncRenderer {
-    pub fn new(opts: RendererOptions) -> Result<(Self, EventLoop), RendererInitError> {
+    pub fn new(opts: RendererOptions) -> Result<(Self, EventLoop), InitRendererEngineError> {
         let renderer = Renderer::new(opts)?;
         let event_loop = EventLoop::new(renderer.chromium_context.cef_context());
 
         Ok((Self(Arc::new(Mutex::new(renderer))), event_loop))
     }
 
-    pub fn register_renderer(&self, spec: RendererSpec) -> Result<(), RendererRegisterError> {
+    pub fn register_renderer(&self, spec: RendererSpec) -> Result<(), RegisterRendererError> {
         let ctx = self.0.lock().unwrap().register_ctx();
         let mut guard = self.0.lock().unwrap();
         match spec {
@@ -50,11 +48,11 @@ impl SyncRenderer {
         }
     }
 
-    pub fn render(&self, input: FrameSet<InputId>) -> Result<FrameSet<OutputId>, RenderError> {
+    pub fn render(&self, input: FrameSet<InputId>) -> Result<FrameSet<OutputId>, RenderSceneError> {
         self.0.lock().unwrap().render(input)
     }
 
-    pub fn update_scene(&mut self, scene_specs: Arc<SceneSpec>) -> Result<(), SceneUpdateError> {
+    pub fn update_scene(&mut self, scene_specs: Arc<SceneSpec>) -> Result<(), UpdateSceneError> {
         self.0.lock().unwrap().update_scene(scene_specs)
     }
 

--- a/compositor_render/src/transformations/builtin/fixed_position_layout.wgsl
+++ b/compositor_render/src/transformations/builtin/fixed_position_layout.wgsl
@@ -1,13 +1,13 @@
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) tex_coords: vec2<f32>,
-    @location(2) video_id: i32,
+    @location(2) texture_id: i32,
 }
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) tex_coords: vec2<f32>,
-    @location(1) @interpolate(flat) video_id: i32,
+    @location(1) @interpolate(flat) texture_id: i32,
 }
 
 struct CommonShaderParameters {
@@ -47,15 +47,15 @@ fn scale_matrix(x_scale: f32, y_scale: f32) -> mat3x3<f32> {
 @vertex
 fn vs_main(input: VertexInput) -> VertexOutput {
     var output: VertexOutput;
-    if input.video_id == -1 {
+    if input.texture_id == -1 {
         output.position = vec4<f32>(input.position, 1.0);
         output.tex_coords = input.tex_coords;
-        output.video_id = 0;
+        output.texture_id = 0;
         return output;
     }
 
-    let input_texture_size: vec2<u32> = textureDimensions(textures[input.video_id]);
-    let texture_layout: TextureLayout = layouts[input.video_id];
+    let input_texture_size: vec2<u32> = textureDimensions(textures[input.texture_id]);
+    let texture_layout: TextureLayout = layouts[input.texture_id];
     let output_width: f32 = f32(common_params.output_resolution.x);
     let output_height: f32 = f32(common_params.output_resolution.y);
 
@@ -80,14 +80,14 @@ fn vs_main(input: VertexInput) -> VertexOutput {
 
     output.position = vec4<f32>(output_position_pixels.x * 2.0 / output_width, output_position_pixels.y * 2.0 / output_height, 0.0, 1.0);
     output.tex_coords = input.tex_coords;
-    output.video_id = input.video_id;
+    output.texture_id = input.texture_id;
 
     return output;
 }
 
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-    let sample = textureSample(textures[input.video_id], sampler_, input.tex_coords);
+    let sample = textureSample(textures[input.texture_id], sampler_, input.tex_coords);
     
     if common_params.textures_count == 0u {
         return vec4<f32>(0.0, 0.0, 0.0, 0.0);

--- a/compositor_render/src/transformations/builtin/fixed_position_layout.wgsl
+++ b/compositor_render/src/transformations/builtin/fixed_position_layout.wgsl
@@ -1,13 +1,13 @@
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) tex_coords: vec2<f32>,
-    @location(2) texture_id: i32,
+    @location(2) video_id: i32,
 }
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) tex_coords: vec2<f32>,
-    @location(1) @interpolate(flat) texture_id: i32,
+    @location(1) @interpolate(flat) video_id: i32,
 }
 
 struct CommonShaderParameters {
@@ -47,15 +47,15 @@ fn scale_matrix(x_scale: f32, y_scale: f32) -> mat3x3<f32> {
 @vertex
 fn vs_main(input: VertexInput) -> VertexOutput {
     var output: VertexOutput;
-    if input.texture_id == -1 {
+    if input.video_id == -1 {
         output.position = vec4<f32>(input.position, 1.0);
         output.tex_coords = input.tex_coords;
-        output.texture_id = 0;
+        output.video_id = 0;
         return output;
     }
 
-    let input_texture_size: vec2<u32> = textureDimensions(textures[input.texture_id]);
-    let texture_layout: TextureLayout = layouts[input.texture_id];
+    let input_texture_size: vec2<u32> = textureDimensions(textures[input.video_id]);
+    let texture_layout: TextureLayout = layouts[input.video_id];
     let output_width: f32 = f32(common_params.output_resolution.x);
     let output_height: f32 = f32(common_params.output_resolution.y);
 
@@ -80,14 +80,14 @@ fn vs_main(input: VertexInput) -> VertexOutput {
 
     output.position = vec4<f32>(output_position_pixels.x * 2.0 / output_width, output_position_pixels.y * 2.0 / output_height, 0.0, 1.0);
     output.tex_coords = input.tex_coords;
-    output.texture_id = input.texture_id;
+    output.video_id = input.video_id;
 
     return output;
 }
 
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-    let sample = textureSample(textures[input.texture_id], sampler_, input.tex_coords);
+    let sample = textureSample(textures[input.video_id], sampler_, input.tex_coords);
     
     if common_params.textures_count == 0u {
         return vec4<f32>(0.0, 0.0, 0.0, 0.0);

--- a/compositor_render/src/transformations/builtin/transform_to_resolution/fill.wgsl
+++ b/compositor_render/src/transformations/builtin/transform_to_resolution/fill.wgsl
@@ -1,13 +1,13 @@
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) tex_coords: vec2<f32>,
-    @location(2) video_id: i32,
+    @location(2) texture_id: i32,
 }
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) tex_coords: vec2<f32>,
-    @location(1) @interpolate(flat) video_id: i32,
+    @location(1) @interpolate(flat) texture_id: i32,
 }
 
 struct CommonShaderParameters {

--- a/compositor_render/src/transformations/builtin/transform_to_resolution/fit.wgsl
+++ b/compositor_render/src/transformations/builtin/transform_to_resolution/fit.wgsl
@@ -1,13 +1,13 @@
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) tex_coords: vec2<f32>,
-    @location(2) video_id: i32,
+    @location(2) texture_id: i32,
 }
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) tex_coords: vec2<f32>,
-    @location(1) @interpolate(flat) video_id: i32,
+    @location(1) @interpolate(flat) texture_id: i32,
 }
 
 struct CommonShaderParameters {

--- a/compositor_render/src/transformations/builtin/transform_to_resolution/stretch.wgsl
+++ b/compositor_render/src/transformations/builtin/transform_to_resolution/stretch.wgsl
@@ -1,13 +1,13 @@
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) tex_coords: vec2<f32>,
-    @location(2) video_id: i32,
+    @location(2) texture_id: i32,
 }
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) tex_coords: vec2<f32>,
-    @location(1) @interpolate(flat) video_id: i32,
+    @location(1) @interpolate(flat) texture_id: i32,
 }
 
 struct CommonShaderParameters {

--- a/compositor_render/src/transformations/builtin/transform_to_resolution/stretch.wgsl
+++ b/compositor_render/src/transformations/builtin/transform_to_resolution/stretch.wgsl
@@ -10,7 +10,7 @@ struct VertexOutput {
     @location(1) @interpolate(flat) video_id: i32,
 }
 
-struct CommonParams {
+struct CommonShaderParameters {
     time: f32,
     textures_count: u32,
     output_resolution: vec2<u32>,
@@ -19,7 +19,7 @@ struct CommonParams {
 @group(0) @binding(0) var textures: binding_array<texture_2d<f32>, 16>;
 @group(2) @binding(0) var sampler_: sampler;
 
-var<push_constant> common_params: CommonParams;
+var<push_constant> common_params: CommonShaderParameters;
 
 @vertex
 fn vs_main(input: VertexInput) -> VertexOutput {

--- a/compositor_render/src/transformations/shader.rs
+++ b/compositor_render/src/transformations/shader.rs
@@ -24,14 +24,14 @@ pub const VERTEX_ENTRYPOINT_NAME: &str = "vs_main";
 pub const FRAGMENT_ENTRYPOINT_NAME: &str = "fs_main";
 
 #[derive(Debug, thiserror::Error)]
-pub enum ShaderNewError {
-    #[error("wgpu error.")]
+pub enum CreateShaderError {
+    #[error(transparent)]
     Wgpu(#[from] WgpuError),
 
-    #[error("Shader validation error.")]
+    #[error(transparent)]
     Validation(#[from] ShaderValidationError),
 
-    #[error("Shader parse error.")]
+    #[error("Shader parse error:\n{0}")]
     ParseError(#[from] naga::front::wgsl::ParseError),
 }
 
@@ -51,7 +51,7 @@ pub struct Shader {
 }
 
 impl Shader {
-    pub fn new(wgpu_ctx: &Arc<WgpuCtx>, shader_src: String) -> Result<Self, ShaderNewError> {
+    pub fn new(wgpu_ctx: &Arc<WgpuCtx>, shader_src: String) -> Result<Self, CreateShaderError> {
         let scope = WgpuErrorScope::push(&wgpu_ctx.device);
 
         let shader = naga::front::wgsl::parse_str(&shader_src)?;

--- a/compositor_render/src/transformations/shader_header.wgsl
+++ b/compositor_render/src/transformations/shader_header.wgsl
@@ -1,7 +1,7 @@
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) tex_coords: vec2<f32>,
-    @location(2) video_id: i32,
+    @location(2) texture_id: i32,
 }
 
 struct CommonShaderParameters {

--- a/compositor_render/src/transformations/shader_header.wgsl
+++ b/compositor_render/src/transformations/shader_header.wgsl
@@ -1,14 +1,16 @@
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) tex_coords: vec2<f32>,
+    @location(2) video_id: i32,
 }
 
-struct CommonParams {
+struct CommonShaderParameters {
     time: f32,
     textures_count: u32,
+    output_resolution: vec2<u32>,
 }
 
 @group(0) @binding(0) var textures: binding_array<texture_2d<f32>, 16>;
 @group(2) @binding(0) var sampler_: sampler;
 
-var<push_constant> common_params: CommonParams;
+var<push_constant> common_params: CommonShaderParameters;

--- a/compositor_render/src/transformations/web_renderer.rs
+++ b/compositor_render/src/transformations/web_renderer.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use self::{
     browser::{BrowserClient, BrowserState},
-    chromium::ChromiumContextError,
+    chromium::WebRendererContextError,
 };
 
 mod browser;
@@ -48,7 +48,7 @@ pub struct WebRenderer {
 }
 
 impl WebRenderer {
-    pub fn new(ctx: &RegisterCtx, params: WebRendererSpec) -> Result<Self, WebRendererNewError> {
+    pub fn new(ctx: &RegisterCtx, params: WebRendererSpec) -> Result<Self, CreateWebRendererError> {
         info!("Starting web renderer for {}", &params.url);
 
         let (painted_frames_sender, painted_frames_receiver) = crossbeam_channel::bounded(1);
@@ -95,7 +95,7 @@ impl WebRenderer {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum WebRendererNewError {
+pub enum CreateWebRendererError {
     #[error("failed to create new web renderer session")]
-    CreateContextFailure(#[from] ChromiumContextError),
+    CreateContextFailure(#[from] WebRendererContextError),
 }

--- a/compositor_render/src/transformations/web_renderer/chromium.rs
+++ b/compositor_render/src/transformations/web_renderer/chromium.rs
@@ -18,7 +18,7 @@ impl ChromiumContext {
     pub(crate) fn new(
         opts: WebRendererOptions,
         framerate: Framerate,
-    ) -> Result<Self, ChromiumContextError> {
+    ) -> Result<Self, WebRendererContextError> {
         if !opts.init {
             info!("Chromium context disabled");
             return Ok(Self {
@@ -50,11 +50,11 @@ impl ChromiumContext {
         &self,
         url: &str,
         state: BrowserClient,
-    ) -> Result<cef::Browser, ChromiumContextError> {
+    ) -> Result<cef::Browser, WebRendererContextError> {
         let context = self
             .context
             .as_ref()
-            .ok_or(ChromiumContextError::NoContext)?;
+            .ok_or(WebRendererContextError::NoContext)?;
 
         let window_info = cef::WindowInfo {
             windowless_rendering_enabled: true,
@@ -113,7 +113,7 @@ impl cef::App for ChromiumApp {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum ChromiumContextError {
+pub enum WebRendererContextError {
     #[error("Chromium context failed: {0}")]
     ContextFailure(#[from] cef::ContextError),
 

--- a/examples/common/common.rs
+++ b/examples/common/common.rs
@@ -55,12 +55,33 @@ fn log_request_error<T: Serialize + ?Sized>(request_body: &T, response: Response
     let status = response.status();
     let request_str = serde_json::to_string_pretty(request_body).unwrap();
     let body_str = response.text().unwrap();
-    let formated_body = serde_json::from_str::<serde_json::Value>(&body_str)
-        .map(|parsed| serde_json::to_string_pretty(&parsed).unwrap())
-        .unwrap_or(body_str);
+
+    let formated_body = get_formated_body(&body_str);
     error!(
-        "Request failed:\nRequest: {}\nResponse code: {}\nResponse body:\n{}",
+        "Request failed:\n\nRequest: {}\n\nResponse code: {}\n\nResponse body:\n{}",
         request_str, status, formated_body
+    )
+}
+
+fn get_formated_body(body_str: &str) -> String {
+    let Ok(mut body_json) = serde_json::from_str::<serde_json::Value>(body_str) else {
+        return body_str.to_string();
+    };
+
+    let Some(msg_value) = body_json.get("msg") else {
+        return serde_json::to_string_pretty(&body_json).unwrap();
+    };
+
+    let Some(msg_string) = msg_value.as_str() else {
+        return serde_json::to_string_pretty(&body_json).unwrap();
+    };
+    let msg_string = msg_string.to_string();
+    let body_map = body_json.as_object_mut().unwrap();
+    body_map.remove("msg");
+    format!(
+        "{}\n\nError message:\n{}",
+        serde_json::to_string_pretty(&body_map).unwrap(),
+        msg_string,
     )
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -224,7 +224,7 @@ impl Api {
             if let Some((node_id, _)) = iter.find(|(_, output)| output.port == port && output.ip == ip) {
                 return Err(ApiError{
                     error_code: "PORT_AND_IP_ALREADY_IN_USE",
-                    message: format!("Failed to register output stream with id \"{output_id}\". Combination of port {port} and IP {ip} is already used by node \"{node_id}\""),
+                    message: format!("Failed to register output stream \"{output_id}\". Combination of port {port} and IP {ip} is already used by node \"{node_id}\""),
                     http_status_code: tiny_http::StatusCode(400)
                 });
             };
@@ -250,7 +250,7 @@ impl Api {
         if let Some((node_id, _)) = self.pipeline.inputs().find(|(_, input)| input.port == port) {
             return Err(ApiError{
                 error_code: "PORT_ALREADY_IN_USE",
-                message: format!("Failed to register input stream with id \"{id}\". Port {port} is already used by node \"{node_id}\""),
+                message: format!("Failed to register input stream \"{id}\". Port {port} is already used by node \"{node_id}\""),
                 http_status_code: tiny_http::StatusCode(400)
             });
         }


### PR DESCRIPTION
Changes (both introduced and proposed new patterns):

- Stop using names like RendererNewError, instead sth like InitRendererError or CrateRendererError, or if you really want to name it the same as method NewRendererError.
This is very subjective, but at least for me that word order is very confusing. If anyone disagrees I won't oppose it, but we need to decide specific naming convention. e.g. check here https://rust-lang.github.io/api-guidelines/naming.html#names-use-a-consistent-word-order-c-word-order
- This PR fixes issues introduced by a combination of PRs that added layout components and shader validation. (One PR introduced changes to shaders structure and the other still validated the old structure.
- This is not the final PR, but this already grew to much plus it's moving a lot of top level types, so wanted to merge it sooner.

The main idea behind error handling:
- Extract top-level errors to error.rs in crate
- Each error is expected to provide all necessary information and context e.g. we can't just say that expected a name x and received y. We need to identify e.g.  shader where it happened.
- In most cases error should be either transparent or repeat message of an inner error. e.g.
```
#[error("Some error x. {inner_err}")]
```
- If `#[error(msg)]` does not provide any usefull info over err.source() does then change it to transparent.