### PR TITLE
Simplify types in renderer API

### DIFF
--- a/compositor_common/src/error.rs
+++ b/compositor_common/src/error.rs
@@ -128,7 +128,7 @@ impl From<&NodeParams> for NodeIdentifier {
             NodeParams::Shader { shader_id, .. } => Self::Shader(shader_id.clone()),
             NodeParams::Text(_) => Self::Text,
             NodeParams::Image { image_id } => Self::Image(image_id.clone()),
-            NodeParams::Builtin { transformation } => {
+            NodeParams::Builtin(transformation) => {
                 Self::Builtin(transformation.transformation_name())
             }
             NodeParams::Transition(TransitionSpec { start, end, .. }) => {

--- a/compositor_common/src/scene/builtin_transformations.rs
+++ b/compositor_common/src/scene/builtin_transformations.rs
@@ -15,7 +15,9 @@ pub(crate) mod fixed_postion_layout;
 pub mod tiled_layout;
 
 pub use fixed_postion_layout::FixedPositionLayoutSpec;
+pub use fixed_postion_layout::HorizontalPosition;
 pub use fixed_postion_layout::TextureLayout;
+pub use fixed_postion_layout::VerticalPosition;
 
 pub const TILED_LAYOUT_MAX_INPUTS_COUNT: u32 = 16;
 pub const FIXED_POSITION_LAYOUT_MAX_INPUTS_COUNT: u32 = 16;
@@ -105,35 +107,6 @@ impl BuiltinSpec {
                         layout_count: texture_layouts.len() as u32,
                         input_count: node_spec.input_pads.len() as u32,
                     });
-                }
-
-                for layout in texture_layouts {
-                    match layout {
-                        TextureLayout {
-                            top: None,
-                            bottom: None,
-                            ..
-                        } => return Err(BuiltinSpecValidationError::FixedLayoutTopBottomRequired),
-                        TextureLayout {
-                            top: Some(_),
-                            bottom: Some(_),
-                            ..
-                        } => return Err(BuiltinSpecValidationError::FixedLayoutTopBottomOnlyOne),
-                        _ => (),
-                    };
-                    match layout {
-                        TextureLayout {
-                            left: None,
-                            right: None,
-                            ..
-                        } => return Err(BuiltinSpecValidationError::FixedLayoutLeftRightRequired),
-                        TextureLayout {
-                            left: Some(_),
-                            right: Some(_),
-                            ..
-                        } => return Err(BuiltinSpecValidationError::FixedLayoutLeftRightOnlyOne),
-                        _ => (),
-                    };
                 }
                 Ok(())
             }

--- a/compositor_common/src/scene/builtin_transformations/fixed_postion_layout.rs
+++ b/compositor_common/src/scene/builtin_transformations/fixed_postion_layout.rs
@@ -5,12 +5,22 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct TextureLayout {
-    pub top: Option<Coord>,
-    pub bottom: Option<Coord>,
-    pub left: Option<Coord>,
-    pub right: Option<Coord>,
+    pub horizontal_position: HorizontalPosition,
+    pub vertical_position: VerticalPosition,
     pub scale: f32,
     pub rotation: Degree,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum VerticalPosition {
+    Top(Coord),
+    Bottom(Coord),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum HorizontalPosition {
+    Left(Coord),
+    Right(Coord),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/compositor_common/src/scene/node.rs
+++ b/compositor_common/src/scene/node.rs
@@ -23,16 +23,14 @@ pub enum NodeParams {
     Image {
         image_id: RendererId,
     },
-    Builtin {
-        transformation: BuiltinSpec,
-    },
+    Builtin(BuiltinSpec),
     Transition(TransitionSpec),
 }
 
 impl NodeSpec {
     pub fn validate_params(&self) -> Result<(), NodeSpecValidationError> {
         match &self.params {
-            NodeParams::Builtin { transformation } => Ok(transformation.validate_params(self)?),
+            NodeParams::Builtin(transformation) => Ok(transformation.validate_params(self)?),
             NodeParams::Transition(TransitionSpec { start, end, .. }) => {
                 start.validate_params(self)?;
                 end.validate_params(self)?;

--- a/compositor_render/src/renderer/node.rs
+++ b/compositor_render/src/renderer/node.rs
@@ -50,7 +50,7 @@ impl RenderNode {
                 let node = ShaderNode::new(ctx, shader_id, shader_params, resolution)?;
                 Ok(Self::Shader(node))
             }
-            NodeParams::Builtin { transformation } => {
+            NodeParams::Builtin(transformation) => {
                 let node = BuiltinNode::new_static(ctx, transformation, spec.input_pads.len());
 
                 Ok(Self::Builtin(node))
@@ -221,7 +221,7 @@ impl NodeSpecExt for NodeSpec {
                 }),
             NodeParams::Text(_) => Ok(NodeParams::text_constraints()),
             NodeParams::Image { .. } => Ok(NodeParams::image_constraints()),
-            NodeParams::Builtin { transformation } => Ok(transformation.constraints()),
+            NodeParams::Builtin(transformation) => Ok(transformation.constraints()),
             NodeParams::Transition(spec) => Ok(spec.end.constraints()),
         }
     }

--- a/compositor_render/src/transformations/builtin/params/fixed_position_layout.rs
+++ b/compositor_render/src/transformations/builtin/params/fixed_position_layout.rs
@@ -1,8 +1,9 @@
 use compositor_common::scene::{
-    builtin_transformations::{FixedPositionLayoutSpec, TextureLayout},
+    builtin_transformations::{
+        FixedPositionLayoutSpec, HorizontalPosition, TextureLayout, VerticalPosition,
+    },
     Resolution,
 };
-use log::error;
 
 use crate::transformations::builtin::box_layout::BoxLayout;
 
@@ -50,35 +51,20 @@ fn spec_to_top_left_coords(
     input_resolution: &Resolution,
     output_resolution: &Resolution,
 ) -> (f32, f32) {
-    let top = match layout {
-        TextureLayout { top: Some(top), .. } => top.pixels(output_resolution.height as u32),
-        TextureLayout {
-            bottom: Some(bottom),
-            ..
-        } => {
+    let top = match layout.vertical_position {
+        VerticalPosition::Top(top) => top.pixels(output_resolution.height as u32),
+        VerticalPosition::Bottom(bottom) => {
             output_resolution.height as i32
                 - (input_resolution.height as f32 * layout.scale) as i32
                 - bottom.pixels(output_resolution.height as u32)
         }
-        _ => {
-            error!("Invalid specs in fixed_position_layout: {:?}", layout);
-            0
-        }
     };
-    let left = match layout {
-        TextureLayout {
-            left: Some(left), ..
-        } => left.pixels(output_resolution.width as u32),
-        TextureLayout {
-            right: Some(right), ..
-        } => {
+    let left = match layout.horizontal_position {
+        HorizontalPosition::Left(left) => left.pixels(output_resolution.width as u32),
+        HorizontalPosition::Right(right) => {
             output_resolution.width as i32
                 - (input_resolution.width as f32 * layout.scale) as i32
                 - right.pixels(output_resolution.width as u32)
-        }
-        _ => {
-            error!("Invalid specs in fixed_position_layout: {:?}", layout);
-            0
         }
     };
 

--- a/src/types/into_node.rs
+++ b/src/types/into_node.rs
@@ -31,7 +31,7 @@ impl From<NodeSpec> for Node {
                 image_id: image_id.into(),
             }),
             scene::NodeParams::Transition(spec) => NodeParams::Transition(spec.into()),
-            scene::NodeParams::Builtin { transformation } => match transformation {
+            scene::NodeParams::Builtin(transformation) => match transformation {
                 scene::builtin_transformations::BuiltinSpec::TransformToResolution {
                     resolution,
                     strategy,
@@ -220,10 +220,24 @@ impl From<builtin_transformations::FixedPositionLayoutSpec> for FixedPositionLay
     fn from(spec: builtin_transformations::FixedPositionLayoutSpec) -> Self {
         fn from_texture_layout(layout: builtin_transformations::TextureLayout) -> TextureLayout {
             TextureLayout {
-                top: layout.top.map(Into::into),
-                bottom: layout.bottom.map(Into::into),
-                left: layout.left.map(Into::into),
-                right: layout.right.map(Into::into),
+                top: match layout.vertical_position {
+                    builtin_transformations::VerticalPosition::Top(top) => Some(top.into()),
+                    builtin_transformations::VerticalPosition::Bottom(_) => None,
+                },
+                bottom: match layout.vertical_position {
+                    builtin_transformations::VerticalPosition::Top(_) => None,
+                    builtin_transformations::VerticalPosition::Bottom(bottom) => {
+                        Some(bottom.into())
+                    }
+                },
+                left: match layout.horizontal_position {
+                    builtin_transformations::HorizontalPosition::Left(left) => Some(left.into()),
+                    builtin_transformations::HorizontalPosition::Right(_) => None,
+                },
+                right: match layout.horizontal_position {
+                    builtin_transformations::HorizontalPosition::Left(_) => None,
+                    builtin_transformations::HorizontalPosition::Right(right) => Some(right.into()),
+                },
                 scale: Some(layout.scale),
                 rotation: Some(layout.rotation.into()),
             }


### PR DESCRIPTION
Follow up after adding type layer for http:
- remove unnecessary transformation field in Builtin transformation
- modify TextureLayout type to be more type safe