### PR TITLE
Change text renderer api

### DIFF
--- a/compositor_common/src/scene/node.rs
+++ b/compositor_common/src/scene/node.rs
@@ -3,10 +3,8 @@ use serde::{Deserialize, Serialize};
 use crate::{error::NodeSpecValidationError, renderer_spec::RendererId};
 
 use super::{
-    builtin_transformations::BuiltinSpec,
-    shader::ShaderParam,
-    text_spec::{TextDimensions, TextSpec},
-    NodeSpec, Resolution,
+    builtin_transformations::BuiltinSpec, shader::ShaderParam, text_spec::TextSpec, NodeSpec,
+    Resolution,
 };
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -20,11 +18,7 @@ pub enum NodeParams {
         shader_params: Option<ShaderParam>,
         resolution: Resolution,
     },
-    TextRenderer {
-        #[serde(flatten)]
-        text_params: TextSpec,
-        resolution: TextDimensions,
-    },
+    Text(TextSpec),
     Image {
         image_id: RendererId,
     },

--- a/compositor_common/src/scene/text_spec.rs
+++ b/compositor_common/src/scene/text_spec.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::util::{align::HorizontalAlign, colors::RGBAColor};
 
-use super::{Resolution, MAX_NODE_RESOLUTION};
+use super::MAX_NODE_RESOLUTION;
 
 fn default_color() -> RGBAColor {
     RGBAColor(255, 255, 255, 255)
@@ -81,6 +81,7 @@ pub struct TextSpec {
     pub align: HorizontalAlign,
     #[serde(default = "default_wrap")]
     pub wrap: Wrap,
+    pub dimensions: TextDimensions,
 }
 
 impl From<&TextSpec> for AttrsOwned {
@@ -107,7 +108,7 @@ impl From<&TextSpec> for AttrsOwned {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TextDimensions {
     /// Renders text and "trims" texture to smallest possible size
@@ -124,5 +125,5 @@ pub enum TextDimensions {
     },
     /// Renders text according to provided spec
     /// and outputs texture with provided fixed size
-    Fixed { resolution: Resolution },
+    Fixed { width: u32, height: u32 },
 }

--- a/compositor_render/src/renderer/node.rs
+++ b/compositor_render/src/renderer/node.rs
@@ -66,11 +66,8 @@ impl RenderNode {
                     input_count,
                 )))
             }
-            NodeParams::TextRenderer {
-                text_params,
-                resolution,
-            } => {
-                let renderer = TextRendererNode::new(ctx, text_params.clone(), resolution.clone());
+            NodeParams::Text(text_spec) => {
+                let renderer = TextRendererNode::new(ctx, text_spec.clone());
                 Ok(Self::Text(renderer))
             }
             NodeParams::Image { image_id } => {

--- a/compositor_render/src/transformations/text_renderer.rs
+++ b/compositor_render/src/transformations/text_renderer.rs
@@ -74,14 +74,11 @@ pub struct TextRendererNode {
 
 impl TextRendererNode {
     #[allow(dead_code)]
-    pub fn new(
-        renderer_ctx: &RenderCtx,
-        text_params: TextSpec,
-        text_resolution: TextDimensions,
-    ) -> Self {
+    pub fn new(renderer_ctx: &RenderCtx, text_spec: TextSpec) -> Self {
         let text_renderer_ctx = &renderer_ctx.text_renderer_ctx;
+        let text_dimensions = text_spec.dimensions;
         let (buffer, resolution) =
-            Self::layout_text(text_renderer_ctx, text_params.into(), text_resolution);
+            Self::layout_text(text_renderer_ctx, text_spec.into(), text_dimensions);
         Self {
             buffer,
             resolution,
@@ -197,19 +194,21 @@ impl TextRendererNode {
         buffer.set_wrap(font_system, text_params.wrap);
 
         match text_resolution {
-            TextDimensions::Fixed { resolution } => {
-                buffer.set_size(
-                    font_system,
-                    resolution.width as f32,
-                    resolution.height as f32,
-                );
+            TextDimensions::Fixed { width, height } => {
+                buffer.set_size(font_system, width as f32, height as f32);
 
                 for line in &mut buffer.lines {
                     line.set_align(Some(text_params.align));
                 }
 
                 buffer.shape_until_scroll(font_system);
-                (buffer, resolution)
+                (
+                    buffer,
+                    Resolution {
+                        width: width as usize,
+                        height: height as usize,
+                    },
+                )
             }
             TextDimensions::Fitted {
                 max_width,

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -139,11 +139,11 @@ fn start_example_client_code() -> Result<()> {
             },
             {
                  "node_id": "gif_1_label",
-                 "type": "text_renderer",
+                 "type": "text",
                  "content": "GIF example",
                  "font_size": 40.0,
                  "font_family": "Comic Sans MS",
-                 "resolution": {
+                 "dimensions": {
                      "type": "fitted",
                  },
             },
@@ -175,11 +175,11 @@ fn start_example_client_code() -> Result<()> {
             },
             {
                  "node_id": "png_1_label",
-                 "type": "text_renderer",
+                 "type": "text",
                  "content": "PNG example",
                  "font_size": 40.0,
                  "font_family": "Comic Sans MS",
-                 "resolution": {
+                 "dimensions": {
                      "type": "fitted",
                  },
             },
@@ -212,12 +212,12 @@ fn start_example_client_code() -> Result<()> {
             },
             {
                  "node_id": "jpeg_1_label",
-                 "type": "text_renderer",
+                 "type": "text",
                  "content": "JPEG example",
                  "font_size": 40.0,
                  "color_rgba": "#FF0000FF",
                  "font_family": "Comic Sans MS",
-                 "resolution": {
+                 "dimensions": {
                      "type": "fitted",
                  },
             },
@@ -249,11 +249,11 @@ fn start_example_client_code() -> Result<()> {
             },
             {
                  "node_id": "svg_1_label",
-                 "type": "text_renderer",
+                 "type": "text",
                  "content": "SVG example",
                  "font_size": 40.0,
                  "font_family": "Comic Sans MS",
-                 "resolution": {
+                 "dimensions": {
                      "type": "fitted",
                  },
             },

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -78,15 +78,16 @@ fn start_example_client_code() -> Result<()> {
         "nodes": [
            {
                 "node_id": "text_renderer_1",
-                "type": "text_renderer",
+                "type": "text",
                 "content": "VideoCompositor🚀\nSecond Line\nLorem ipsum dolor sit amet consectetur adipisicing elit. Soluta delectus optio fugit maiores eaque ab totam, veritatis aperiam provident, aliquam consectetur deserunt cumque est? Saepe tenetur impedit culpa asperiores id?",
                 "font_size": 100.0,
                 "font_family": "Comic Sans MS",
                 "align": "center",
                 "wrap": "word",
-                "resolution": {
+                "dimensions": {
                     "type": "fixed",
-                    "resolution": {"width": 1920, "height": 1080},
+                    "width": 1920,
+                    "height": 1080,
                 },
            }
         ],


### PR DESCRIPTION
While writing docs I noticed few issues with text renderer API

- rename example name
- change node type `text_renderer` -> `text`
- rename `resolution` -> `dimensions`
- Avoid 2 nested resolution fields in fixed type