### PR TITLE
Synchronize shared memory resize

### DIFF
--- a/compositor_render/src/lib.rs
+++ b/compositor_render/src/lib.rs
@@ -15,8 +15,7 @@ pub use event_loop::EventLoop;
 pub use frame_set::FrameSet;
 
 pub use transformations::web_renderer::{
-    WebRendererOptions, EMBED_SOURCE_FRAMES_MESSAGE, GET_FRAME_POSITIONS_MESSAGE,
-    UNEMBED_SOURCE_FRAMES_MESSAGE,
+    WebRendererOptions, EMBED_SOURCES_MESSAGE, GET_FRAME_POSITIONS_MESSAGE, UNEMBED_SOURCE_MESSAGE,
 };
 
 pub type Renderer = sync_renderer::SyncRenderer;

--- a/compositor_render/src/transformations/web_renderer.rs
+++ b/compositor_render/src/transformations/web_renderer.rs
@@ -22,13 +22,12 @@ use log::{error, info};
 pub mod browser_client;
 pub mod chromium_context;
 mod chromium_sender;
-mod chromium_sender_thread;
 mod embedder;
 pub(crate) mod node;
 mod shared_memory;
 
-pub const EMBED_SOURCE_FRAMES_MESSAGE: &str = "EMBED_SOURCE_FRAMES";
-pub const UNEMBED_SOURCE_FRAMES_MESSAGE: &str = "UNEMBED_SOURCE_FRAMES";
+pub const EMBED_SOURCES_MESSAGE: &str = "EMBED_SOURCES";
+pub const UNEMBED_SOURCE_MESSAGE: &str = "UNEMBED_SOURCE";
 pub const GET_FRAME_POSITIONS_MESSAGE: &str = "GET_FRAME_POSITIONS";
 
 pub(super) type FrameData = Arc<Mutex<Bytes>>;

--- a/compositor_render/src/transformations/web_renderer/chromium_sender/chromium_sender_thread.rs
+++ b/compositor_render/src/transformations/web_renderer/chromium_sender/chromium_sender_thread.rs
@@ -1,6 +1,5 @@
-use std::path::PathBuf;
 use std::{
-    collections::HashMap,
+    path::PathBuf,
     sync::Arc,
     thread::{self, JoinHandle},
 };
@@ -11,25 +10,28 @@ use compositor_common::{
     scene::{NodeId, Resolution},
 };
 use crossbeam_channel::{Receiver, Sender};
-use log::error;
+use log::{error, warn};
 
-use crate::renderer::RegisterCtx;
 use crate::transformations::web_renderer::chromium_sender::{
     ChromiumSenderMessage, UpdateSharedMemoryInfo,
 };
 use crate::transformations::web_renderer::shared_memory::{SharedMemory, SharedMemoryError};
-use crate::transformations::web_renderer::WebRenderer;
 use crate::{
-    wgpu::texture::utils::pad_to_256, EMBED_SOURCE_FRAMES_MESSAGE, GET_FRAME_POSITIONS_MESSAGE,
+    renderer::RegisterCtx,
+    transformations::web_renderer::{
+        browser_client::BrowserClient, chromium_context::ChromiumContext,
+    },
 };
+use crate::{wgpu::texture::utils::pad_to_256, EMBED_SOURCES_MESSAGE, GET_FRAME_POSITIONS_MESSAGE};
 
-use super::{browser_client::BrowserClient, chromium_context::ChromiumContext};
+use super::thread_state::ThreadState;
 
 pub(super) struct ChromiumSenderThread {
     chromium_ctx: Arc<ChromiumContext>,
     url: String,
     browser_client: BrowserClient,
 
+    message_sender: Sender<ChromiumSenderMessage>,
     message_receiver: Receiver<ChromiumSenderMessage>,
     unmap_signal_sender: Sender<()>,
 }
@@ -38,14 +40,17 @@ impl ChromiumSenderThread {
     pub fn new(
         ctx: &RegisterCtx,
         url: String,
-        browser_client: BrowserClient,
-        message_receiver: Receiver<ChromiumSenderMessage>,
+        mut browser_client: BrowserClient,
         unmap_signal_sender: Sender<()>,
     ) -> Self {
+        let (message_sender, message_receiver) = crossbeam_channel::unbounded();
+        browser_client.set_chromium_thread_sender(message_sender.clone());
+
         Self {
             chromium_ctx: ctx.chromium.clone(),
             url,
             browser_client,
+            message_sender,
             message_receiver,
             unmap_signal_sender,
         }
@@ -53,6 +58,10 @@ impl ChromiumSenderThread {
 
     pub fn spawn(mut self) -> JoinHandle<()> {
         thread::spawn(move || self.run())
+    }
+
+    pub fn sender(&self) -> Sender<ChromiumSenderMessage> {
+        self.message_sender.clone()
     }
 
     fn run(&mut self) {
@@ -70,16 +79,18 @@ impl ChromiumSenderThread {
                 ChromiumSenderMessage::EmbedSources {
                     node_id,
                     resolutions,
-                } => self.embed_frames(&mut state, node_id, resolutions),
-                ChromiumSenderMessage::EnsureSharedMemory {
-                    node_id,
-                    resolutions,
-                } => self.ensure_shared_memory(&mut state, node_id, resolutions),
+                } => self.embed_frames(&state, node_id, resolutions),
+                ChromiumSenderMessage::EnsureSharedMemory { node_id, sizes } => {
+                    self.ensure_shared_memory(&mut state, node_id, sizes)
+                }
                 ChromiumSenderMessage::UpdateSharedMemory(info) => {
                     self.update_shared_memory(&mut state, info)
                 }
                 ChromiumSenderMessage::GetFramePositions { source_count } => {
                     self.get_frame_positions(&state, source_count)
+                }
+                ChromiumSenderMessage::FinalizePendingResize { shared_memory_path } => {
+                    self.finalize_pending_resize(&mut state, shared_memory_path)
                 }
             };
 
@@ -94,28 +105,35 @@ impl ChromiumSenderThread {
 
     fn embed_frames(
         &self,
-        state: &mut ThreadState,
+        state: &ThreadState,
         node_id: NodeId,
         resolutions: Vec<Option<Resolution>>,
     ) -> Result<(), ChromiumSenderThreadError> {
         let Some(shared_memory) = state.shared_memory.get(&node_id) else {
             return Err(ChromiumSenderThreadError::SharedMemoryNotAllocated(node_id));
         };
-        let mut process_message = cef::ProcessMessage::new(EMBED_SOURCE_FRAMES_MESSAGE);
+        let mut process_message = cef::ProcessMessage::new(EMBED_SOURCES_MESSAGE);
         let mut index = 0;
 
         // IPC message to chromium renderer subprocess consists of:
         // - shared memory path
+        // - input/source index
         // - texture width
         // - texture height
-        for (i, resolution) in resolutions.iter().enumerate() {
+        for (source_idx, resolution) in resolutions.iter().enumerate() {
+            let shared_memory = &shared_memory[source_idx];
+            if !state.is_shared_memory_accessible(shared_memory) {
+                continue;
+            }
             let Resolution { width, height } = resolution.unwrap_or_else(|| Resolution {
                 width: 0,
                 height: 0,
             });
-            process_message.write_string(index, shared_memory[i].to_path_string());
-            process_message.write_int(index + 1, width as i32);
-            process_message.write_int(index + 2, height as i32);
+
+            process_message.write_string(index, shared_memory.to_path_string());
+            process_message.write_int(index + 1, source_idx as i32);
+            process_message.write_int(index + 2, width as i32);
+            process_message.write_int(index + 3, height as i32);
 
             index += 3;
         }
@@ -130,48 +148,52 @@ impl ChromiumSenderThread {
         &self,
         state: &mut ThreadState,
         node_id: NodeId,
-        resolutions: Vec<Option<Resolution>>,
+        sizes: Vec<usize>,
     ) -> Result<(), ChromiumSenderThreadError> {
         if !state.shared_memory.contains_key(&node_id) {
-            state.shared_memory.insert(node_id.clone(), Vec::new());
+            state
+                .shared_memory
+                .insert(node_id.clone(), Vec::with_capacity(sizes.len()));
         }
 
-        let frame = state.browser.main_frame()?;
-        let shared_memory = state.shared_memory.get_mut(&node_id).unwrap();
-        for (source_idx, resolution) in resolutions.into_iter().enumerate() {
-            let size = match resolution {
-                Some(res) => 4 * res.width * res.height,
-                None => 1,
-            };
+        // Add missing shared_memory
+        {
+            let node_shared_memory = state.shared_memory.get_mut(&node_id).unwrap();
+            for (source_idx, size) in sizes.iter().enumerate().skip(node_shared_memory.len()) {
+                node_shared_memory.push(SharedMemory::new(
+                    &state.shared_memory_root_path,
+                    &node_id,
+                    source_idx,
+                    *size,
+                )?);
+            }
+        }
 
-            match shared_memory.get_mut(source_idx) {
-                Some(shmem) => {
-                    shmem.ensure_size(size, &frame)?;
-                }
-                None => {
-                    shared_memory.push(SharedMemory::new(
-                        &state.shared_memory_root_path,
-                        &node_id,
-                        source_idx,
-                        size,
-                    )?);
-                }
+        // Ensure existing shared memory
+        for (source_idx, size) in sizes.into_iter().enumerate() {
+            let shared_memory_len = state.shared_memory(&node_id, source_idx)?.len();
+            if shared_memory_len != size {
+                state.request_shared_memory_resize(&node_id, source_idx, size)?;
             }
         }
 
         Ok(())
     }
 
-    // TODO: Synchronize shared memory access
     fn update_shared_memory(
         &self,
         state: &mut ThreadState,
         info: UpdateSharedMemoryInfo,
     ) -> Result<(), ChromiumSenderThreadError> {
         let shared_memory = state.shared_memory(&info.node_id, info.source_idx)?;
+        if !state.is_shared_memory_accessible(shared_memory) {
+            self.unmap_signal_sender.send(()).unwrap();
+            return Ok(());
+        }
 
         // Writes buffer data to shared memory
         {
+            let shared_memory = state.shared_memory_mut(&info.node_id, info.source_idx)?;
             let range = info.buffer.slice(..).get_mapped_range();
             let chunks = range.chunks((4 * pad_to_256(info.size.width)) as usize);
             for (i, chunk) in chunks.enumerate() {
@@ -197,42 +219,27 @@ impl ChromiumSenderThread {
 
         Ok(())
     }
-}
 
-struct ThreadState {
-    browser: cef::Browser,
-    shared_memory: HashMap<NodeId, Vec<SharedMemory>>,
-    shared_memory_root_path: PathBuf,
-}
+    fn finalize_pending_resize(
+        &self,
+        state: &mut ThreadState,
+        shared_memory_path: PathBuf,
+    ) -> Result<(), ChromiumSenderThreadError> {
+        let Some(pending_resize) = state.pending_resizes.remove(&shared_memory_path) else {
+            warn!("There is no pending resize for \"{shared_memory_path:?}\"");
+            return Ok(());
+        };
 
-impl ThreadState {
-    fn new(browser: cef::Browser, renderer_id: &str) -> Self {
-        let shared_memory_root_path = WebRenderer::shared_memory_root_path(renderer_id);
-        let shared_memory = HashMap::new();
+        let shared_memory =
+            state.shared_memory_mut(&pending_resize.node_id, pending_resize.source_idx)?;
+        shared_memory.resize(pending_resize.new_size)?;
 
-        Self {
-            browser,
-            shared_memory,
-            shared_memory_root_path,
-        }
-    }
-
-    fn shared_memory(
-        &mut self,
-        node_id: &NodeId,
-        source_idx: usize,
-    ) -> Result<&mut SharedMemory, ChromiumSenderThreadError> {
-        let node_shared_memory = self
-            .shared_memory
-            .get_mut(node_id)
-            .ok_or_else(|| ChromiumSenderThreadError::SharedMemoryNotAllocated(node_id.clone()))?;
-
-        Ok(&mut node_shared_memory[source_idx])
+        Ok(())
     }
 }
 
 #[derive(Debug, thiserror::Error)]
-enum ChromiumSenderThreadError {
+pub enum ChromiumSenderThreadError {
     #[error("Browser is no longer alive")]
     BrowserNotAlive(#[from] cef::BrowserError),
 

--- a/compositor_render/src/transformations/web_renderer/chromium_sender/thread_state.rs
+++ b/compositor_render/src/transformations/web_renderer/chromium_sender/thread_state.rs
@@ -1,0 +1,98 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use compositor_chromium::cef;
+use compositor_common::scene::NodeId;
+
+use crate::{
+    transformations::web_renderer::{shared_memory::SharedMemory, WebRenderer},
+    UNEMBED_SOURCE_MESSAGE,
+};
+
+use super::chromium_sender_thread::ChromiumSenderThreadError;
+
+pub(super) struct ThreadState {
+    pub browser: cef::Browser,
+    pub shared_memory: HashMap<NodeId, Vec<SharedMemory>>,
+    pub shared_memory_root_path: PathBuf,
+    pub pending_resizes: HashMap<PathBuf, PendingResize>,
+}
+
+impl ThreadState {
+    pub fn new(browser: cef::Browser, renderer_id: &str) -> Self {
+        let shared_memory_root_path = WebRenderer::shared_memory_root_path(renderer_id);
+        let shared_memory = HashMap::new();
+        let pending_resizes = HashMap::new();
+
+        Self {
+            browser,
+            shared_memory,
+            shared_memory_root_path,
+            pending_resizes,
+        }
+    }
+
+    pub fn shared_memory(
+        &self,
+        node_id: &NodeId,
+        source_idx: usize,
+    ) -> Result<&SharedMemory, ChromiumSenderThreadError> {
+        let node_shared_memory = self
+            .shared_memory
+            .get(node_id)
+            .ok_or_else(|| ChromiumSenderThreadError::SharedMemoryNotAllocated(node_id.clone()))?;
+
+        Ok(&node_shared_memory[source_idx])
+    }
+
+    pub fn shared_memory_mut(
+        &mut self,
+        node_id: &NodeId,
+        source_idx: usize,
+    ) -> Result<&mut SharedMemory, ChromiumSenderThreadError> {
+        let node_shared_memory = self
+            .shared_memory
+            .get_mut(node_id)
+            .ok_or_else(|| ChromiumSenderThreadError::SharedMemoryNotAllocated(node_id.clone()))?;
+
+        Ok(&mut node_shared_memory[source_idx])
+    }
+
+    pub fn request_shared_memory_resize(
+        &mut self,
+        node_id: &NodeId,
+        source_idx: usize,
+        new_size: usize,
+    ) -> Result<(), ChromiumSenderThreadError> {
+        let shared_memory_path = self.shared_memory(node_id, source_idx)?.path().to_owned();
+        if let Some(pending_resize) = self.pending_resizes.get_mut(&shared_memory_path) {
+            pending_resize.new_size = new_size;
+            // UNEMBED_SOURCE request is already sent by the previous resize request
+            return Ok(());
+        }
+
+        self.pending_resizes.insert(
+            shared_memory_path.clone(),
+            PendingResize {
+                node_id: node_id.clone(),
+                source_idx,
+                new_size,
+            },
+        );
+        let frame = self.browser.main_frame()?;
+        let mut msg = cef::ProcessMessage::new(UNEMBED_SOURCE_MESSAGE);
+        msg.write_string(0, shared_memory_path.display().to_string());
+        frame.send_process_message(cef::ProcessId::Renderer, msg)?;
+
+        Ok(())
+    }
+
+    pub fn is_shared_memory_accessible(&self, shared_memory: &SharedMemory) -> bool {
+        !self.pending_resizes.contains_key(shared_memory.path())
+    }
+}
+
+pub(super) struct PendingResize {
+    pub node_id: NodeId,
+    pub source_idx: usize,
+    pub new_size: usize,
+}

--- a/compositor_render/src/transformations/web_renderer/render_website.wgsl
+++ b/compositor_render/src/transformations/web_renderer/render_website.wgsl
@@ -51,7 +51,6 @@ fn vs_main(input: VertexInput) -> VertexOutput {
 
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-
     let sample = textureSample(textures[input.texture_id], sampler_, input.tex_coords);
 
     if common_params.texture_count == 0u {

--- a/examples/web_renderer.rs
+++ b/examples/web_renderer.rs
@@ -110,6 +110,7 @@ fn start_example_client_code() -> Result<()> {
         "instance_id": "example_website",
         "url": format!("file://{file_path}"), // or other way of providing source
         "resolution": { "width": VIDEO_RESOLUTION.width, "height": VIDEO_RESOLUTION.height },
+        "embedding_method": "chromium_embedding",
         "constraints": [
             {
                 "type": "input_count",
@@ -122,20 +123,21 @@ fn start_example_client_code() -> Result<()> {
     info!("[example] Update scene");
     common::post(&json!({
         "type": "update_scene",
-        "nodes": [
-            {
-                "node_id": "embed_input_on_website",
-                "type": "web_renderer",
-                "instance_id": "example_website",
-                "input_pads": [
-                     "input_1",
-                 ]
-            }
-        ],
-        "outputs": [
+        "scenes": [
             {
                 "output_id": "output_1",
-                "input_pad": "embed_input_on_website"
+                "root": {
+                    "node_id": "embed_input_on_website",
+                    "type": "web_renderer",
+                    "instance_id": "example_website",
+                    "children": [
+                        {
+                            "node_id": "input_1",
+                            "type": "input_stream",
+                            "input_id": "input_1",
+                        },
+                    ]
+                }
             }
         ]
     }))?;
@@ -158,5 +160,6 @@ fn start_example_client_code() -> Result<()> {
             "rtp://127.0.0.1:8004?rtcpport=8004",
         ])
         .spawn()?;
+
     Ok(())
 }


### PR DESCRIPTION
Resizing step by step:
- `ChromiumSenderThread` creates a `PendingResize` and sends an unembed request to process helper
- Process helper unembeds the source (stops using the shared memory) and sends a confirmation to `BrowserClient`
- `BrowserClient` asks `ChromiumSenderThread` to finalize the resize
- `ChromiumSenderThread` resizes the shared memory

During the resize procedure, shared memory can't be accessed. 