### PR TITLE
Fix fallback on output

### DIFF
--- a/compositor_common/src/util/colors.rs
+++ b/compositor_common/src/util/colors.rs
@@ -6,7 +6,7 @@ use serde_with::{DeserializeFromStr, SerializeDisplay};
 pub struct RGBColor(pub u8, pub u8, pub u8);
 
 impl RGBColor {
-    pub const BLACK: Self = Self(255, 255, 255);
+    pub const BLACK: Self = Self(0, 0, 0);
 
     pub fn to_yuv(&self) -> (f32, f32, f32) {
         let r = self.0 as f32 / 255.0;

--- a/compositor_render/src/render_loop.rs
+++ b/compositor_render/src/render_loop.rs
@@ -72,12 +72,6 @@ pub(super) fn read_outputs(
                     ((node.rgba_texture()), (node.bind_group())),
                     output_texture.yuv_textures(),
                 );
-                let yuv_pending = output_texture.start_download(ctx.wgpu_ctx);
-                pending_downloads.push((
-                    output_id,
-                    yuv_pending,
-                    output_texture.resolution().to_owned(),
-                ));
             }
             None => {
                 let (y, u, v) = RGBColor::BLACK.to_yuv();
@@ -98,6 +92,12 @@ pub(super) fn read_outputs(
                 );
             }
         };
+        let yuv_pending = output_texture.start_download(ctx.wgpu_ctx);
+        pending_downloads.push((
+            output_id,
+            yuv_pending,
+            output_texture.resolution().to_owned(),
+        ));
     }
     ctx.wgpu_ctx.device.poll(wgpu::MaintainBase::Wait);
 


### PR DESCRIPTION
The fallback on output did not work. It should be triggered when an empty texture is passed all the way to the output node and no fallback returns a real texture. When this happens compositor should send frames with black stream, but instead it was  not sending any frames and ffplay shown the last frame.