### PR TITLE
Add RTC.ON workshops link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ For better performance, build examples with the [release compilation profile](ht
 cargo run --release --example <example_name>
 ```
 
+You can also check out [RTC.ON 2023 workshops repo](https://github.com/membraneframework-labs/rtcon_video_compositor_workshops) for more examples / exercises.
+
 ## Supported platforms
 
 Linux and MacOS.


### PR DESCRIPTION
If RTC.ON workshops repo becomes outdated due to API change, then I would suggest adding a note about it. Currently, I find adding a note about such a possibility unnecessary and potentially confusing. 