### PR TITLE
Fix memory leak in web renderer

### DIFF
--- a/compositor_render/src/transformations/web_renderer.rs
+++ b/compositor_render/src/transformations/web_renderer.rs
@@ -93,7 +93,7 @@ impl WebRenderer {
         if let Some(frame) = controller.retrieve_frame() {
             let target = target.ensure_size(ctx.wgpu_ctx, self.params.resolution);
 
-            self.bgra_texture.upload(ctx.wgpu_ctx, frame);
+            self.bgra_texture.upload(ctx.wgpu_ctx, &frame);
             self.bgra_to_rgba.convert(
                 ctx.wgpu_ctx,
                 (&self.bgra_texture, &self.bgra_bind_group),


### PR DESCRIPTION
When input finishes, fallback is triggered and the web render method is not called. It causes `painted_frames_receiver ` to grow because the frames are not being actively read.

I fixed it by limiting the amount of frames the channel is able to receive.

Fixes #141 