### PR TITLE
Add support for nvidia GPUs in the docker example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN source ~/.cargo/env && rustup install $RUST_VERSION && rustup default $RUST_
 
 ENV DISPLAY=:99
 ENV XDG_RUNTIME_DIR=/home/$USERNAME/.cache/xdgr
+ENV NVIDIA_DRIVER_CAPABILITIES compute,graphics,utility
 
 COPY --chown=$USERNAME:$USERNAME . /home/$USERNAME/project
 WORKDIR /home/$USERNAME/project

--- a/examples/docker.rs
+++ b/examples/docker.rs
@@ -59,20 +59,20 @@ fn build_and_start_docker(skip_build: bool) -> Result<()> {
         warn!("Skipping image build, using old version.")
     }
 
+    let mut args = vec!["run", "-it", "-p", "8004:8004/udp", "-p", "8001:8001"];
+
+    if env::var("NVIDIA").is_ok() {
+        info!("[example] configured for nvidia GPUs");
+        args.extend_from_slice(&["--gpus", "all", "--runtime=nvidia"]);
+    } else {
+        info!("[example] configured for non-nvidia GPUs");
+        args.extend_from_slice(&["--device", "/dev/dri"]);
+    }
+
+    args.push("video-compositor");
+
     info!("[example] docker run");
-    Command::new("docker")
-        .args([
-            "run",
-            "-it",
-            "--device",
-            "/dev/dri", // expose gpu to container
-            "-p",
-            "8004:8004/udp",
-            "-p",
-            "8001:8001",
-            "video-compositor",
-        ])
-        .spawn()?;
+    Command::new("docker").args(args).spawn()?;
     Ok(())
 }
 


### PR DESCRIPTION
You can enable the support by setting the environment variable `NVIDIA=1`