### PR TITLE
Fix tests for new API + add `View` tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,16 +12,25 @@ concurrency:
 jobs:
     rust:
         runs-on: ubuntu-latest
+        container:
+            image: ubuntu:mantic-20231011
         steps:
             - name: 🛠 Install system dependencies
               run: |
                   set -e
 
-                  sudo apt-get update -y -qq
-                  sudo apt-get install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev ffmpeg libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev
+                  echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
+
+                  apt-get update -y -qq
+                  apt-get install -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev ffmpeg libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev ttf-mscorefonts-installer
+                
+                  # required when job is running in docker container                
+                  apt-get install -y build-essential curl pkg-config git libssl-dev libclang-dev libnss3 libatk1.0-0 libatk-bridge2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0
 
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
+              with:
+                  components: rustfmt, clippy
 
             - name: 🔬 Install nextest
               uses: taiki-e/install-action@v2
@@ -45,11 +54,19 @@ jobs:
             - name: 📎 Run clippy
               run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
-            - name: Generate JSON schema
+            - name: 📄 Generate JSON schema
               run: cargo run --bin generate_json_schema
 
             - name: 🧪 Run tests
               run: cargo nextest run --no-fail-fast --workspace
+
+            - name: 📦 Upload failed snapshot test artifacts
+              if: failure()
+              uses: actions/upload-artifact@v3
+              with:
+                  name: failed_snapshot_tests
+                  path: failed_snapshot_tests
+                  retention-days: 2
 
             - name: 📚 Run doctests
               run: cargo test --workspace --doc

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ target/
 
 # Generated during runtime
 /shmem
+/failed_snapshot_tests
 
 /video_compositor.app
 /video_compositor

--- a/compositor_render/src/scene/scene_state.rs
+++ b/compositor_render/src/scene/scene_state.rs
@@ -9,6 +9,7 @@ pub(crate) struct SceneState {
     outputs: Vec<OutputScene>,
 }
 
+#[derive(Debug, Clone)]
 pub struct OutputScene {
     pub output_id: OutputId,
     pub root: Component,

--- a/snapshot_tests/simple_input_pass_through.scene.json
+++ b/snapshot_tests/simple_input_pass_through.scene.json
@@ -1,9 +1,12 @@
 {
-    "nodes": [],
-    "outputs": [
-        {
-            "output_id": "output_1",
-            "input_pad": "input_1"
-        }
-    ]
+    "output_id": "output_1",
+    "root": {
+        "type": "view",
+        "children": [
+            {
+                "type": "input_stream",
+                "input_id": "input_1"
+            }
+        ]
+    }
 }

--- a/snapshot_tests/view/constant_width_and_height_views_row.scene.json
+++ b/snapshot_tests/view/constant_width_and_height_views_row.scene.json
@@ -1,0 +1,26 @@
+{
+    "output_id": "output_1",
+    "root": {
+        "type": "view",
+        "children": [
+            {
+                "type": "view",
+                "width": 200,
+                "height": 300,
+                "background_color_rgba": "#FF0000FF"
+            },
+            {
+                "type": "view",
+                "width": 200,
+                "height": 200,
+                "background_color_rgba": "#00FF00FF"
+            },
+            {
+                "type": "view",
+                "width": 200,
+                "height": 300,
+                "background_color_rgba": "#0000FFFF"
+            }
+        ]
+    }
+}

--- a/snapshot_tests/view/constant_width_views_row.scene.json
+++ b/snapshot_tests/view/constant_width_views_row.scene.json
@@ -1,0 +1,23 @@
+{
+    "output_id": "output_1",
+    "root": {
+        "type": "view",
+        "children": [
+            {
+                "type": "view",
+                "width": 200,
+                "background_color_rgba": "#FF0000FF"
+            },
+            {
+                "type": "view",
+                "width": 200,
+                "background_color_rgba": "#00FF00FF"
+            },
+            {
+                "type": "view",
+                "width": 200,
+                "background_color_rgba": "#0000FFFF"
+            }
+        ]
+    }
+}

--- a/snapshot_tests/view/constant_width_views_row_with_overflow.scene.json
+++ b/snapshot_tests/view/constant_width_views_row_with_overflow.scene.json
@@ -1,0 +1,23 @@
+{
+    "output_id": "output_1",
+    "root": {
+        "type": "view",
+        "children": [
+            {
+                "type": "view",
+                "width": 300,
+                "background_color_rgba": "#FF0000FF"
+            },
+            {
+                "type": "view",
+                "width": 300,
+                "background_color_rgba": "#00FF00FF"
+            },
+            {
+                "type": "view",
+                "width": 300,
+                "background_color_rgba": "#0000FFFF"
+            }
+        ]
+    }
+}

--- a/snapshot_tests/view/dynamic_and_constant_width_views_row.scene.json
+++ b/snapshot_tests/view/dynamic_and_constant_width_views_row.scene.json
@@ -1,0 +1,22 @@
+{
+    "output_id": "output_1",
+    "root": {
+        "type": "view",
+        "children": [
+            {
+                "type": "view",
+                "background_color_rgba": "#FF0000FF"
+            },
+            {
+                "type": "view",
+                "width": 100,
+                "background_color_rgba": "#00FF00FF"
+            },
+            {
+                "type": "view",
+                "width": 100,
+                "background_color_rgba": "#0000FFFF"
+            }
+        ]
+    }
+}

--- a/snapshot_tests/view/dynamic_and_constant_width_views_row_with_overflow.scene.json
+++ b/snapshot_tests/view/dynamic_and_constant_width_views_row_with_overflow.scene.json
@@ -1,0 +1,22 @@
+{
+    "output_id": "output_1",
+    "root": {
+        "type": "view",
+        "children": [
+            {
+                "type": "view",
+                "background_color_rgba": "#FF0000FF"
+            },
+            {
+                "type": "view",
+                "width": 400,
+                "background_color_rgba": "#00FF00FF"
+            },
+            {
+                "type": "view",
+                "width": 400,
+                "background_color_rgba": "#0000FFFF"
+            }
+        ]
+    }
+}

--- a/snapshot_tests/view/dynamic_width_views_row.scene.json
+++ b/snapshot_tests/view/dynamic_width_views_row.scene.json
@@ -1,0 +1,20 @@
+{
+    "output_id": "output_1",
+    "root": {
+        "type": "view",
+        "children": [
+            {
+                "type": "view",
+                "background_color_rgba": "#FF0000FF"
+            },
+            {
+                "type": "view",
+                "background_color_rgba": "#00FF00FF"
+            },
+            {
+                "type": "view",
+                "background_color_rgba": "#0000FFFF"
+            }
+        ]
+    }
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -7,6 +7,7 @@ use compositor_pipeline::{
 use compositor_render::{EventLoop, RegistryType};
 use crossbeam_channel::{bounded, Receiver};
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tiny_http::StatusCode;
 
@@ -33,7 +34,7 @@ pub enum Request {
     Start,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, JsonSchema)]
 pub struct UpdateScene {
     pub scenes: Vec<types::OutputScene>,
 }

--- a/src/bin/update_snapshots/main.rs
+++ b/src/bin/update_snapshots/main.rs
@@ -1,72 +1,78 @@
-//use std::{collections::HashSet, fs, io};
-//
-//#[path = "../../snapshot_tests/tests.rs"]
-//mod tests;
-//
-//#[allow(dead_code)]
-//#[path = "../../snapshot_tests/utils.rs"]
-//mod utils;
-//
-//#[path = "../../snapshot_tests/test_case.rs"]
-//mod test_case;
-//
-//use tests::snapshot_tests;
-//
-//use crate::{
-//    test_case::TestCase,
-//    utils::{find_unused_snapshots, snapshots_path},
-//};
-//
-//fn main() {
-//    println!("Updating snapshots:");
-//
-//    let test_cases = snapshot_tests();
-//    for snapshot_test in test_cases.iter() {
-//        let snapshots = snapshot_test.generate_snapshots().unwrap();
-//        let was_test_successful = snapshot_test.test_snapshots(&snapshots).is_ok();
-//        if was_test_successful {
-//            println!("PASS: \"{}\"", snapshot_test.name);
-//            continue;
-//        } else {
-//            println!("UPDATE: \"{}\"", snapshot_test.name);
-//        }
-//
-//        for snapshot in snapshots {
-//            let snapshot_path = snapshot.save_path();
-//
-//            if let Err(err) = fs::remove_file(&snapshot_path) {
-//                if err.kind() != io::ErrorKind::NotFound {
-//                    panic!("Failed to remove old snapshots: {err}");
-//                }
-//            }
-//            let parent_folder = snapshot_path.parent().unwrap();
-//            if !parent_folder.exists() {
-//                fs::create_dir_all(parent_folder).unwrap();
-//            }
-//
-//            let width = snapshot.resolution.width - (snapshot.resolution.width % 2);
-//            let height = snapshot.resolution.height - (snapshot.resolution.height % 2);
-//            image::save_buffer(
-//                snapshot_path,
-//                &snapshot.data,
-//                width as u32,
-//                height as u32,
-//                image::ColorType::Rgba8,
-//            )
-//            .unwrap();
-//        }
-//    }
-//
-//    // Check for unused snapshots
-//    let snapshot_paths = test_cases
-//        .iter()
-//        .flat_map(TestCase::snapshot_paths)
-//        .collect::<HashSet<_>>();
-//    for path in find_unused_snapshots(&snapshot_paths, snapshots_path()) {
-//        println!("Removed unused snapshot {path:?}");
-//        fs::remove_file(path).unwrap();
-//    }
-//
-//    println!("Update finished");
-//}
-fn main() {}
+use std::{collections::HashSet, fs, io};
+
+#[path = "../../snapshot_tests/tests.rs"]
+mod tests;
+
+#[allow(dead_code)]
+#[path = "../../snapshot_tests/utils.rs"]
+mod utils;
+
+#[path = "../../snapshot_tests/test_case.rs"]
+mod test_case;
+
+use tests::snapshot_tests;
+
+use crate::{
+    test_case::TestCaseInstance,
+    utils::{find_unused_snapshots, snapshots_path},
+};
+
+fn main() {
+    println!("Updating snapshots:");
+
+    let test: Vec<_> = snapshot_tests()
+        .into_iter()
+        .map(TestCaseInstance::new)
+        .collect();
+    for test in test.iter() {
+        for pts in &test.case.timestamps {
+            let (snapshots, Err(_)) = test.test_snapshots_for_pts(*pts) else {
+                println!("PASS: \"{}\" (pts: {}ms)", test.case.name, pts.as_millis());
+                continue;
+            };
+
+            println!(
+                "UPDATE: \"{}\" (pts: {}ms)",
+                test.case.name,
+                pts.as_millis()
+            );
+
+            for snapshot in snapshots {
+                let snapshot_path = snapshot.save_path();
+
+                if let Err(err) = fs::remove_file(&snapshot_path) {
+                    if err.kind() != io::ErrorKind::NotFound {
+                        panic!("Failed to remove old snapshots: {err}");
+                    }
+                }
+                let parent_folder = snapshot_path.parent().unwrap();
+                if !parent_folder.exists() {
+                    fs::create_dir_all(parent_folder).unwrap();
+                }
+
+                let width = snapshot.resolution.width - (snapshot.resolution.width % 2);
+                let height = snapshot.resolution.height - (snapshot.resolution.height % 2);
+                image::save_buffer(
+                    snapshot_path,
+                    &snapshot.data,
+                    width as u32,
+                    height as u32,
+                    image::ColorType::Rgba8,
+                )
+                .unwrap();
+            }
+        }
+    }
+
+    // Check for unused snapshots
+    let snapshot_paths = test
+        .iter()
+        .flat_map(TestCaseInstance::snapshot_paths)
+        .collect::<HashSet<_>>();
+    for path in find_unused_snapshots(&snapshot_paths, snapshots_path()) {
+        println!("Removed unused snapshot {path:?}");
+        fs::remove_file(path).unwrap();
+    }
+
+    println!("Update finished");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,8 @@ mod rtp_receiver;
 mod rtp_sender;
 mod types;
 
-// TODO enbale it back
-//#[cfg(test)]
-//mod snapshot_tests;
+#[cfg(test)]
+mod snapshot_tests;
 
 fn main() {
     env_logger::init_from_env(

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -1,7 +1,11 @@
-use std::{collections::HashSet, env};
+use std::{collections::HashSet, env, fs, path::PathBuf};
+
+use anyhow::Error;
+
+use crate::snapshot_tests::test_case::TestCase;
 
 use self::{
-    test_case::Snapshot,
+    test_case::TestCaseError,
     tests::snapshot_tests,
     utils::{find_unused_snapshots, snapshots_path},
 };
@@ -12,22 +16,66 @@ mod utils;
 
 #[test]
 fn test_snapshots() {
-    if env::var("CI").is_ok() {
-        return;
+    let failed_snapshot_path = failed_snapshot_path();
+    if failed_snapshot_path.exists() {
+        fs::remove_dir_all(failed_snapshot_path).unwrap();
     }
 
-    let mut produced_snapshots = HashSet::new();
-    for snapshot_test in snapshot_tests() {
-        eprintln!("Test \"{}\"", snapshot_test.name);
-        let snapshots = snapshot_test.generate_snapshots().unwrap();
-        match snapshot_test.test_snapshots(&snapshots) {
-            Ok(_) => produced_snapshots.extend(snapshots.iter().map(Snapshot::save_path)),
-            Err(err) => panic!("{err}"),
+    let test_cases = snapshot_tests();
+    for test_case in test_cases.iter() {
+        eprintln!("Test \"{}\"", test_case.name);
+        let snapshots = test_case.generate_snapshots().unwrap();
+        if let Err(err) = test_case.test_snapshots(&snapshots) {
+            handle_error(err);
         }
     }
 
-    let unused_snapshots = find_unused_snapshots(&produced_snapshots, snapshots_path());
+    // Check for unused snapshots
+    let snapshot_paths = test_cases
+        .iter()
+        .flat_map(TestCase::snapshot_paths)
+        .collect::<HashSet<_>>();
+    let unused_snapshots = find_unused_snapshots(&snapshot_paths, snapshots_path());
     if !unused_snapshots.is_empty() {
         panic!("Some snapshots were not used: {unused_snapshots:#?}")
     }
+}
+
+fn handle_error(err: Error) {
+    let test_case_err = err.downcast_ref::<TestCaseError>().unwrap();
+    let TestCaseError::Mismatch {
+        snapshot_from_disk,
+        produced_snapshot,
+    } = test_case_err
+    else {
+        panic!("{err}");
+    };
+
+    let failed_snapshot_path = failed_snapshot_path();
+    if !failed_snapshot_path.exists() {
+        fs::create_dir_all(&failed_snapshot_path).unwrap();
+    }
+    let snapshot_save_path = produced_snapshot.save_path();
+    let snapshot_name = snapshot_save_path.file_name().unwrap().to_string_lossy();
+
+    let width = produced_snapshot.resolution.width - (produced_snapshot.resolution.width % 2);
+    let height = produced_snapshot.resolution.height - (produced_snapshot.resolution.height % 2);
+    image::save_buffer(
+        failed_snapshot_path.join(format!("mismatched_{snapshot_name}")),
+        &produced_snapshot.data,
+        width as u32,
+        height as u32,
+        image::ColorType::Rgba8,
+    )
+    .unwrap();
+
+    snapshot_from_disk
+        .save(failed_snapshot_path.join(format!("original_{snapshot_name}")))
+        .unwrap();
+
+    panic!("{err}");
+}
+
+fn failed_snapshot_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("failed_snapshot_tests")
 }

--- a/src/snapshot_tests/test_case.rs
+++ b/src/snapshot_tests/test_case.rs
@@ -16,6 +16,7 @@ use compositor_common::{
     Frame,
 };
 use compositor_render::{FrameSet, Renderer};
+use image::ImageBuffer;
 use video_compositor::types::{RegisterRequest, Scene};
 
 pub struct TestCase {
@@ -25,6 +26,7 @@ pub struct TestCase {
     pub scene_json: &'static str,
     pub timestamps: Vec<Duration>,
     pub outputs: Vec<&'static str>,
+    pub allowed_error: f32,
 }
 
 impl Default for TestCase {
@@ -36,6 +38,7 @@ impl Default for TestCase {
             scene_json: "",
             timestamps: vec![Duration::from_secs(0)],
             outputs: vec!["output_1"],
+            allowed_error: 30.0,
         }
     }
 }
@@ -66,8 +69,12 @@ impl TestCase {
             }
 
             let snapshot_from_disk = image::open(&save_path)?.to_rgba8();
-            if !are_snapshots_near_equal(&snapshot_from_disk, &snapshot.data) {
-                return Err(TestCaseError::Mismatch(snapshot.clone()).into());
+            if !are_snapshots_near_equal(&snapshot_from_disk, &snapshot.data, self.allowed_error) {
+                return Err(TestCaseError::Mismatch {
+                    snapshot_from_disk,
+                    produced_snapshot: snapshot.clone(),
+                }
+                .into());
             }
         }
 
@@ -282,7 +289,10 @@ impl Snapshot {
 #[derive(Debug)]
 pub enum TestCaseError {
     SnapshotNotFound(Snapshot),
-    Mismatch(Snapshot),
+    Mismatch {
+        snapshot_from_disk: ImageBuffer<image::Rgba<u8>, Vec<u8>>,
+        produced_snapshot: Snapshot,
+    },
     OutputNotFound(&'static str),
     UnknownOutputs {
         expected: Vec<&'static str>,
@@ -301,19 +311,21 @@ impl Display for TestCaseError {
                 pts,
                 ..
             }) => format!(
-                "Test \"{}\": OutputId({}) & PTS({}). Snapshot file not found. Generate snapshots first",
+                "FAILED: \"{}\", OutputId({}), PTS({}). Snapshot file not found. Generate snapshots first",
                 test_name,
                 output_id,
                 pts.as_secs()
             ),
-            TestCaseError::Mismatch(Snapshot {
+            TestCaseError::Mismatch{produced_snapshot: Snapshot {
                 test_name,
                 output_id,
                 pts,
                 ..
-            }) => {
+            },
+            ..
+            } => {
                 format!(
-                    "Test \"{}\": OutputId({}) & PTS({}). Snapshots are different",
+                    "FAILED: \"{}\", OutputId({}), PTS({}). Snapshots are different",
                     test_name,
                     output_id,
                     pts.as_secs_f32()

--- a/src/snapshot_tests/tests.rs
+++ b/src/snapshot_tests/tests.rs
@@ -2,561 +2,639 @@ use compositor_common::scene::Resolution;
 
 use super::test_case::{TestCase, TestInput};
 
+const DEFAULT_RESOLUTION: Resolution = Resolution {
+    width: 640,
+    height: 360,
+};
+
 pub fn snapshot_tests() -> Vec<TestCase> {
     let mut tests = Vec::new();
-    tests.append(&mut text_snapshot_tests());
-    tests.append(&mut tiled_layout_tests());
+    tests.append(&mut base_snapshot_tests());
+    tests.append(&mut view_snapshot_tests());
+    // tests.append(&mut text_snapshot_tests());
+    // tests.append(&mut tiled_layout_tests());
     // tests.append(&mut stretch_to_resolution_tests());
-    tests.append(&mut fill_to_resolution_tests());
-    tests.append(&mut fit_to_resolution_tests());
-    tests.append(&mut fixed_position_layout_tests());
-    tests.append(&mut corners_rounding_tests());
-    tests.append(&mut mirror_image());
+    // tests.append(&mut fill_to_resolution_tests());
+    // tests.append(&mut fit_to_resolution_tests());
+    // tests.append(&mut fixed_position_layout_tests());
+    // tests.append(&mut corners_rounding_tests());
+    // tests.append(&mut mirror_image());
     tests
 }
 
-fn mirror_image() -> Vec<TestCase> {
-    let image_renderer = include_str!("../../snapshot_tests/register/image_jpeg.register.json");
+//fn mirror_image() -> Vec<TestCase> {
+//    let image_renderer = include_str!("../../snapshot_tests/register/image_jpeg.register.json");
+//
+//    Vec::from([
+//        TestCase {
+//            name: "mirror_image/vertical",
+//            scene_json: include_str!("../../snapshot_tests/mirror_image/vertical.scene.json"),
+//            renderers: vec![image_renderer],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "mirror_image/horizontal",
+//            scene_json: include_str!("../../snapshot_tests/mirror_image/horizontal.scene.json"),
+//            renderers: vec![image_renderer],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "mirror_image/horizontal-vertical",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/mirror_image/horizontal_and_vertical.scene.json"
+//            ),
+//            renderers: vec![image_renderer],
+//            ..Default::default()
+//        },
+//    ])
+//}
+//
+//fn corners_rounding_tests() -> Vec<TestCase> {
+//    let input1 = TestInput::new(1);
+//    Vec::from([
+//        TestCase {
+//            name: "corners_rounding/border_radius_50px",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/corners_rounding/border_radius_50px.scene.json"
+//            ),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "corners_rounding/border_radius_5px",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/corners_rounding/border_radius_5px.scene.json"
+//            ),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//    ])
+//}
+//
+//fn fixed_position_layout_tests() -> Vec<TestCase> {
+//    let input1 = TestInput::new(1);
+//
+//    Vec::from([
+//        TestCase {
+//            name: "fixed_position_layout/top_right_corner",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/fixed_position_layout/top_right_corner.scene.json"
+//            ),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "fixed_position_layout/rotation_30_degree",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/fixed_position_layout/rotation_30_degree.scene.json"
+//            ),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "fixed_position_layout/rotation_multiple_loops",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/fixed_position_layout/rotation_multiple_loops.scene.json"
+//            ),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "fixed_position_layout/overlapping_inputs",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/fixed_position_layout/overlapping_inputs.scene.json"
+//            ),
+//            inputs: vec![
+//                input1.clone(),
+//                TestInput::new(2),
+//                TestInput::new(3),
+//                TestInput::new(4),
+//            ],
+//            ..Default::default()
+//        },
+//        // TODO: fix stretch to resolution
+//        //TestCase {
+//        //    name: "fixed_position_layout/scale_2x",
+//        //    scene_json: include_str!(
+//        //        "../../snapshot_tests/fixed_position_layout/scale_2x.scene.json"
+//        //    ),
+//        //    inputs: vec![input1.clone()],
+//        //    ..Default::default()
+//        //},
+//        //TestCase {
+//        //    name: "fixed_position_layout/scale_0_5x",
+//        //    scene_json: include_str!(
+//        //        "../../snapshot_tests/fixed_position_layout/scale_0_5x.scene.json"
+//        //    ),
+//        //    inputs: vec![input1.clone()],
+//        //    ..Default::default()
+//        //},
+//    ])
+//}
+//
+//pub fn fit_to_resolution_tests() -> Vec<TestCase> {
+//    let input1 = TestInput::new(1);
+//    Vec::from([
+//        TestCase {
+//            name: "fit_to_resolution/narrow_column",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/fit_to_resolution/narrow_column.scene.json"
+//            ),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "fit_to_resolution/wide_row",
+//            scene_json: include_str!("../../snapshot_tests/fit_to_resolution/wide_row.scene.json"),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "fit_to_resolution/green_background",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/fit_to_resolution/green_background.scene.json"
+//            ),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "fit_to_resolution/vertical_align_top",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/fit_to_resolution/vertical_align_top.scene.json"
+//            ),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "fit_to_resolution/horizontal_align_right",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/fit_to_resolution/horizontal_align_right.scene.json"
+//            ),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//    ])
+//}
+//
+//pub fn fill_to_resolution_tests() -> Vec<TestCase> {
+//    let input1 = TestInput::new(1);
+//    Vec::from([
+//        TestCase {
+//            name: "fill_to_resolution/narrow_column",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/fill_to_resolution/narrow_column.scene.json"
+//            ),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "fill_to_resolution/wide_row",
+//            scene_json: include_str!("../../snapshot_tests/fill_to_resolution/wide_row.scene.json"),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//    ])
+//}
+//
+//#[allow(dead_code)]
+//pub fn stretch_to_resolution_tests() -> Vec<TestCase> {
+//    let input1 = TestInput::new(1);
+//    Vec::from([
+//        TestCase {
+//            name: "stretch_to_resolution/narrow_column",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/stretch_to_resolution/narrow_column.scene.json"
+//            ),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "stretch_to_resolution/wide_row",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/stretch_to_resolution/wide_row.scene.json"
+//            ),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//    ])
+//}
+//
+//pub fn tiled_layout_tests() -> Vec<TestCase> {
+//    let input1 = TestInput::new(1);
+//    let input2 = TestInput::new(2);
+//    let input3 = TestInput::new(3);
+//    let input4 = TestInput::new(4);
+//    let input5 = TestInput::new(5);
+//    let input6 = TestInput::new(6);
+//    let input7 = TestInput::new(7);
+//    let input8 = TestInput::new(8);
+//    let input9 = TestInput::new(9);
+//    let input10 = TestInput::new(10);
+//    let input11 = TestInput::new(11);
+//    let input12 = TestInput::new(12);
+//    let input13 = TestInput::new(13);
+//    let input14 = TestInput::new(14);
+//    let input15 = TestInput::new(15);
+//    let portrait_resolution = Resolution {
+//        width: 360,
+//        height: 640,
+//    };
+//    let portrait_input1 = TestInput::new_with_resolution(1, portrait_resolution);
+//    let portrait_input2 = TestInput::new_with_resolution(2, portrait_resolution);
+//    let portrait_input3 = TestInput::new_with_resolution(3, portrait_resolution);
+//    let portrait_input4 = TestInput::new_with_resolution(4, portrait_resolution);
+//    let portrait_input5 = TestInput::new_with_resolution(5, portrait_resolution);
+//    let portrait_input6 = TestInput::new_with_resolution(6, portrait_resolution);
+//    let portrait_input7 = TestInput::new_with_resolution(7, portrait_resolution);
+//    let portrait_input8 = TestInput::new_with_resolution(8, portrait_resolution);
+//    let portrait_input9 = TestInput::new_with_resolution(9, portrait_resolution);
+//    let portrait_input10 = TestInput::new_with_resolution(10, portrait_resolution);
+//    let portrait_input11 = TestInput::new_with_resolution(11, portrait_resolution);
+//    let portrait_input12 = TestInput::new_with_resolution(12, portrait_resolution);
+//    let portrait_input13 = TestInput::new_with_resolution(13, portrait_resolution);
+//    let portrait_input14 = TestInput::new_with_resolution(14, portrait_resolution);
+//    let portrait_input15 = TestInput::new_with_resolution(15, portrait_resolution);
+//    Vec::from([
+//        TestCase {
+//            name: "tiled_layout/01_inputs",
+//            scene_json: include_str!("../../snapshot_tests/tiled_layout/01_inputs.scene.json"),
+//            inputs: vec![input1.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/02_inputs",
+//            scene_json: include_str!("../../snapshot_tests/tiled_layout/02_inputs.scene.json"),
+//            inputs: vec![input1.clone(), input2.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/03_inputs",
+//            scene_json: include_str!("../../snapshot_tests/tiled_layout/03_inputs.scene.json"),
+//            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/04_inputs",
+//            scene_json: include_str!("../../snapshot_tests/tiled_layout/04_inputs.scene.json"),
+//            inputs: vec![
+//                input1.clone(),
+//                input2.clone(),
+//                input3.clone(),
+//                input4.clone(),
+//            ],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/05_inputs",
+//            scene_json: include_str!("../../snapshot_tests/tiled_layout/05_inputs.scene.json"),
+//            inputs: vec![
+//                input1.clone(),
+//                input2.clone(),
+//                input3.clone(),
+//                input4.clone(),
+//                input5.clone(),
+//            ],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/15_inputs",
+//            scene_json: include_str!("../../snapshot_tests/tiled_layout/15_inputs.scene.json"),
+//            inputs: vec![
+//                input1.clone(),
+//                input2.clone(),
+//                input3.clone(),
+//                input4.clone(),
+//                input5.clone(),
+//                input6.clone(),
+//                input7.clone(),
+//                input8.clone(),
+//                input9.clone(),
+//                input10.clone(),
+//                input11.clone(),
+//                input12.clone(),
+//                input13.clone(),
+//                input14.clone(),
+//                input15.clone(),
+//            ],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/01_portrait_inputs",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/01_portrait_inputs.scene.json"
+//            ),
+//            inputs: vec![portrait_input1.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/02_portrait_inputs",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/02_portrait_inputs.scene.json"
+//            ),
+//            inputs: vec![portrait_input1.clone(), portrait_input2.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/03_portrait_inputs",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/03_portrait_inputs.scene.json"
+//            ),
+//            inputs: vec![
+//                portrait_input1.clone(),
+//                portrait_input2.clone(),
+//                portrait_input3.clone(),
+//            ],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/05_portrait_inputs",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/05_portrait_inputs.scene.json"
+//            ),
+//            inputs: vec![
+//                portrait_input1.clone(),
+//                portrait_input2.clone(),
+//                portrait_input3.clone(),
+//                portrait_input4.clone(),
+//                portrait_input5.clone(),
+//            ],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/15_portrait_inputs",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/15_portrait_inputs.scene.json"
+//            ),
+//            inputs: vec![
+//                portrait_input1.clone(),
+//                portrait_input2.clone(),
+//                portrait_input3.clone(),
+//                portrait_input4.clone(),
+//                portrait_input5.clone(),
+//                portrait_input6.clone(),
+//                portrait_input7.clone(),
+//                portrait_input8.clone(),
+//                portrait_input9.clone(),
+//                portrait_input10.clone(),
+//                portrait_input11.clone(),
+//                portrait_input12.clone(),
+//                portrait_input13.clone(),
+//                portrait_input14.clone(),
+//                portrait_input15.clone(),
+//            ],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/01_inputs_on_portrait_output",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/01_inputs_on_portrait_output.scene.json"
+//            ),
+//            inputs: vec![portrait_input1.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/03_inputs_on_portrait_output",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/03_inputs_on_portrait_output.scene.json"
+//            ),
+//            inputs: vec![
+//                portrait_input1.clone(),
+//                portrait_input2.clone(),
+//                portrait_input3.clone(),
+//            ],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/05_portrait_inputs_on_portrait_output",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/05_portrait_inputs_on_portrait_output.scene.json"
+//            ),
+//            inputs: vec![
+//                portrait_input1.clone(),
+//                portrait_input2.clone(),
+//                portrait_input3.clone(),
+//                portrait_input4.clone(),
+//                portrait_input5.clone(),
+//            ],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/15_portrait_inputs_on_portrait_output",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/15_portrait_inputs_on_portrait_output.scene.json"
+//            ),
+//            inputs: vec![
+//                portrait_input1.clone(),
+//                portrait_input2.clone(),
+//                portrait_input3.clone(),
+//                portrait_input4.clone(),
+//                portrait_input5.clone(),
+//                portrait_input6.clone(),
+//                portrait_input7.clone(),
+//                portrait_input8.clone(),
+//                portrait_input9.clone(),
+//                portrait_input10.clone(),
+//                portrait_input11.clone(),
+//                portrait_input12.clone(),
+//                portrait_input13.clone(),
+//                portrait_input14.clone(),
+//                portrait_input15.clone(),
+//            ],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/align_center_with_03_inputs",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/align_center_with_03_inputs.scene.json"
+//            ),
+//            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/align_top_left_with_03_inputs",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/align_top_left_with_03_inputs.scene.json"
+//            ),
+//            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/align_with_margin_and_padding_with_03_inputs",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/align_with_margin_and_padding_with_03_inputs.scene.json"
+//            ),
+//            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/margin_with_03_inputs",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/margin_with_03_inputs.scene.json"
+//            ),
+//            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/margin_and_padding_with_03_inputs",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/margin_and_padding_with_03_inputs.scene.json"
+//            ),
+//            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "tiled_layout/padding_with_03_inputs",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/tiled_layout/padding_with_03_inputs.scene.json"
+//            ),
+//            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
+//            ..Default::default()
+//        },
+//    ])
+//}
+//
+//pub fn text_snapshot_tests() -> Vec<TestCase> {
+//    Vec::from([
+//        TestCase {
+//            name: "text/align_center",
+//            scene_json: include_str!("../../snapshot_tests/text/align_center.scene.json"),
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "text/align_right",
+//            scene_json: include_str!("../../snapshot_tests/text/align_right.scene.json"),
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "text/bold_text",
+//            scene_json: include_str!("../../snapshot_tests/text/bold_text.scene.json"),
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "text/dimensions_fitted_column_with_long_text",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/text/dimensions_fitted_column_with_long_text.scene.json"
+//            ),
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "text/dimensions_fitted_column_with_short_text",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/text/dimensions_fitted_column_with_short_text.scene.json"
+//            ),
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "text/dimensions_fitted",
+//            scene_json: include_str!("../../snapshot_tests/text/dimensions_fitted.scene.json"),
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "text/dimensions_fixed",
+//            scene_json: include_str!("../../snapshot_tests/text/dimensions_fixed.scene.json"),
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "text/dimensions_fixed_with_overflow",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/text/dimensions_fixed_with_overflow.scene.json"
+//            ),
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "text/red_text_on_blue_background",
+//            scene_json: include_str!(
+//                "../../snapshot_tests/text/red_text_on_blue_background.scene.json"
+//            ),
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "text/wrap_glyph",
+//            scene_json: include_str!("../../snapshot_tests/text/wrap_glyph.scene.json"),
+//            allowed_error: 325.7,
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "text/wrap_none",
+//            scene_json: include_str!("../../snapshot_tests/text/wrap_none.scene.json"),
+//            ..Default::default()
+//        },
+//        TestCase {
+//            name: "text/wrap_word",
+//            scene_json: include_str!("../../snapshot_tests/text/wrap_word.scene.json"),
+//            allowed_error: 321.8,
+//            ..Default::default()
+//        },
+//    ])
+//}
 
+pub fn view_snapshot_tests() -> Vec<TestCase> {
     Vec::from([
         TestCase {
-            name: "mirror_image/vertical",
-            scene_json: include_str!("../../snapshot_tests/mirror_image/vertical.scene.json"),
-            renderers: vec![image_renderer],
+            name: "view/constant_width_views_row",
+            outputs: vec![(
+                include_str!("../../snapshot_tests/view/constant_width_views_row.scene.json"),
+                DEFAULT_RESOLUTION,
+            )],
+            inputs: vec![TestInput::new(1)],
             ..Default::default()
         },
         TestCase {
-            name: "mirror_image/horizontal",
-            scene_json: include_str!("../../snapshot_tests/mirror_image/horizontal.scene.json"),
-            renderers: vec![image_renderer],
+            name: "view/constant_width_views_row_with_overflow",
+            outputs: vec![(
+                include_str!("../../snapshot_tests/view/constant_width_views_row_with_overflow.scene.json"),
+                DEFAULT_RESOLUTION,
+            )],
+            inputs: vec![TestInput::new(1)],
             ..Default::default()
         },
         TestCase {
-            name: "mirror_image/horizontal-vertical",
-            scene_json: include_str!(
-                "../../snapshot_tests/mirror_image/horizontal_and_vertical.scene.json"
-            ),
-            renderers: vec![image_renderer],
+            name: "view/dynamic_width_views_row",
+            outputs: vec![(
+                include_str!("../../snapshot_tests/view/dynamic_width_views_row.scene.json"),
+                DEFAULT_RESOLUTION,
+            )],
+            inputs: vec![TestInput::new(1)],
             ..Default::default()
         },
+        TestCase {
+            name: "view/dynamic_and_constant_width_views_row",
+            outputs: vec![(
+                include_str!("../../snapshot_tests/view/dynamic_and_constant_width_views_row.scene.json"),
+                DEFAULT_RESOLUTION,
+            )],
+            inputs: vec![TestInput::new(1)],
+            ..Default::default()
+        },
+        TestCase {
+            name: "view/dynamic_and_constant_width_views_row_with_overflow",
+            outputs: vec![(
+                include_str!("../../snapshot_tests/view/dynamic_and_constant_width_views_row_with_overflow.scene.json"),
+                DEFAULT_RESOLUTION,
+            )],
+            inputs: vec![TestInput::new(1)],
+            ..Default::default()
+        },
+        TestCase {
+            name: "view/constant_width_and_height_views_row",
+            outputs: vec![(
+                include_str!("../../snapshot_tests/view/constant_width_and_height_views_row.scene.json"),
+                DEFAULT_RESOLUTION,
+            )],
+            inputs: vec![TestInput::new(1)],
+            ..Default::default()
+        }
     ])
 }
 
-fn corners_rounding_tests() -> Vec<TestCase> {
-    let input1 = TestInput::new(1);
-    Vec::from([
-        TestCase {
-            name: "corners_rounding/border_radius_50px",
-            scene_json: include_str!(
-                "../../snapshot_tests/corners_rounding/border_radius_50px.scene.json"
-            ),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "corners_rounding/border_radius_5px",
-            scene_json: include_str!(
-                "../../snapshot_tests/corners_rounding/border_radius_5px.scene.json"
-            ),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-    ])
-}
-
-fn fixed_position_layout_tests() -> Vec<TestCase> {
-    let input1 = TestInput::new(1);
-
-    Vec::from([
-        TestCase {
-            name: "fixed_position_layout/top_right_corner",
-            scene_json: include_str!(
-                "../../snapshot_tests/fixed_position_layout/top_right_corner.scene.json"
-            ),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "fixed_position_layout/rotation_30_degree",
-            scene_json: include_str!(
-                "../../snapshot_tests/fixed_position_layout/rotation_30_degree.scene.json"
-            ),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "fixed_position_layout/rotation_multiple_loops",
-            scene_json: include_str!(
-                "../../snapshot_tests/fixed_position_layout/rotation_multiple_loops.scene.json"
-            ),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "fixed_position_layout/overlapping_inputs",
-            scene_json: include_str!(
-                "../../snapshot_tests/fixed_position_layout/overlapping_inputs.scene.json"
-            ),
-            inputs: vec![
-                input1.clone(),
-                TestInput::new(2),
-                TestInput::new(3),
-                TestInput::new(4),
-            ],
-            ..Default::default()
-        },
-        // TODO: fix stretch to resolution
-        //TestCase {
-        //    name: "fixed_position_layout/scale_2x",
-        //    scene_json: include_str!(
-        //        "../../snapshot_tests/fixed_position_layout/scale_2x.scene.json"
-        //    ),
-        //    inputs: vec![input1.clone()],
-        //    ..Default::default()
-        //},
-        //TestCase {
-        //    name: "fixed_position_layout/scale_0_5x",
-        //    scene_json: include_str!(
-        //        "../../snapshot_tests/fixed_position_layout/scale_0_5x.scene.json"
-        //    ),
-        //    inputs: vec![input1.clone()],
-        //    ..Default::default()
-        //},
-    ])
-}
-
-pub fn fit_to_resolution_tests() -> Vec<TestCase> {
-    let input1 = TestInput::new(1);
-    Vec::from([
-        TestCase {
-            name: "fit_to_resolution/narrow_column",
-            scene_json: include_str!(
-                "../../snapshot_tests/fit_to_resolution/narrow_column.scene.json"
-            ),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "fit_to_resolution/wide_row",
-            scene_json: include_str!("../../snapshot_tests/fit_to_resolution/wide_row.scene.json"),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "fit_to_resolution/green_background",
-            scene_json: include_str!(
-                "../../snapshot_tests/fit_to_resolution/green_background.scene.json"
-            ),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "fit_to_resolution/vertical_align_top",
-            scene_json: include_str!(
-                "../../snapshot_tests/fit_to_resolution/vertical_align_top.scene.json"
-            ),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "fit_to_resolution/horizontal_align_right",
-            scene_json: include_str!(
-                "../../snapshot_tests/fit_to_resolution/horizontal_align_right.scene.json"
-            ),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-    ])
-}
-
-pub fn fill_to_resolution_tests() -> Vec<TestCase> {
-    let input1 = TestInput::new(1);
-    Vec::from([
-        TestCase {
-            name: "fill_to_resolution/narrow_column",
-            scene_json: include_str!(
-                "../../snapshot_tests/fill_to_resolution/narrow_column.scene.json"
-            ),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "fill_to_resolution/wide_row",
-            scene_json: include_str!("../../snapshot_tests/fill_to_resolution/wide_row.scene.json"),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-    ])
-}
-
-#[allow(dead_code)]
-pub fn stretch_to_resolution_tests() -> Vec<TestCase> {
-    let input1 = TestInput::new(1);
-    Vec::from([
-        TestCase {
-            name: "stretch_to_resolution/narrow_column",
-            scene_json: include_str!(
-                "../../snapshot_tests/stretch_to_resolution/narrow_column.scene.json"
-            ),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "stretch_to_resolution/wide_row",
-            scene_json: include_str!(
-                "../../snapshot_tests/stretch_to_resolution/wide_row.scene.json"
-            ),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-    ])
-}
-
-pub fn tiled_layout_tests() -> Vec<TestCase> {
-    let input1 = TestInput::new(1);
-    let input2 = TestInput::new(2);
-    let input3 = TestInput::new(3);
-    let input4 = TestInput::new(4);
-    let input5 = TestInput::new(5);
-    let input6 = TestInput::new(6);
-    let input7 = TestInput::new(7);
-    let input8 = TestInput::new(8);
-    let input9 = TestInput::new(9);
-    let input10 = TestInput::new(10);
-    let input11 = TestInput::new(11);
-    let input12 = TestInput::new(12);
-    let input13 = TestInput::new(13);
-    let input14 = TestInput::new(14);
-    let input15 = TestInput::new(15);
-    let portrait_resolution = Resolution {
-        width: 360,
-        height: 640,
-    };
-    let portrait_input1 = TestInput::new_with_resolution(1, portrait_resolution);
-    let portrait_input2 = TestInput::new_with_resolution(2, portrait_resolution);
-    let portrait_input3 = TestInput::new_with_resolution(3, portrait_resolution);
-    let portrait_input4 = TestInput::new_with_resolution(4, portrait_resolution);
-    let portrait_input5 = TestInput::new_with_resolution(5, portrait_resolution);
-    let portrait_input6 = TestInput::new_with_resolution(6, portrait_resolution);
-    let portrait_input7 = TestInput::new_with_resolution(7, portrait_resolution);
-    let portrait_input8 = TestInput::new_with_resolution(8, portrait_resolution);
-    let portrait_input9 = TestInput::new_with_resolution(9, portrait_resolution);
-    let portrait_input10 = TestInput::new_with_resolution(10, portrait_resolution);
-    let portrait_input11 = TestInput::new_with_resolution(11, portrait_resolution);
-    let portrait_input12 = TestInput::new_with_resolution(12, portrait_resolution);
-    let portrait_input13 = TestInput::new_with_resolution(13, portrait_resolution);
-    let portrait_input14 = TestInput::new_with_resolution(14, portrait_resolution);
-    let portrait_input15 = TestInput::new_with_resolution(15, portrait_resolution);
-    Vec::from([
-        TestCase {
-            name: "tiled_layout/01_inputs",
-            scene_json: include_str!("../../snapshot_tests/tiled_layout/01_inputs.scene.json"),
-            inputs: vec![input1.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/02_inputs",
-            scene_json: include_str!("../../snapshot_tests/tiled_layout/02_inputs.scene.json"),
-            inputs: vec![input1.clone(), input2.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/03_inputs",
-            scene_json: include_str!("../../snapshot_tests/tiled_layout/03_inputs.scene.json"),
-            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/04_inputs",
-            scene_json: include_str!("../../snapshot_tests/tiled_layout/04_inputs.scene.json"),
-            inputs: vec![
-                input1.clone(),
-                input2.clone(),
-                input3.clone(),
-                input4.clone(),
-            ],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/05_inputs",
-            scene_json: include_str!("../../snapshot_tests/tiled_layout/05_inputs.scene.json"),
-            inputs: vec![
-                input1.clone(),
-                input2.clone(),
-                input3.clone(),
-                input4.clone(),
-                input5.clone(),
-            ],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/15_inputs",
-            scene_json: include_str!("../../snapshot_tests/tiled_layout/15_inputs.scene.json"),
-            inputs: vec![
-                input1.clone(),
-                input2.clone(),
-                input3.clone(),
-                input4.clone(),
-                input5.clone(),
-                input6.clone(),
-                input7.clone(),
-                input8.clone(),
-                input9.clone(),
-                input10.clone(),
-                input11.clone(),
-                input12.clone(),
-                input13.clone(),
-                input14.clone(),
-                input15.clone(),
-            ],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/01_portrait_inputs",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/01_portrait_inputs.scene.json"
-            ),
-            inputs: vec![portrait_input1.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/02_portrait_inputs",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/02_portrait_inputs.scene.json"
-            ),
-            inputs: vec![portrait_input1.clone(), portrait_input2.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/03_portrait_inputs",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/03_portrait_inputs.scene.json"
-            ),
-            inputs: vec![
-                portrait_input1.clone(),
-                portrait_input2.clone(),
-                portrait_input3.clone(),
-            ],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/05_portrait_inputs",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/05_portrait_inputs.scene.json"
-            ),
-            inputs: vec![
-                portrait_input1.clone(),
-                portrait_input2.clone(),
-                portrait_input3.clone(),
-                portrait_input4.clone(),
-                portrait_input5.clone(),
-            ],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/15_portrait_inputs",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/15_portrait_inputs.scene.json"
-            ),
-            inputs: vec![
-                portrait_input1.clone(),
-                portrait_input2.clone(),
-                portrait_input3.clone(),
-                portrait_input4.clone(),
-                portrait_input5.clone(),
-                portrait_input6.clone(),
-                portrait_input7.clone(),
-                portrait_input8.clone(),
-                portrait_input9.clone(),
-                portrait_input10.clone(),
-                portrait_input11.clone(),
-                portrait_input12.clone(),
-                portrait_input13.clone(),
-                portrait_input14.clone(),
-                portrait_input15.clone(),
-            ],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/01_inputs_on_portrait_output",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/01_inputs_on_portrait_output.scene.json"
-            ),
-            inputs: vec![portrait_input1.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/03_inputs_on_portrait_output",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/03_inputs_on_portrait_output.scene.json"
-            ),
-            inputs: vec![
-                portrait_input1.clone(),
-                portrait_input2.clone(),
-                portrait_input3.clone(),
-            ],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/05_portrait_inputs_on_portrait_output",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/05_portrait_inputs_on_portrait_output.scene.json"
-            ),
-            inputs: vec![
-                portrait_input1.clone(),
-                portrait_input2.clone(),
-                portrait_input3.clone(),
-                portrait_input4.clone(),
-                portrait_input5.clone(),
-            ],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/15_portrait_inputs_on_portrait_output",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/15_portrait_inputs_on_portrait_output.scene.json"
-            ),
-            inputs: vec![
-                portrait_input1.clone(),
-                portrait_input2.clone(),
-                portrait_input3.clone(),
-                portrait_input4.clone(),
-                portrait_input5.clone(),
-                portrait_input6.clone(),
-                portrait_input7.clone(),
-                portrait_input8.clone(),
-                portrait_input9.clone(),
-                portrait_input10.clone(),
-                portrait_input11.clone(),
-                portrait_input12.clone(),
-                portrait_input13.clone(),
-                portrait_input14.clone(),
-                portrait_input15.clone(),
-            ],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/align_center_with_03_inputs",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/align_center_with_03_inputs.scene.json"
-            ),
-            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/align_top_left_with_03_inputs",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/align_top_left_with_03_inputs.scene.json"
-            ),
-            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/align_with_margin_and_padding_with_03_inputs",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/align_with_margin_and_padding_with_03_inputs.scene.json"
-            ),
-            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/margin_with_03_inputs",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/margin_with_03_inputs.scene.json"
-            ),
-            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/margin_and_padding_with_03_inputs",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/margin_and_padding_with_03_inputs.scene.json"
-            ),
-            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
-            ..Default::default()
-        },
-        TestCase {
-            name: "tiled_layout/padding_with_03_inputs",
-            scene_json: include_str!(
-                "../../snapshot_tests/tiled_layout/padding_with_03_inputs.scene.json"
-            ),
-            inputs: vec![input1.clone(), input2.clone(), input3.clone()],
-            ..Default::default()
-        },
-    ])
-}
-
-pub fn text_snapshot_tests() -> Vec<TestCase> {
-    Vec::from([
-        TestCase {
-            name: "text/align_center",
-            scene_json: include_str!("../../snapshot_tests/text/align_center.scene.json"),
-            ..Default::default()
-        },
-        TestCase {
-            name: "text/align_right",
-            scene_json: include_str!("../../snapshot_tests/text/align_right.scene.json"),
-            ..Default::default()
-        },
-        TestCase {
-            name: "text/bold_text",
-            scene_json: include_str!("../../snapshot_tests/text/bold_text.scene.json"),
-            ..Default::default()
-        },
-        TestCase {
-            name: "text/dimensions_fitted_column_with_long_text",
-            scene_json: include_str!(
-                "../../snapshot_tests/text/dimensions_fitted_column_with_long_text.scene.json"
-            ),
-            ..Default::default()
-        },
-        TestCase {
-            name: "text/dimensions_fitted_column_with_short_text",
-            scene_json: include_str!(
-                "../../snapshot_tests/text/dimensions_fitted_column_with_short_text.scene.json"
-            ),
-            ..Default::default()
-        },
-        TestCase {
-            name: "text/dimensions_fitted",
-            scene_json: include_str!("../../snapshot_tests/text/dimensions_fitted.scene.json"),
-            ..Default::default()
-        },
-        TestCase {
-            name: "text/dimensions_fixed",
-            scene_json: include_str!("../../snapshot_tests/text/dimensions_fixed.scene.json"),
-            ..Default::default()
-        },
-        TestCase {
-            name: "text/dimensions_fixed_with_overflow",
-            scene_json: include_str!(
-                "../../snapshot_tests/text/dimensions_fixed_with_overflow.scene.json"
-            ),
-            ..Default::default()
-        },
-        TestCase {
-            name: "text/red_text_on_blue_background",
-            scene_json: include_str!(
-                "../../snapshot_tests/text/red_text_on_blue_background.scene.json"
-            ),
-            ..Default::default()
-        },
-        TestCase {
-            name: "text/wrap_glyph",
-            scene_json: include_str!("../../snapshot_tests/text/wrap_glyph.scene.json"),
-            allowed_error: 325.7,
-            ..Default::default()
-        },
-        TestCase {
-            name: "text/wrap_none",
-            scene_json: include_str!("../../snapshot_tests/text/wrap_none.scene.json"),
-            ..Default::default()
-        },
-        TestCase {
-            name: "text/wrap_word",
-            scene_json: include_str!("../../snapshot_tests/text/wrap_word.scene.json"),
-            allowed_error: 321.8,
-            ..Default::default()
-        },
-    ])
+pub fn base_snapshot_tests() -> Vec<TestCase> {
+    Vec::from([TestCase {
+        name: "simple_input_pass_through",
+        outputs: vec![(
+            include_str!("../../snapshot_tests/simple_input_pass_through.scene.json"),
+            DEFAULT_RESOLUTION,
+        )],
+        inputs: vec![TestInput::new(1)],
+        ..Default::default()
+    }])
 }

--- a/src/snapshot_tests/tests.rs
+++ b/src/snapshot_tests/tests.rs
@@ -544,6 +544,7 @@ pub fn text_snapshot_tests() -> Vec<TestCase> {
         TestCase {
             name: "text/wrap_glyph",
             scene_json: include_str!("../../snapshot_tests/text/wrap_glyph.scene.json"),
+            allowed_error: 325.7,
             ..Default::default()
         },
         TestCase {
@@ -554,6 +555,7 @@ pub fn text_snapshot_tests() -> Vec<TestCase> {
         TestCase {
             name: "text/wrap_word",
             scene_json: include_str!("../../snapshot_tests/text/wrap_word.scene.json"),
+            allowed_error: 321.8,
             ..Default::default()
         },
     ])

--- a/src/snapshot_tests/utils.rs
+++ b/src/snapshot_tests/utils.rs
@@ -39,9 +39,11 @@ pub(super) fn frame_to_rgba(frame: &Frame) -> Vec<u8> {
     rgba_data
 }
 
-pub(super) fn are_snapshots_near_equal(old_snapshot: &[u8], new_snapshot: &[u8]) -> bool {
-    const ALLOWED_ERROR: f32 = 2.5;
-
+pub(super) fn are_snapshots_near_equal(
+    old_snapshot: &[u8],
+    new_snapshot: &[u8],
+    allowed_error: f32,
+) -> bool {
     if old_snapshot.len() != new_snapshot.len() {
         return false;
     }
@@ -51,7 +53,7 @@ pub(super) fn are_snapshots_near_equal(old_snapshot: &[u8], new_snapshot: &[u8])
         .map(|(a, b)| (*a as i32 - *b as i32).pow(2) as f32)
         .sum();
 
-    (square_error / old_snapshot.len() as f32) < ALLOWED_ERROR
+    (square_error / old_snapshot.len() as f32) < allowed_error
 }
 
 pub(super) fn create_renderer(renderers: Vec<RendererSpec>, scene: Arc<SceneSpec>) -> Renderer {

--- a/src/snapshot_tests/utils.rs
+++ b/src/snapshot_tests/utils.rs
@@ -1,9 +1,11 @@
-use std::{collections::HashSet, fs, path::PathBuf, sync::Arc, time::Duration};
+use std::{collections::HashSet, fs, path::PathBuf, time::Duration};
 
 use compositor_common::{
-    frame::YuvData, renderer_spec::RendererSpec, scene::SceneSpec, Frame, Framerate,
+    frame::YuvData, renderer_spec::RendererSpec, scene::OutputId, Frame, Framerate,
 };
-use compositor_render::{renderer::RendererOptions, Renderer, WebRendererOptions};
+use compositor_render::{
+    renderer::RendererOptions, scene::OutputScene, Renderer, WebRendererOptions,
+};
 
 pub const SNAPSHOTS_DIR_NAME: &str = "snapshot_tests/snapshots/render_snapshots";
 
@@ -56,7 +58,7 @@ pub(super) fn are_snapshots_near_equal(
     (square_error / old_snapshot.len() as f32) < allowed_error
 }
 
-pub(super) fn create_renderer(renderers: Vec<RendererSpec>, scene: Arc<SceneSpec>) -> Renderer {
+pub(super) fn create_renderer(renderers: Vec<RendererSpec>, scene: Vec<OutputScene>) -> Renderer {
     let (mut renderer, _event_loop) = Renderer::new(RendererOptions {
         web_renderer: WebRendererOptions {
             init: false,
@@ -106,7 +108,7 @@ pub fn find_unused_snapshots(
     unused_snapshots
 }
 
-pub(super) fn snaphot_save_path(test_name: &str, pts: &Duration, output_id: &str) -> PathBuf {
+pub(super) fn snaphot_save_path(test_name: &str, pts: &Duration, output_id: OutputId) -> PathBuf {
     let out_file_name = format!("{}_{}_{}.png", test_name, pts.as_millis(), output_id);
     snapshots_path().join(out_file_name)
 }

--- a/src/types/convert.rs
+++ b/src/types/convert.rs
@@ -64,13 +64,19 @@ impl TryFrom<UpdateScene> for Vec<compositor_pipeline::pipeline::OutputScene> {
         update_scene
             .scenes
             .into_iter()
-            .map(|component| {
-                Ok(compositor_pipeline::pipeline::OutputScene {
-                    output_id: component.output_id.try_into()?,
-                    root: component.root.try_into()?,
-                })
-            })
+            .map(TryInto::try_into)
             .collect::<Result<Vec<_>, TypeError>>()
+    }
+}
+
+impl TryFrom<OutputScene> for compositor_pipeline::pipeline::OutputScene {
+    type Error = TypeError;
+
+    fn try_from(scene: OutputScene) -> Result<Self, Self::Error> {
+        Ok(compositor_pipeline::pipeline::OutputScene {
+            output_id: scene.output_id.try_into()?,
+            root: scene.root.try_into()?,
+        })
     }
 }
 


### PR DESCRIPTION
https://github.com/membraneframework-labs/video_compositor_snapshot_tests/pull/4

This PR includes:
- cherry picked https://github.com/membraneframework/video_compositor/commit/bf448457c6d75e91b1abceb9b2c2d5643730946c
- https://github.com/membraneframework/video_compositor/pull/249/commits/96ef574c36659744065bb43bf05e558c45ff1392
  - update test code to use new types
  - simplify + refactor parts of the test implementation
  - Add tests for `View` and remove the old test
  
Given that this PR includes commit cherry picked from master I will merge this PR without squashing 