### PR TITLE
Check if pipeline already started

### DIFF
--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -59,6 +59,7 @@ pub struct Pipeline<Input: PipelineInput, Output: PipelineOutput> {
     outputs: OutputRegistry<Encoder<Output>>,
     queue: Arc<Queue>,
     renderer: Renderer,
+    is_started: bool,
 }
 
 #[serde_as]
@@ -86,6 +87,7 @@ impl<Input: PipelineInput, Output: PipelineOutput> Pipeline<Input, Output> {
             inputs: HashMap::new(),
             queue: Arc::new(Queue::new(opts.framerate)),
             renderer,
+            is_started: false,
         };
 
         Ok((pipeline, event_loop))
@@ -197,7 +199,11 @@ impl<Input: PipelineInput, Output: PipelineOutput> Pipeline<Input, Output> {
         self.renderer.update_scene(scene_spec)
     }
 
-    pub fn start(&self) {
+    pub fn start(&mut self) {
+        if self.is_started {
+            error!("Pipeline already started.");
+            return;
+        }
         let (frames_sender, frames_receiver) = unbounded();
         let renderer = self.renderer.clone();
         let outputs = self.outputs.clone();


### PR DESCRIPTION
starting the pipeline twice gives a very cryptic error becaus muxer receives non monotonic dts from encoder