### PR TITLE
Add relative positioning support for layout components

### DIFF
--- a/compositor_render/src/scene.rs
+++ b/compositor_render/src/scene.rs
@@ -53,7 +53,10 @@ impl Component {
         match self {
             Component::InputStream(input) => input.size.map(|s| s.width),
             Component::Shader(shader) => Some(shader.size.width),
-            Component::Layout(layout) => layout.width(),
+            Component::Layout(layout) => match layout.position() {
+                Position::Static { width, .. } => width,
+                Position::Relative(position) => Some(position.width),
+            },
         }
     }
 
@@ -61,7 +64,10 @@ impl Component {
         match self {
             Component::InputStream(input) => input.size.map(|s| s.height),
             Component::Shader(shader) => Some(shader.size.height),
-            Component::Layout(layout) => layout.height(),
+            Component::Layout(layout) => match layout.position() {
+                Position::Static { height, .. } => height,
+                Position::Relative(position) => Some(position.height),
+            },
         }
     }
 

--- a/compositor_render/src/scene/components.rs
+++ b/compositor_render/src/scene/components.rs
@@ -37,14 +37,44 @@ pub struct ViewComponent {
     pub id: Option<ComponentId>,
     pub children: Vec<Component>,
 
-    pub width: Option<usize>,
-    pub height: Option<usize>,
     pub direction: ViewChildrenDirection,
+    pub position: Position,
+
     pub background_color: RGBAColor,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Position {
+    Static {
+        width: Option<usize>,
+        height: Option<usize>,
+    },
+    Relative(RelativePosition),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RelativePosition {
+    pub width: usize,
+    pub height: usize,
+    pub position_horizontal: HorizontalPosition,
+    pub position_vertical: VerticalPosition,
+    pub rotation_degrees: f32,
 }
 
 #[derive(Debug, Clone)]
 pub enum ViewChildrenDirection {
     Row,
     Column,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum VerticalPosition {
+    Top(usize),
+    Bottom(usize),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum HorizontalPosition {
+    Left(usize),
+    Right(usize),
 }

--- a/compositor_render/src/scene/scene_state.rs
+++ b/compositor_render/src/scene/scene_state.rs
@@ -2,7 +2,7 @@ use compositor_common::scene::{OutputId, Resolution};
 
 use super::{
     layout::SizedLayoutComponent, BuildSceneError, Component, InputStreamComponent,
-    LayoutComponent, LayoutNode, Node, NodeKind, ShaderComponent,
+    LayoutComponent, LayoutNode, Node, NodeKind, Position, ShaderComponent,
 };
 
 pub(crate) struct SceneState {
@@ -103,8 +103,12 @@ impl BaseNode {
                 children: _,
             } => Ok(shader.size),
             BaseNode::Layout { root, children: _ } => {
-                let width = root.width();
-                let height = root.height();
+                let (width, height) = match root.position() {
+                    Position::Static { width, height } => (width, height),
+                    // Technically relative positioning is a bug here, but I think throwing error
+                    // in this case would be to invasive. It's better to just ignore those values.
+                    Position::Relative(position) => (Some(position.width), Some(position.height)),
+                };
                 if let (Some(width), Some(height)) = (width, height) {
                     Ok(Resolution { width, height })
                 } else {

--- a/compositor_render/src/scene/view_component.rs
+++ b/compositor_render/src/scene/view_component.rs
@@ -5,7 +5,21 @@ use crate::{
     transformations::layout::{Layout, LayoutContent, NestedLayout},
 };
 
-use super::{components::ViewComponent, BaseNode, BuildSceneError, Component, LayoutComponent};
+use super::{
+    components::ViewComponent, BaseNode, BuildSceneError, Component, LayoutComponent, Position,
+};
+
+#[derive(Debug)]
+struct StaticChildLayoutOpts {
+    width: Option<usize>,
+    height: Option<usize>,
+    /// offset inside parent component
+    static_offset: usize,
+    /// For direction=row defines width of a dynamically sized component
+    /// For direction=column defines height of a dynamically sized component
+    dynamic_child_size: usize,
+    parent_size: Resolution,
+}
 
 impl ViewComponent {
     pub(super) fn base_node(&self) -> Result<BaseNode, BuildSceneError> {
@@ -45,94 +59,99 @@ impl ViewComponent {
         // child component should be placed
         let mut static_offset = 0;
 
-        let create_static_layout = match self.direction {
-            ViewChildrenDirection::Row => Self::create_static_layout_row,
-            ViewChildrenDirection::Column => Self::create_static_layout_column,
-        };
-
         self.children
             .iter()
             .map(|child| {
-                if Self::is_static_child(child) {
-                    let layout =
-                        create_static_layout(child, static_offset, dynamic_child_size, size);
-                    match self.direction {
-                        ViewChildrenDirection::Row => static_offset += layout.width as usize,
-                        ViewChildrenDirection::Column => static_offset += layout.height as usize,
-                    };
-                    match child {
-                        Component::Layout(layout_component) => {
-                            let children_layouts = layout_component.layout(Resolution {
-                                width: layout.width as usize,
-                                height: layout.height as usize,
-                            });
-                            NestedLayout {
-                                layout: Layout {
-                                    content: LayoutContent::Color(
-                                        layout_component
-                                            .background_color()
-                                            .unwrap_or(RGBAColor(0, 0, 0, 0)),
-                                    ),
-                                    ..layout
-                                },
-                                children: children_layouts,
-                            }
-                        }
-                        _ => {
-                            NestedLayout {
-                                layout: layout.clone(),
-                                children: vec![NestedLayout {
-                                    layout: Layout {
-                                        top: 0.0,
-                                        left: 0.0,
-                                        content: LayoutContent::ChildNode(0), // TODO: this will be recalculated latter
-                                        ..layout
-                                    },
-                                    children: vec![],
-                                }],
-                            }
-                        }
+                let position = match child {
+                    Component::Layout(layout) => layout.position(),
+                    non_layout_component => Position::Static {
+                        width: non_layout_component.width(),
+                        height: non_layout_component.height(),
+                    },
+                };
+                match position {
+                    Position::Static { width, height } => {
+                        let (layout, updated_static_offset) = self.layout_static_child(
+                            child,
+                            StaticChildLayoutOpts {
+                                width,
+                                height,
+                                static_offset,
+                                dynamic_child_size,
+                                parent_size: size,
+                            },
+                        );
+
+                        static_offset = updated_static_offset;
+                        layout
                     }
-                } else {
-                    // Add support to top/left/right/bottom options
-                    todo!()
+                    Position::Relative(position) => {
+                        LayoutComponent::layout_relative_child(child, position, size)
+                    }
                 }
             })
             .collect()
     }
 
-    fn create_static_layout_row(
-        component: &Component,
-        offset: usize,
-        width_for_dynamic: usize,
-        parent_size: Resolution,
-    ) -> Layout {
-        let width = component.width().unwrap_or(width_for_dynamic);
-        Layout {
-            top: 0.0,
-            left: offset as f32,
-            width: width as f32,
-            height: component.height().unwrap_or(parent_size.height) as f32,
-            rotation_degrees: 0.0,
-            content: LayoutContent::Color(RGBAColor(0, 0, 0, 0)),
-        }
-    }
-
-    fn create_static_layout_column(
-        component: &Component,
-        offset: usize,
-        height_for_dynamic: usize,
-        parent_size: Resolution,
-    ) -> Layout {
-        let height = component.height().unwrap_or(height_for_dynamic);
-        Layout {
-            top: offset as f32,
-            left: 0.0,
-            width: component.width().unwrap_or(parent_size.width) as f32,
-            height: height as f32,
-            rotation_degrees: 0.0,
-            content: LayoutContent::Color(RGBAColor(0, 0, 0, 0)),
-        }
+    fn layout_static_child(
+        &self,
+        child: &Component,
+        opts: StaticChildLayoutOpts,
+    ) -> (NestedLayout, usize) {
+        let mut static_offset = opts.static_offset;
+        let (top, left, width, height) = match self.direction {
+            ViewChildrenDirection::Row => {
+                let width = opts.width.unwrap_or(opts.dynamic_child_size);
+                let height = opts.height.unwrap_or(opts.parent_size.height);
+                let top = 0.0;
+                let left = static_offset;
+                static_offset += width;
+                (top as f32, left as f32, width as f32, height as f32)
+            }
+            ViewChildrenDirection::Column => {
+                let height = opts.height.unwrap_or(opts.dynamic_child_size);
+                let width = opts.width.unwrap_or(opts.parent_size.width);
+                let top = static_offset;
+                let left = 0.0;
+                static_offset += height;
+                (top as f32, left as f32, width as f32, height as f32)
+            }
+        };
+        let layout = match child {
+            Component::Layout(layout_component) => {
+                let children_layouts = layout_component.layout(Resolution {
+                    width: width as usize,
+                    height: height as usize,
+                });
+                NestedLayout {
+                    layout: Layout {
+                        top,
+                        left,
+                        width,
+                        height,
+                        rotation_degrees: 0.0,
+                        content: LayoutContent::Color(
+                            layout_component
+                                .background_color()
+                                .unwrap_or(RGBAColor(0, 0, 0, 0)),
+                        ),
+                    },
+                    children: children_layouts,
+                }
+            }
+            _ => NestedLayout {
+                layout: Layout {
+                    top,
+                    left,
+                    width,
+                    height,
+                    rotation_degrees: 0.0,
+                    content: LayoutContent::ChildNode(0),
+                },
+                children: vec![],
+            },
+        };
+        (layout, static_offset)
     }
 
     /// Calculate size of a dynamically sized child component. Returned value
@@ -151,14 +170,14 @@ impl ViewComponent {
                 ViewChildrenDirection::Column => child.height().is_none(),
             })
             .count();
-        let static_children_sizes = self.sum_static_children_sizes();
+        let static_children_sum = self.sum_static_children_sizes();
 
         if dynamic_children_count == 0 {
             return 0; // if there is no dynamically sized children then this value does not matter
         }
         f32::max(
             0.0,
-            (max_size as f32 - static_children_sizes as f32) / dynamic_children_count as f32,
+            (max_size as f32 - static_children_sum as f32) / dynamic_children_count as f32,
         ) as usize
     }
 
@@ -174,15 +193,12 @@ impl ViewComponent {
     }
 
     fn static_children_iter(&self) -> impl Iterator<Item = &Component> {
-        self.children.iter().filter(|v| Self::is_static_child(v))
-    }
-
-    /// Resolves if specific component will be positioned in the row or column layout. Function
-    /// should return false for components that are positioned absolutely inside the parent component.
-    fn is_static_child(component: &Component) -> bool {
-        match component {
-            super::Component::Layout(_layout) => true, // TODO: add support for top/left/right/bottom
+        self.children.iter().filter(|child| match child {
+            Component::Layout(layout) => match layout.position() {
+                super::Position::Static { .. } => true,
+                super::Position::Relative(_) => false,
+            },
             _ => true,
-        }
+        })
     }
 }

--- a/compositor_render/src/transformations/layout.rs
+++ b/compositor_render/src/transformations/layout.rs
@@ -44,12 +44,12 @@ pub struct Layout {
 pub struct NestedLayout {
     pub(crate) layout: Layout,
     pub(crate) children: Vec<NestedLayout>,
-    /// describes how many children of this component are nodes. This value also
-    /// counts `layout` if it's content is a `LayoutContent::ChildNode`.
+    /// Describes how many children of this component are nodes. This value also
+    /// counts `layout` if its content is a `LayoutContent::ChildNode`.
     ///
-    /// This value is not necessarily equal to number of `LayoutContent::ChildNode` in
+    /// `child_nodes_count` is not necessarily equal to number of `LayoutContent::ChildNode` in
     /// a sub-tree. For example, if we have a component that conditionally shows one
-    /// of it's children then child_nodes_count will count all of those components even
+    /// of its children then child_nodes_count will count all of those components even
     /// though only one of those children will be present in the layouts tree.
     pub(crate) child_nodes_count: usize,
 }

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -45,6 +45,15 @@
                 }
               ]
             },
+            "bottom": {
+              "description": "Distance between the bottom edge of this component and the bottom edge of it's parent. If this field is defined, then component will not use static layout of it's parent (component will ignore layout defined by it's parent).",
+              "format": "uint",
+              "minimum": 0.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "children": {
               "items": {
                 "$ref": "#/definitions/Component"
@@ -53,6 +62,17 @@
                 "array",
                 "null"
               ]
+            },
+            "direction": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ViewDirection"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Direction defines how static children are positioned inside the View. \"row\" - Children positioned from left to right. \"column\" - Children positioned from top to bottom."
             },
             "height": {
               "format": "uint",
@@ -70,6 +90,41 @@
                 {
                   "type": "null"
                 }
+              ]
+            },
+            "left": {
+              "description": "Distance between the left edge of this component and the left edge of it's parent. If this field is defined, then component will not use static layout of it's parent (component will ignore layout defined by it's parent).",
+              "format": "uint",
+              "minimum": 0.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "right": {
+              "description": "Distance between the right edge of this component and the right edge of it's parent. If this field is defined, then component will not use static layout of it's parent (component will ignore layout defined by it's parent).",
+              "format": "uint",
+              "minimum": 0.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "rotation": {
+              "description": "Rotation of a component in degrees. If this field is defined, then component will not use static layout of it's parent (component will ignore layout defined by it's parent).",
+              "format": "float",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "top": {
+              "description": "Distance between the top edge of this component and the top edge of it's parent. If this field is defined, then component will not use static layout of it's parent (component will ignore layout defined by it's parent).",
+              "format": "uint",
+              "minimum": 0.0,
+              "type": [
+                "integer",
+                "null"
               ]
             },
             "type": {
@@ -1074,6 +1129,13 @@
         "center",
         "bottom",
         "justified"
+      ],
+      "type": "string"
+    },
+    "ViewDirection": {
+      "enum": [
+        "Row",
+        "Column"
       ],
       "type": "string"
     }

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -43,10 +43,11 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Background color of a component in a \"#RRGGBBAA\" format. Defaults to transparent \"#00000000\"."
             },
             "bottom": {
-              "description": "Distance between the bottom edge of this component and the bottom edge of it's parent. If this field is defined, then component will not use static layout of it's parent (component will ignore layout defined by it's parent).",
+              "description": "Distance between the bottom edge of this component and the bottom edge of its parent. If this field is defined, then component will ignore a layout defined by its parent.",
               "format": "uint",
               "minimum": 0.0,
               "type": [
@@ -75,6 +76,7 @@
               "description": "Direction defines how static children are positioned inside the View. \"row\" - Children positioned from left to right. \"column\" - Children positioned from top to bottom."
             },
             "height": {
+              "description": "Height of a component in pixels. Required when using absolute positioning.",
               "format": "uint",
               "minimum": 0.0,
               "type": [
@@ -93,7 +95,7 @@
               ]
             },
             "left": {
-              "description": "Distance between the left edge of this component and the left edge of it's parent. If this field is defined, then component will not use static layout of it's parent (component will ignore layout defined by it's parent).",
+              "description": "Distance between the left edge of this component and the left edge of its parent. If this field is defined, then component will ignore a layout defined by its parent.",
               "format": "uint",
               "minimum": 0.0,
               "type": [
@@ -102,7 +104,7 @@
               ]
             },
             "right": {
-              "description": "Distance between the right edge of this component and the right edge of it's parent. If this field is defined, then component will not use static layout of it's parent (component will ignore layout defined by it's parent).",
+              "description": "Distance between the right edge of this component and the right edge of its parent. If this field is defined, then component will ignore  layout defined by its parent.",
               "format": "uint",
               "minimum": 0.0,
               "type": [
@@ -111,7 +113,7 @@
               ]
             },
             "rotation": {
-              "description": "Rotation of a component in degrees. If this field is defined, then component will not use static layout of it's parent (component will ignore layout defined by it's parent).",
+              "description": "Rotation of a component in degrees. If this field is defined, then component will ignore a layout defined by its parent.",
               "format": "float",
               "type": [
                 "number",
@@ -119,7 +121,7 @@
               ]
             },
             "top": {
-              "description": "Distance between the top edge of this component and the top edge of it's parent. If this field is defined, then component will not use static layout of it's parent (component will ignore layout defined by it's parent).",
+              "description": "Distance between the top edge of this component and the top edge of its parent. If this field is defined, then component will ignore a layout defined by its parent.",
               "format": "uint",
               "minimum": 0.0,
               "type": [
@@ -134,6 +136,7 @@
               "type": "string"
             },
             "width": {
+              "description": "Width of a component in pixels. Required when using absolute positioning.",
               "format": "uint",
               "minimum": 0.0,
               "type": [

--- a/snapshot_tests/view/root_view_with_background_color.scene.json
+++ b/snapshot_tests/view/root_view_with_background_color.scene.json
@@ -1,0 +1,17 @@
+{
+    "output_id": "output_1",
+    "root": {
+        "type": "view",
+        "background_color_rgba": "#FF0000FF",
+        "children": [
+            {
+                "type": "view",
+                "top": 50,
+                "right": 50,
+                "width": 400,
+                "height": 200,
+                "background_color_rgba": "#00FF00FF"
+            }
+        ]
+    }
+}

--- a/snapshot_tests/view/view_with_relative_positioning_partially_covered_by_sibling.scene.json
+++ b/snapshot_tests/view/view_with_relative_positioning_partially_covered_by_sibling.scene.json
@@ -1,0 +1,24 @@
+{
+    "output_id": "output_1",
+    "root": {
+        "type": "view",
+        "children": [
+            {
+                "type": "view",
+                "background_color_rgba": "#FF0000FF"
+            },
+            {
+                "type": "view",
+                "top": 50,
+                "right": 50,
+                "width": 400,
+                "height": 200,
+                "background_color_rgba": "#00FF00FF"
+            },
+            {
+                "type": "view",
+                "background_color_rgba": "#0000FFFF"
+            }
+        ]
+    }
+}

--- a/snapshot_tests/view/view_with_relative_positioning_render_over_siblings.scene.json
+++ b/snapshot_tests/view/view_with_relative_positioning_render_over_siblings.scene.json
@@ -1,0 +1,24 @@
+{
+    "output_id": "output_1",
+    "root": {
+        "type": "view",
+        "children": [
+            {
+                "type": "view",
+                "background_color_rgba": "#FF0000FF"
+            },
+            {
+                "type": "view",
+                "background_color_rgba": "#0000FFFF"
+            },
+            {
+                "type": "view",
+                "top": 50,
+                "right": 50,
+                "width": 400,
+                "height": 200,
+                "background_color_rgba": "#00FF00FF"
+            }
+        ]
+    }
+}

--- a/src/snapshot_tests/tests.rs
+++ b/src/snapshot_tests/tests.rs
@@ -623,7 +623,26 @@ pub fn view_snapshot_tests() -> Vec<TestCase> {
             )],
             inputs: vec![TestInput::new(1)],
             ..Default::default()
+        },
+        TestCase {
+            name: "view/view_with_relative_positioning_partially_covered_by_sibling",
+            outputs: vec![(
+                include_str!("../../snapshot_tests/view/view_with_relative_positioning_partially_covered_by_sibling.scene.json"),
+                DEFAULT_RESOLUTION,
+            )],
+            inputs: vec![TestInput::new(1)],
+            ..Default::default()
+        },
+        TestCase {
+            name: "view/view_with_relative_positioning_render_over_siblings",
+            outputs: vec![(
+                include_str!("../../snapshot_tests/view/view_with_relative_positioning_render_over_siblings.scene.json"),
+                DEFAULT_RESOLUTION,
+            )],
+            inputs: vec![TestInput::new(1)],
+            ..Default::default()
         }
+
     ])
 }
 

--- a/src/snapshot_tests/tests.rs
+++ b/src/snapshot_tests/tests.rs
@@ -641,8 +641,16 @@ pub fn view_snapshot_tests() -> Vec<TestCase> {
             )],
             inputs: vec![TestInput::new(1)],
             ..Default::default()
+        },
+        TestCase {
+            name: "view/root_view_with_background_color",
+            outputs: vec![(
+                include_str!("../../snapshot_tests/view/root_view_with_background_color.scene.json"),
+                DEFAULT_RESOLUTION,
+            )],
+            inputs: vec![TestInput::new(1)],
+            ..Default::default()
         }
-
     ])
 }
 

--- a/src/types/component.rs
+++ b/src/types/component.rs
@@ -48,7 +48,9 @@ pub struct View {
     pub id: Option<ComponentId>,
     pub children: Option<Vec<Component>>,
 
+    /// Width of a component in pixels. Required when using absolute positioning.
     pub width: Option<usize>,
+    /// Height of a component in pixels. Required when using absolute positioning.
     pub height: Option<usize>,
 
     /// Direction defines how static children are positioned inside the View.
@@ -56,26 +58,24 @@ pub struct View {
     /// "column" - Children positioned from top to bottom.
     pub direction: Option<ViewDirection>,
 
-    /// Distance between the top edge of this component and the top edge of it's parent. If this
-    /// field is defined, then component will not use static layout of it's parent (component will
-    /// ignore layout defined by it's parent).
+    /// Distance between the top edge of this component and the top edge of its parent.
+    /// If this field is defined, then component will ignore a layout defined by its parent.
     pub top: Option<usize>,
-    /// Distance between the left edge of this component and the left edge of it's parent. If this
-    /// field is defined, then component will not use static layout of it's parent (component will
-    /// ignore layout defined by it's parent).
+    /// Distance between the left edge of this component and the left edge of its parent.
+    /// If this field is defined, then component will ignore a layout defined by its parent.
     pub left: Option<usize>,
-    /// Distance between the bottom edge of this component and the bottom edge of it's parent. If this
-    /// field is defined, then component will not use static layout of it's parent (component will
-    /// ignore layout defined by it's parent).
+    /// Distance between the bottom edge of this component and the bottom edge of its parent.
+    /// If this field is defined, then component will ignore a layout defined by its parent.
     pub bottom: Option<usize>,
-    /// Distance between the right edge of this component and the right edge of it's parent. If this
-    /// field is defined, then component will not use static layout of it's parent (component will
-    /// ignore layout defined by it's parent).
+    /// Distance between the right edge of this component and the right edge of its parent.
+    /// If this field is defined, then component will ignore  layout defined by its parent.
     pub right: Option<usize>,
-    /// Rotation of a component in degrees. If this field is defined, then component will not use
-    /// static layout of it's parent (component will ignore layout defined by it's parent).
+    /// Rotation of a component in degrees. If this field is defined, then component will
+    /// ignore a layout defined by its parent.
     pub rotation: Option<f32>,
 
+    /// Background color of a component in a "#RRGGBBAA" format. Defaults to transparent
+    /// "#00000000".
     pub background_color_rgba: Option<RGBAColor>,
 }
 

--- a/src/types/component.rs
+++ b/src/types/component.rs
@@ -47,9 +47,42 @@ pub struct InputStream {
 pub struct View {
     pub id: Option<ComponentId>,
     pub children: Option<Vec<Component>>,
+
     pub width: Option<usize>,
     pub height: Option<usize>,
+
+    /// Direction defines how static children are positioned inside the View.
+    /// "row" - Children positioned from left to right.
+    /// "column" - Children positioned from top to bottom.
+    pub direction: Option<ViewDirection>,
+
+    /// Distance between the top edge of this component and the top edge of it's parent. If this
+    /// field is defined, then component will not use static layout of it's parent (component will
+    /// ignore layout defined by it's parent).
+    pub top: Option<usize>,
+    /// Distance between the left edge of this component and the left edge of it's parent. If this
+    /// field is defined, then component will not use static layout of it's parent (component will
+    /// ignore layout defined by it's parent).
+    pub left: Option<usize>,
+    /// Distance between the bottom edge of this component and the bottom edge of it's parent. If this
+    /// field is defined, then component will not use static layout of it's parent (component will
+    /// ignore layout defined by it's parent).
+    pub bottom: Option<usize>,
+    /// Distance between the right edge of this component and the right edge of it's parent. If this
+    /// field is defined, then component will not use static layout of it's parent (component will
+    /// ignore layout defined by it's parent).
+    pub right: Option<usize>,
+    /// Rotation of a component in degrees. If this field is defined, then component will not use
+    /// static layout of it's parent (component will ignore layout defined by it's parent).
+    pub rotation: Option<f32>,
+
     pub background_color_rgba: Option<RGBAColor>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+pub enum ViewDirection {
+    Row,
+    Column,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]


### PR DESCRIPTION
- https://github.com/membraneframework/video_compositor/pull/250/commits/1917333ffb0d09e7dd8b1c9b7f3b21a1a0b9ac84 Add relative positioning to view (it's intended to be supported in other layout components)
- https://github.com/membraneframework/video_compositor/pull/250/commits/929739d11363d7a6eaae2714088f7a651dd14060 Fix counting child nodes (old implementation wouldn't work for components where not all children are part of a layout tree)
- Fix rendering background on component that is a root of a node

https://github.com/membraneframework-labs/video_compositor_snapshot_tests/pull/5