### PR TITLE
Implement user web embedding API

### DIFF
--- a/examples/web_renderer.html
+++ b/examples/web_renderer.html
@@ -39,35 +39,13 @@
 
 <body>
 <h2>Frame embedding:</h2>
-<canvas id="input_0"></canvas>
+<canvas id="input_1"></canvas>
 </body>
 
 <script>
-    // TODO: Figure out embedding API
-    // NOTE TO REVIEWERS: The section below is not part of this PR
-    async function run(sourceID, interval) {
-        const sourceCanvas = document.getElementById(sourceID);
-        const ctx = sourceCanvas.getContext("2d");
-
-        setInterval(() => {
-            const data = window[`${sourceID}_data`];
-            const width = window[`${sourceID}_width`];
-            const height = window[`${sourceID}_height`];
-            if (data == undefined || width == undefined || height == undefined) {
-                return;
-            }
-            if (width == 1 || height == 1) {
-                return;
-            }
-
-            sourceCanvas.width = width;
-            sourceCanvas.height = height;
-            const imageView = new ImageData(new Uint8ClampedArray(data), width, height);
-            ctx.putImageData(imageView, 0, 0);
-        }, 16);
-    }
-
-    run("input_0");
+    register_inputs(
+        "input_1"
+    );
 </script>
 
 </html>

--- a/src/bin/process_helper/handler.rs
+++ b/src/bin/process_helper/handler.rs
@@ -3,16 +3,32 @@ use std::sync::Arc;
 
 use compositor_chromium::cef;
 use compositor_render::{EMBED_SOURCE_FRAMES_MESSAGE, UNEMBED_SOURCE_FRAMES_MESSAGE};
-use log::{error, warn};
-use shared_memory::ShmemConf;
+use log::{debug, error, warn};
+use anyhow::{Result, anyhow, Context};
 
-use crate::state::{FrameInfo, Source, State};
+use crate::state::{FrameInfo, State};
 
 pub struct RenderProcessHandler {
     state: Arc<State>,
 }
 
 impl cef::RenderProcessHandler for RenderProcessHandler {
+    fn on_context_created(
+        &mut self,
+        _browser: &cef::Browser,
+        _frame: &cef::Frame,
+        context: &cef::V8Context,
+    ) {
+        let mut global = context.global().unwrap();
+        let ctx_entered = context.enter().unwrap();
+
+        context.eval(include_str!("render_frame.js")).unwrap();
+        if let Err(err) = self.register_native_funcs(&mut global, &ctx_entered) {
+            error!("Failed to register native functions for V8Context");
+            return;
+        }
+    }
+
     fn on_process_message_received(
         &mut self,
         _browser: &cef::Browser,
@@ -20,12 +36,17 @@ impl cef::RenderProcessHandler for RenderProcessHandler {
         _source_process: cef::ProcessId,
         message: &cef::ProcessMessage,
     ) -> bool {
-        match message.name().as_str() {
-            EMBED_SOURCE_FRAMES_MESSAGE => self.handle_embed_sources(message, frame),
-            UNEMBED_SOURCE_FRAMES_MESSAGE => self.handle_unembed_source(message, frame),
-            name => error!("Unknown message type: {name}"),
+        let result = match message.name().as_str() {
+            EMBED_SOURCE_FRAMES_MESSAGE => self.embed_sources(message, frame),
+            UNEMBED_SOURCE_FRAMES_MESSAGE => self.unembed_source(message, frame),
+            name => Err(anyhow!("Unknown message type: {name}")),
+        };
+
+        if let Err(err) = result {
+            error!("Error occurred while processing IPC message: {err}");
         }
-        false
+
+        true
     }
 }
 
@@ -34,129 +55,127 @@ impl RenderProcessHandler {
         Self { state }
     }
 
-    fn handle_embed_sources(&self, msg: &cef::ProcessMessage, surface: &cef::Frame) {
-        let ctx = surface.v8_context().unwrap();
-        let ctx_entered = ctx.enter().unwrap();
-        let mut global = ctx.global().unwrap();
+    fn embed_sources(&self, msg: &cef::ProcessMessage, surface: &cef::Frame) -> Result<()> {
+        let ctx = surface.v8_context()?;
+        let ctx_entered = ctx.enter()?;
+        let mut global = ctx.global()?;
 
         const MSG_SIZE: usize = 3;
         for i in (0..msg.size()).step_by(3) {
             let source_idx = i / MSG_SIZE;
 
             let Some(shmem_path) = msg.read_string(i) else {
-                error!("Failed to read shared memory path at {i}");
-                continue;
+                return Err(anyhow!("Failed to read shared memory path at {i}"));
             };
             let shmem_path = PathBuf::from(shmem_path);
 
             let Some(width) = msg.read_int(i + 1) else {
-                error!("Failed to read width of input {} at {}", source_idx, i + 1);
-                continue;
+                return Err(anyhow!("Failed to read width of input {} at {}", source_idx, i + 1));
             };
 
             let Some(height) = msg.read_int(i + 2) else {
-                error!("Failed to read height of input {} at {}", source_idx, i + 2);
-                continue;
+                return Err(anyhow!("Failed to read height of input {} at {}", source_idx, i + 2));
             };
 
             if width == 0 && height == 0 {
                 continue;
             }
 
-            if !self.state.contains_source(&shmem_path) {
-                let frame_info = FrameInfo {
-                    source_idx,
-                    width: width as u32,
-                    height: height as u32,
-                    shmem_path,
-                };
+            let frame_info = FrameInfo {
+                source_idx,
+                width: width as u32,
+                height: height as u32,
+                shmem_path,
+            };
 
-                self.embed_frame(frame_info, &mut global, &ctx_entered);
-            }
+            self.render_frame(frame_info, &mut global, &ctx_entered)?;
         }
+
+        Ok(())
     }
 
-    fn embed_frame(
+    fn render_frame(
         &self,
         frame_info: FrameInfo,
         global: &mut cef::V8Global,
         ctx_entered: &cef::V8ContextEntered,
-    ) {
-        let shmem = ShmemConf::new()
-            .flink(&frame_info.shmem_path)
-            .open()
-            .unwrap();
-        let data_ptr = shmem.as_ptr();
-
-        let array_buffer: cef::V8Value = unsafe {
-            cef::V8ArrayBuffer::from_ptr(
-                data_ptr,
-                (4 * frame_info.width * frame_info.height) as usize,
-                ctx_entered,
-            )
-        }
-        .into();
-
-        // TODO: Figure out emedding API
-        // NOTE TO REVIEWERS: The section below is not part of this PR
-        // Currently we pass frame data, width and height to JS context.
-        // User has to handle this data manually. This approach is not really ergonomic and elegant
-        global
-            .set(
-                &format!("input_{}_data", frame_info.source_idx),
-                &array_buffer,
-                cef::V8PropertyAttribute::DoNotDelete,
-                ctx_entered,
-            )
-            .unwrap();
+    ) -> Result<()> {
+        let source = match self.state.source(&frame_info.shmem_path) {
+            Some(source) => source,
+            None => self.state.create_source(frame_info, ctx_entered)?,
+        };
 
         global
-            .set(
-                &format!("input_{}_width", frame_info.source_idx),
-                &cef::V8Uint::new(frame_info.width).into(),
-                cef::V8PropertyAttribute::DoNotDelete,
+            .call_method(
+                "renderFrame",
+                &[
+                    &source.source_id,
+                    &source.array_buffer,
+                    &source.width,
+                    &source.height,
+                ],
                 ctx_entered,
-            )
-            .unwrap();
+            )?;
 
-        global
-            .set(
-                &format!("input_{}_height", frame_info.source_idx),
-                &cef::V8Uint::new(frame_info.height).into(),
-                cef::V8PropertyAttribute::DoNotDelete,
-                ctx_entered,
-            )
-            .unwrap();
-        // ------
-
-        self.state.insert_source(
-            frame_info.shmem_path.clone(),
-            Source {
-                _shmem: shmem,
-                _array_buffer: array_buffer,
-                info: frame_info,
-            },
-        );
+        Ok(())
     }
 
-    fn handle_unembed_source(&self, msg: &cef::ProcessMessage, surface: &cef::Frame) {
+    fn unembed_source(&self, msg: &cef::ProcessMessage, surface: &cef::Frame) -> Result<()> {
         let Some(shmem_path) = msg.read_string(0) else {
-            error!("Failed to read node ID");
-            return;
+            return Err(anyhow!("Failed to read node ID"));
         };
         let shmem_path = PathBuf::from(shmem_path);
-        let Some(source_idx) = self.state.source_index(&shmem_path) else {
-            warn!("Source {shmem_path:?} not found");
-            return;
+        let Some(source) = self.state.source(&shmem_path) else {
+            debug!("Source {shmem_path:?} not found");
+            return Ok(());
         };
-        let ctx = surface.v8_context().unwrap();
-        let ctx_entered = ctx.enter().unwrap();
 
-        // NOTE: This will change once embedding API is finished
-        let source_id = format!("input_{}_data", source_idx);
-        let mut global = ctx.global().unwrap();
-        global.delete(&source_id, &ctx_entered).unwrap();
+        let ctx = surface.v8_context()?;
+        let ctx_entered = ctx.enter()?;
 
+        let source_id = self.state.input_name(source.source_index)?;
+        let mut global = ctx.global()?;
+        global.delete(&source_id, &ctx_entered)?;
         self.state.remove_source(&shmem_path);
+
+        Ok(())
+    }
+
+    pub fn register_native_funcs(
+        &self,
+        global: &mut cef::V8Global,
+        ctx_entered: &cef::V8ContextEntered,
+    ) -> Result<()> {
+        let state = self.state.clone();
+        let func = cef::V8Function::new("register_inputs", move |args| {
+            let mut input_mappings = Vec::new();
+            for arg in args {
+                let cef::V8Value::String(element_id) = arg else {
+                    return Err("Expected string value".into());
+                };
+                let element_id = element_id.get().unwrap().into();
+                if input_mappings.contains(&element_id) {
+                    return Err(format!(
+                        "\"{element_id}\" already exists in the provided input mappings"
+                    )
+                    .into());
+                }
+
+                input_mappings.push(element_id);
+            }
+
+            state.set_input_mappings(input_mappings);
+            Ok(cef::V8Undefined::new().into())
+        });
+
+        global
+            .set(
+                "register_inputs",
+                &cef::V8Value::from(func),
+                cef::V8PropertyAttribute::None,
+                ctx_entered,
+            )?;
+
+        Ok(())
     }
 }

--- a/src/bin/process_helper/render_frame.js
+++ b/src/bin/process_helper/render_frame.js
@@ -1,0 +1,9 @@
+function renderFrame(sourceId, buffer, width, height) {
+    const canvas = document.getElementById(sourceId);
+    const ctx = canvas.getContext("2d");
+    const imageData = new ImageData(new Uint8ClampedArray(buffer), width, height);
+
+    canvas.width = width;
+    canvas.height = height;
+    ctx.putImageData(imageData, 0, 0);
+}

--- a/src/bin/process_helper/state.rs
+++ b/src/bin/process_helper/state.rs
@@ -1,28 +1,65 @@
+use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::{collections::HashMap, sync::Mutex};
 
 use compositor_chromium::cef;
-use shared_memory::Shmem;
+use shared_memory::{Shmem, ShmemConf};
 
 pub struct State {
-    sources: Mutex<HashMap<PathBuf, Source>>,
+    input_mappings: Mutex<Vec<Arc<str>>>,
+    sources: Mutex<HashMap<PathBuf, Arc<Source>>>,
 }
 
 impl State {
     pub fn new() -> Self {
         Self {
+            input_mappings: Mutex::new(Vec::new()),
             sources: Mutex::new(HashMap::new()),
         }
     }
 
-    pub fn source_index(&self, key: &Path) -> Option<usize> {
+    pub fn source(&self, key: &Path) -> Option<Arc<Source>> {
         let sources = self.sources.lock().unwrap();
-        sources.get(key).map(|src| src.info.source_idx)
+        sources.get(key).cloned()
     }
 
-    pub fn insert_source(&self, key: PathBuf, source: Source) {
+    pub fn create_source(
+        &self,
+        frame_info: FrameInfo,
+        ctx_entered: &cef::V8ContextEntered,
+    ) -> Result<Arc<Source>> {
         let mut sources = self.sources.lock().unwrap();
-        sources.insert(key, source);
+        let source_id = self.input_name(frame_info.source_idx)?;
+        let shmem = ShmemConf::new()
+            .flink(&frame_info.shmem_path)
+            .open()?;
+        let data_ptr = shmem.as_ptr();
+
+        let source_id = cef::V8String::new(&source_id).into();
+        let array_buffer: cef::V8Value = unsafe {
+            cef::V8ArrayBuffer::from_ptr(
+                data_ptr,
+                (4 * frame_info.width * frame_info.height) as usize,
+                ctx_entered,
+            )
+        }
+        .into();
+        let width = cef::V8Uint::new(frame_info.width).into();
+        let height = cef::V8Uint::new(frame_info.height).into();
+
+        #[allow(clippy::arc_with_non_send_sync)]
+        let source = Arc::new(Source {
+            _shmem: shmem,
+            source_index: frame_info.source_idx,
+            source_id,
+            array_buffer,
+            width,
+            height,
+        });
+
+        sources.insert(frame_info.shmem_path, source.clone());
+        Ok(source)
     }
 
     pub fn remove_source(&self, key: &Path) {
@@ -30,16 +67,29 @@ impl State {
         sources.remove(key);
     }
 
-    pub fn contains_source(&self, key: &Path) -> bool {
-        let sources = self.sources.lock().unwrap();
-        sources.contains_key(key)
+    pub fn set_input_mappings(&self, new_input_mappings: Vec<Arc<str>>) {
+        let mut sources = self.sources.lock().unwrap();
+        sources.clear();
+
+        let mut input_mappings = self.input_mappings.lock().unwrap();
+        *input_mappings = new_input_mappings;
+    }
+
+    pub fn input_name(&self, source_idx: usize) -> Result<Arc<str>> {
+        let input_mappings = self.input_mappings.lock().unwrap();
+        input_mappings.get(source_idx).cloned().with_context(|| {
+            format!("Could not retrieve input name. Expected registered input for index {source_idx}. Use register_inputs(\"input_name1\", ...)")
+        })
     }
 }
 
 pub struct Source {
     pub _shmem: Shmem,
-    pub _array_buffer: cef::V8Value,
-    pub info: FrameInfo,
+    pub source_index: usize,
+    pub source_id: cef::V8Value,
+    pub array_buffer: cef::V8Value,
+    pub width: cef::V8Value,
+    pub height: cef::V8Value,
 }
 
 pub struct FrameInfo {


### PR DESCRIPTION
Currently I have 3 ideas of the API:
```html
<canvas id="input_0"></canvas>
<canvas id="input_1"></canvas>
```
```js
// Option 1
// Insert frames automatically in input_<index>
// Pros: user doesn't have to configure anything
// Cons: it does not allow any extra configuration from the JS side

// Option 2
register_inputs(
    "input_0",
    { id: "input_1", overrideCanvasSize: false }
);

// Option 3
// Same as option 2 but more explicit. I find it ugly though
register_inputs({
    0: "input_0",
    1: "input_ 1"
});
```

Update:
I went with option 2
