### PR TITLE
Refactor scene validation code

### DIFF
--- a/compositor_common/src/error.rs
+++ b/compositor_common/src/error.rs
@@ -1,0 +1,57 @@
+use std::{collections::HashSet, fmt::Display};
+
+use crate::scene::{NodeId, OutputId};
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SceneSpecValidationError {
+    #[error("Unknown node \"{missing_node}\" used as an input in the node \"{node}\". Node is not defined in the scene and it was not registered as an input.")]
+    UnknownInputPadOnNode { missing_node: NodeId, node: NodeId },
+    #[error("Unknown node \"{missing_node}\" is connected to the output stream \"{output}\".")]
+    UnknownInputPadOnOutput {
+        missing_node: NodeId,
+        output: OutputId,
+    },
+    #[error(
+        "Unknown output stream \"{0}\". Register it first before using it in the scene definition."
+    )]
+    UnknownOutput(NodeId),
+    #[error("Invalid node id. There is more than one node with the \"{0}\" id.")]
+    DuplicateNodeNames(NodeId),
+    #[error("Invalid node id. There is already an input stream with the \"{0}\" id.")]
+    DuplicateNodeAndInputNames(NodeId),
+    #[error("Cycles between nodes are not allowed. Node \"{0}\" depends on itself via input_pads or fallback option.")]
+    CycleDetected(NodeId),
+    #[error(transparent)]
+    UnusedNodes(#[from] UnusedNodesError),
+    #[error("Invalid params for node \"{1}\". {0}")]
+    InvalidNodeSpec(#[source] NodeSpecValidationError, NodeId),
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub struct UnusedNodesError(pub HashSet<NodeId>);
+
+impl Display for UnusedNodesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut unused_nodes: Vec<String> = self.0.iter().map(ToString::to_string).collect();
+        unused_nodes.sort();
+        write!(
+            f,
+            "There are unused nodes in the scene definition: {0}",
+            unused_nodes.join(", ")
+        )
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum NodeSpecValidationError {
+    #[error(transparent)]
+    Builtin(#[from] BuiltinSpecValidationError),
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum BuiltinSpecValidationError {
+    #[error("Transformation \"fixed_position_layout\" expects {input_count} texture layouts (the same as number of input pads), but {layout_count} layouts were provided.")]
+    FixedLayoutInvalidLayoutCount { layout_count: u32, input_count: u32 },
+    #[error("Nodes that use transformation \"transform_to_resolution\" need to have exactly one input pad.")]
+    TransformToResolutionExactlyOneInput,
+}

--- a/compositor_common/src/lib.rs
+++ b/compositor_common/src/lib.rs
@@ -2,14 +2,14 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
+pub mod error;
 pub mod frame;
 pub mod renderer_spec;
 pub mod scene;
 pub mod util;
-mod validators;
 
 pub type Frame = frame::Frame;
-pub type SpecValidationError = validators::SceneSpecValidationError;
+pub type SceneSpecValidationError = error::SceneSpecValidationError;
 
 /// TODO: This should be a rational.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]

--- a/compositor_common/src/scene.rs
+++ b/compositor_common/src/scene.rs
@@ -1,15 +1,19 @@
 use serde::{Deserialize, Serialize};
-use std::{fmt::Display, sync::Arc};
-
-use crate::renderer_spec::RendererId;
-
-use self::{
-    builtin_transformations::BuiltinSpec,
-    text_spec::{TextDimensions, TextSpec},
-};
 
 pub mod builtin_transformations;
+pub mod id;
+pub mod node;
+pub mod shader;
 pub mod text_spec;
+mod validation;
+
+#[cfg(test)]
+mod validation_test;
+
+pub use id::InputId;
+pub use id::NodeId;
+pub use id::OutputId;
+pub use node::NodeParams;
 
 pub const MAX_NODE_RESOLUTION: Resolution = Resolution {
     width: 7682,
@@ -28,54 +32,15 @@ impl Resolution {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NodeId(pub Arc<str>);
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
-pub struct InputId(pub NodeId);
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
-pub struct OutputId(pub NodeId);
-
-impl Display for InputId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0 .0.fmt(f)
-    }
-}
-
-impl Display for OutputId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0 .0.fmt(f)
-    }
-}
-
-impl Display for NodeId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl From<NodeId> for InputId {
-    fn from(value: NodeId) -> Self {
-        Self(value)
-    }
-}
-
-impl From<NodeId> for OutputId {
-    fn from(value: NodeId) -> Self {
-        Self(value)
-    }
-}
-
 /// SceneSpec represents configuration that can be used to create new Scene
 /// or update an existing one.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SceneSpec {
     pub nodes: Vec<NodeSpec>,
     pub outputs: Vec<OutputSpec>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct OutputSpec {
     pub output_id: OutputId,
     pub input_pad: NodeId,
@@ -90,7 +55,7 @@ pub struct OutputSpec {
 /// on how long the initialization is. Heavy operations should be part of renderer and
 /// light ones part of the Node. Simple rule of thumb for what is heavy/light is answer
 /// to the question: Would it still work if it's done every frame.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct NodeSpec {
     pub node_id: NodeId,
     #[serde(default)]
@@ -98,56 +63,4 @@ pub struct NodeSpec {
     pub fallback_id: Option<NodeId>,
     #[serde(flatten)]
     pub params: NodeParams,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum NodeParams {
-    WebRenderer {
-        instance_id: RendererId,
-    },
-    Shader {
-        shader_id: RendererId,
-        shader_params: Option<ShaderParam>,
-        resolution: Resolution,
-    },
-    TextRenderer {
-        #[serde(flatten)]
-        text_params: TextSpec,
-        resolution: TextDimensions,
-    },
-    Image {
-        image_id: RendererId,
-    },
-    #[serde(rename = "built-in")]
-    Builtin {
-        #[serde(flatten)]
-        transformation: BuiltinSpec,
-    },
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(tag = "type", rename_all = "snake_case", content = "value")]
-pub enum ShaderParam {
-    F32(f32),
-    U32(u32),
-    I32(i32),
-    List(Vec<ShaderParam>),
-    Struct(Vec<ShaderParamStructField>),
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ShaderParamStructField {
-    pub field_name: String,
-    #[serde(flatten)]
-    pub value: ShaderParam,
-}
-
-impl From<(&'static str, ShaderParam)> for ShaderParamStructField {
-    fn from(value: (&'static str, ShaderParam)) -> Self {
-        Self {
-            field_name: value.0.to_owned(),
-            value: value.1,
-        }
-    }
 }

--- a/compositor_common/src/scene/id.rs
+++ b/compositor_common/src/scene/id.rs
@@ -1,0 +1,42 @@
+use std::{fmt::Display, sync::Arc};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeId(pub Arc<str>);
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InputId(pub NodeId);
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutputId(pub NodeId);
+
+impl Display for InputId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0 .0.fmt(f)
+    }
+}
+
+impl Display for OutputId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0 .0.fmt(f)
+    }
+}
+
+impl Display for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<NodeId> for InputId {
+    fn from(value: NodeId) -> Self {
+        Self(value)
+    }
+}
+
+impl From<NodeId> for OutputId {
+    fn from(value: NodeId) -> Self {
+        Self(value)
+    }
+}

--- a/compositor_common/src/scene/node.rs
+++ b/compositor_common/src/scene/node.rs
@@ -1,0 +1,45 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{error::NodeSpecValidationError, renderer_spec::RendererId};
+
+use super::{
+    builtin_transformations::BuiltinSpec,
+    shader::ShaderParam,
+    text_spec::{TextDimensions, TextSpec},
+    NodeSpec, Resolution,
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum NodeParams {
+    WebRenderer {
+        instance_id: RendererId,
+    },
+    Shader {
+        shader_id: RendererId,
+        shader_params: Option<ShaderParam>,
+        resolution: Resolution,
+    },
+    TextRenderer {
+        #[serde(flatten)]
+        text_params: TextSpec,
+        resolution: TextDimensions,
+    },
+    Image {
+        image_id: RendererId,
+    },
+    #[serde(rename = "built-in")]
+    Builtin {
+        #[serde(flatten)]
+        transformation: BuiltinSpec,
+    },
+}
+
+impl NodeSpec {
+    pub fn validate(&self) -> Result<(), NodeSpecValidationError> {
+        match &self.params {
+            NodeParams::Builtin { transformation, .. } => Ok(transformation.validate(self)?),
+            _ => Ok(()),
+        }
+    }
+}

--- a/compositor_common/src/scene/shader.rs
+++ b/compositor_common/src/scene/shader.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case", content = "value")]
+pub enum ShaderParam {
+    F32(f32),
+    U32(u32),
+    I32(i32),
+    List(Vec<ShaderParam>),
+    Struct(Vec<ShaderParamStructField>),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ShaderParamStructField {
+    pub field_name: String,
+    #[serde(flatten)]
+    pub value: ShaderParam,
+}
+
+impl From<(&'static str, ShaderParam)> for ShaderParamStructField {
+    fn from(value: (&'static str, ShaderParam)) -> Self {
+        Self {
+            field_name: value.0.to_owned(),
+            value: value.1,
+        }
+    }
+}

--- a/compositor_common/src/scene/text_spec.rs
+++ b/compositor_common/src/scene/text_spec.rs
@@ -35,7 +35,7 @@ fn default_max_height() -> u32 {
     MAX_NODE_RESOLUTION.height as u32
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum Style {
     Normal,
@@ -43,7 +43,7 @@ pub enum Style {
     Oblique,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum Wrap {
     None,
@@ -61,7 +61,7 @@ impl From<Wrap> for glyphon::cosmic_text::Wrap {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum Align {
     Left,
@@ -81,7 +81,7 @@ impl From<Align> for glyphon::cosmic_text::Align {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "type")]
 pub struct TextSpec {
     pub content: Arc<str>,
@@ -127,7 +127,7 @@ impl From<&TextSpec> for AttrsOwned {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TextDimensions {
     /// Renders text and "trims" texture to smallest possible size

--- a/compositor_common/src/scene/validation_test.rs
+++ b/compositor_common/src/scene/validation_test.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashSet, sync::Arc};
 
 use crate::{
+    error::{SceneSpecValidationError, UnusedNodesError},
     renderer_spec::RendererId,
-    scene::{NodeId, NodeParams, NodeSpec, OutputId, OutputSpec, Resolution, SceneSpec},
-    validators::{SceneSpecValidationError, UnusedNodesError},
+    scene::{id::NodeId, id::OutputId, NodeParams, NodeSpec, OutputSpec, Resolution, SceneSpec},
 };
 
 #[test]
@@ -58,9 +58,10 @@ fn scene_validation_finds_cycle() {
     let registered_inputs = HashSet::from([&input_id]);
     let registered_outputs = HashSet::from([&output_id]);
 
+    let validation_result = scene_spec.validate(&registered_inputs, &registered_outputs);
     assert_eq!(
-        scene_spec.validate(&registered_inputs, &registered_outputs),
-        Err(SceneSpecValidationError::CycleDetected(c_id.clone()))
+        validation_result.err(),
+        Some(SceneSpecValidationError::CycleDetected(c_id.clone()))
     );
 }
 
@@ -128,7 +129,9 @@ fn scene_validation_finds_unused_nodes() {
     let registered_outputs = HashSet::from([&output_id]);
 
     assert_eq!(
-        scene_spec.validate(&registered_inputs, &registered_outputs),
-        Err(UnusedNodesError(unused_nodes).into())
+        scene_spec
+            .validate(&registered_inputs, &registered_outputs)
+            .err(),
+        Some(UnusedNodesError(unused_nodes).into())
     );
 }

--- a/compositor_common/src/util.rs
+++ b/compositor_common/src/util.rs
@@ -1,6 +1,10 @@
 use std::{fmt::Display, num::ParseIntError, str::FromStr};
 
+use serde::{Deserialize, Serialize};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
+pub struct Degree(pub i32);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SerializeDisplay, DeserializeFromStr)]
 pub struct RGBColor(pub u8, pub u8, pub u8);

--- a/compositor_render/examples/silly.rs
+++ b/compositor_render/examples/silly.rs
@@ -3,7 +3,7 @@ use std::{path::Path, process::Stdio, sync::Arc, time::Duration};
 use compositor_common::{
     frame::YuvData,
     renderer_spec::{RendererId, RendererSpec, ShaderSpec},
-    scene::{NodeId, NodeSpec, OutputSpec, Resolution, SceneSpec},
+    scene::{id::NodeId, NodeSpec, OutputSpec, Resolution, SceneSpec},
     Frame, Framerate,
 };
 use compositor_render::{

--- a/compositor_render/src/renderer/scene.rs
+++ b/compositor_render/src/renderer/scene.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use compositor_common::{
     scene::{InputId, NodeId, OutputId, SceneSpec},
-    SpecValidationError,
+    SceneSpecValidationError,
 };
 use log::error;
 
@@ -25,8 +25,8 @@ pub enum UpdateSceneError {
     #[error("Failed to create node \"{1}\". {0}")]
     CreateNodeError(#[source] CreateNodeError, NodeId),
 
-    #[error("Invalid scene: {0}")]
-    InvalidSpec(#[from] SpecValidationError),
+    #[error("Invalid scene. {0}")]
+    InvalidSpec(#[from] SceneSpecValidationError),
 
     #[error("Unknown node \"{0}\" used in scene.")]
     NoNodeWithIdError(NodeId),
@@ -115,7 +115,7 @@ impl Scene {
         // make sure that scene does not refer to missing entities.
         let node = Node::new_input(node_id);
         new_nodes.insert(node_id.clone(), node);
-        inputs.insert(InputId(node_id.clone()), InputTexture::new());
+        inputs.insert(node_id.clone().into(), InputTexture::new());
         Ok(())
     }
 }

--- a/compositor_render/src/transformations/shader.rs
+++ b/compositor_render/src/transformations/shader.rs
@@ -5,7 +5,7 @@ use crate::renderer::{
 
 use std::{sync::Arc, time::Duration};
 
-use compositor_common::scene::{NodeId, ShaderParam};
+use compositor_common::scene::{shader::ShaderParam, NodeId};
 
 use crate::renderer::{texture::Texture, WgpuCtx};
 

--- a/compositor_render/src/transformations/shader/error.rs
+++ b/compositor_render/src/transformations/shader/error.rs
@@ -1,4 +1,4 @@
-use compositor_common::scene::ShaderParam;
+use compositor_common::scene::shader::ShaderParam;
 
 use super::{USER_DEFINED_BUFFER_BINDING, USER_DEFINED_BUFFER_GROUP, VERTEX_ENTRYPOINT_NAME};
 

--- a/compositor_render/src/transformations/shader/node.rs
+++ b/compositor_render/src/transformations/shader/node.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use compositor_common::scene::{NodeId, Resolution, ShaderParam};
+use compositor_common::scene::{shader::ShaderParam, NodeId, Resolution};
 use wgpu::util::DeviceExt;
 
 use crate::renderer::{texture::NodeTexture, WgpuCtx};

--- a/compositor_render/src/transformations/shader/validation.rs
+++ b/compositor_render/src/transformations/shader/validation.rs
@@ -1,4 +1,4 @@
-use compositor_common::scene::ShaderParam;
+use compositor_common::scene::shader::ShaderParam;
 use naga::{ArraySize, ConstantInner, Handle, Module, ScalarKind, ShaderStage, Type, VectorSize};
 
 use super::{


### PR DESCRIPTION
Initially, this PR was aiming to address https://github.com/membraneframework/video_compositor/issues/108, but while implementing it I realized that it would complicate the implementation without any significant upside. It's very unlikely that we ever forgot to validate the scene when this is only done in place and it's one of the most important endpoints in our API.

Changes here are mostly moving stuff around, improving error messages and small refractors here and there. I'll add more in comments.