### PR TITLE
Improve shader validation errors

### DIFF
--- a/compositor_render/examples/silly/silly.wgsl
+++ b/compositor_render/examples/silly/silly.wgsl
@@ -21,7 +21,7 @@ fn vs_main(input: VertexInput) -> VertexOutput {
 
 struct CommonShaderParameters {
     time: f32,
-    textures_count: u32,
+    texture_count: u32,
     output_resolution: vec2<u32>,
 }
 
@@ -33,7 +33,7 @@ var<push_constant> common_params: CommonShaderParameters;
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     // Return transparent frame in case of different input video count
-    if (common_params.textures_count != 1u) {
+    if (common_params.texture_count != 1u) {
         return vec4(0.0, 0.0, 0.0, 0.0);
     }
 

--- a/compositor_render/src/gpu_shader/pipeline.rs
+++ b/compositor_render/src/gpu_shader/pipeline.rs
@@ -138,7 +138,7 @@ impl Pipeline {
             render_pass.set_bind_group(2, &self.sampler.bind_group, &[]);
 
             self.surfaces
-                .draw(&mut render_pass, common_parameters.textures_count);
+                .draw(&mut render_pass, common_parameters.texture_count);
         }
 
         // TODO: this should not submit, it should return the command buffer.

--- a/compositor_render/src/gpu_shader/shader_header.wgsl
+++ b/compositor_render/src/gpu_shader/shader_header.wgsl
@@ -6,7 +6,7 @@ struct VertexInput {
 
 struct CommonShaderParameters {
     time: f32,
-    textures_count: u32,
+    texture_count: u32,
     output_resolution: vec2<u32>,
 }
 

--- a/compositor_render/src/gpu_shader/validation.rs
+++ b/compositor_render/src/gpu_shader/validation.rs
@@ -35,7 +35,7 @@ fn validate_globals(
             |err| {
                 ShaderValidationError::GlobalBadType(
                     err,
-                    global_in_shader.name.clone().unwrap_with("<unknown>"),
+                    global_in_shader.name.unwrap_with("<unknown>"),
                 )
             },
         )?;
@@ -87,7 +87,7 @@ fn validate_vertex_input(
         .find(|(_, ty)| ty.name == vertex_input_type.name)
         .ok_or_else(|| {
             ShaderValidationError::VertexShaderBadInputTypeName(
-                vertex_input_type.name.clone().unwrap_with("<unknown>"),
+                vertex_input_type.name.unwrap_with("<unknown>"),
             )
         })?;
 
@@ -108,8 +108,8 @@ fn validate_type_equivalent(
 
     if expected_type.name != provided_type.name && expected_type.name.is_some() {
         return Err(TypeEquivalenceError::TypeNameMismatch {
-            expected: expected_type.name.clone().unwrap_with("<unknown>"),
-            actual: provided_type.name.clone().unwrap_with("<unknown>"),
+            expected: expected_type.name.unwrap_with("<unknown>"),
+            actual: provided_type.name.unwrap_with("<unknown>"),
         });
     }
 

--- a/compositor_render/src/renderer.rs
+++ b/compositor_render/src/renderer.rs
@@ -246,7 +246,7 @@ impl WgpuCtx {
         ))?;
 
         let shader_header =
-            naga::front::wgsl::parse_str(include_str!("transformations/shader_header.wgsl"))
+            naga::front::wgsl::parse_str(include_str!("gpu_shader/shader_header.wgsl"))
                 .expect("failed to parse the shader header file");
 
         let scope = WgpuErrorScope::push(&device);
@@ -278,15 +278,15 @@ impl WgpuCtx {
 #[derive(Debug, bytemuck::Pod, bytemuck::Zeroable, Clone, Copy)]
 pub struct CommonShaderParameters {
     time: f32,
-    pub textures_count: u32,
+    pub texture_count: u32,
     output_resolution: [u32; 2],
 }
 
 impl CommonShaderParameters {
-    pub fn new(time: Duration, textures_count: u32, output_resolution: Resolution) -> Self {
+    pub fn new(time: Duration, texture_count: u32, output_resolution: Resolution) -> Self {
         Self {
             time: time.as_secs_f32(),
-            textures_count,
+            texture_count,
             output_resolution: [
                 output_resolution.width as u32,
                 output_resolution.height as u32,

--- a/compositor_render/src/renderer/common_pipeline.rs
+++ b/compositor_render/src/renderer/common_pipeline.rs
@@ -12,7 +12,7 @@ pub const PRIMITIVE_STATE: wgpu::PrimitiveState = wgpu::PrimitiveState {
     unclipped_depth: false,
 };
 
-pub const MAX_TEXTURES_COUNT: u32 = 16;
+pub const MAX_TEXTURE_COUNT: u32 = 16;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]

--- a/compositor_render/src/renderer/common_pipeline/surface.rs
+++ b/compositor_render/src/renderer/common_pipeline/surface.rs
@@ -1,6 +1,6 @@
 use wgpu::{util::DeviceExt, Buffer, BufferSlice};
 
-use super::{Vertex, MAX_TEXTURES_COUNT};
+use super::{Vertex, MAX_TEXTURE_COUNT};
 
 /// In case of no input texture, vertex shader receives plane
 /// with 4 vertices with input id -1. This allows using shaders without
@@ -107,8 +107,8 @@ pub struct Surfaces {
     no_inputs_indices: Buffer,
 }
 
-const VERTICES_COUNT: usize = 4 * MAX_TEXTURES_COUNT as usize;
-const INDICES_COUNT: usize = 6 * MAX_TEXTURES_COUNT as usize;
+const VERTICES_COUNT: usize = 4 * MAX_TEXTURE_COUNT as usize;
+const INDICES_COUNT: usize = 6 * MAX_TEXTURE_COUNT as usize;
 
 /// Vertex and index buffer that describe render area as an rectangle mapped to texture.
 impl Surfaces {
@@ -155,39 +155,39 @@ impl Surfaces {
         }
     }
 
-    pub fn draw<'a>(&'a self, render_pass: &mut wgpu::RenderPass<'a>, input_textures_count: u32) {
-        render_pass.set_vertex_buffer(0, self.vertices(input_textures_count));
+    pub fn draw<'a>(&'a self, render_pass: &mut wgpu::RenderPass<'a>, input_texture_count: u32) {
+        render_pass.set_vertex_buffer(0, self.vertices(input_texture_count));
 
-        render_pass.set_index_buffer(self.indices(input_textures_count), INDEX_FORMAT);
+        render_pass.set_index_buffer(self.indices(input_texture_count), INDEX_FORMAT);
 
-        render_pass.draw_indexed(0..Self::indices_len(input_textures_count), 0, 0..1);
+        render_pass.draw_indexed(0..Self::indices_len(input_texture_count), 0, 0..1);
     }
 
-    fn vertices(&self, input_textures_count: u32) -> BufferSlice {
-        if input_textures_count == 0 {
+    fn vertices(&self, input_texture_count: u32) -> BufferSlice {
+        if input_texture_count == 0 {
             self.no_inputs_vertices.slice(..)
         } else {
             let vertex_buffer_len =
-                4 * input_textures_count as u64 * std::mem::size_of::<Vertex>() as u64;
+                4 * input_texture_count as u64 * std::mem::size_of::<Vertex>() as u64;
             self.inputs_vertices.slice(..vertex_buffer_len)
         }
     }
 
-    fn indices(&self, input_textures_count: u32) -> BufferSlice {
-        if input_textures_count == 0 {
+    fn indices(&self, input_texture_count: u32) -> BufferSlice {
+        if input_texture_count == 0 {
             self.no_inputs_indices.slice(..)
         } else {
             let index_buffer_len =
-                6 * input_textures_count as u64 * std::mem::size_of::<u16>() as u64;
+                6 * input_texture_count as u64 * std::mem::size_of::<u16>() as u64;
             self.inputs_indices.slice(..index_buffer_len)
         }
     }
 
-    fn indices_len(input_textures_count: u32) -> u32 {
-        if input_textures_count == 0 {
+    fn indices_len(input_texture_count: u32) -> u32 {
+        if input_texture_count == 0 {
             6
         } else {
-            input_textures_count * 6
+            input_texture_count * 6
         }
     }
 }

--- a/compositor_render/src/renderer/scene.rs
+++ b/compositor_render/src/renderer/scene.rs
@@ -22,10 +22,10 @@ pub struct Scene {
 
 #[derive(Debug, thiserror::Error)]
 pub enum UpdateSceneError {
-    #[error("Failed to create node \"{1}\". {0}")]
+    #[error("Failed to create node \"{1}\".")]
     CreateNodeError(#[source] CreateNodeError, NodeId),
 
-    #[error("Invalid scene. {0}")]
+    #[error(transparent)]
     InvalidSpec(#[from] SceneSpecValidationError),
 
     #[error("Unknown node \"{0}\" used in scene.")]

--- a/compositor_render/src/transformations/builtin/apply_transformation_matrix.wgsl
+++ b/compositor_render/src/transformations/builtin/apply_transformation_matrix.wgsl
@@ -12,7 +12,7 @@ struct VertexOutput {
 
 struct CommonShaderParameters {
     time: f32,
-    textures_count: u32,
+    texture_count: u32,
     output_resolution: vec2<u32>,
 }
 
@@ -48,7 +48,7 @@ fn vs_main(input: VertexInput) -> VertexOutput {
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let sample = textureSample(textures[input.texture_id], sampler_, input.tex_coords);
     
-    if common_params.textures_count == 0u {
+    if common_params.texture_count == 0u {
         return vec4<f32>(0.0, 0.0, 0.0, 0.0);
     }
 

--- a/compositor_render/src/transformations/builtin/corners_rounding.wgsl
+++ b/compositor_render/src/transformations/builtin/corners_rounding.wgsl
@@ -12,7 +12,7 @@ struct VertexOutput {
 
 struct CommonShaderParameters {
     time: f32,
-    textures_count: u32,
+    texture_count: u32,
     output_resolution: vec2<u32>,
 }
 

--- a/compositor_render/src/transformations/builtin/mirror_image.wgsl
+++ b/compositor_render/src/transformations/builtin/mirror_image.wgsl
@@ -12,7 +12,7 @@ struct VertexOutput {
 
 struct CommonShaderParameters {
     time: f32,
-    textures_count: u32,
+    texture_count: u32,
     output_resolution: vec2<u32>,
 }
 


### PR DESCRIPTION
- Follow up to PR when we switched back to stack trace approach (remove some concatenated errors)
- Improve wording, fix some typos
- Improve serialization for errors (mostly focused on comparing types from shader with ShaderParam)
- Replace unwraps in validation code with safer alternative

`.unwrap_with("<unnamed>")` is just to make it shorter. Without this I would have to write
`.clone().unwrap_or_else(|| "<unnamed>".to_string())` everywhere.