### PR TITLE
Add image

### DIFF
--- a/compositor_render/src/renderer.rs
+++ b/compositor_render/src/renderer.rs
@@ -102,7 +102,13 @@ impl Renderer {
 
         let scope = WgpuErrorScope::push(&ctx.wgpu_ctx.device);
 
-        self.scene.register_render_event(inputs.pts);
+        let input_resolutions = inputs
+            .frames
+            .iter()
+            .map(|(input_id, frame)| (input_id.clone(), frame.resolution))
+            .collect();
+        self.scene
+            .register_render_event(inputs.pts, input_resolutions);
 
         populate_inputs(ctx, &mut self.render_graph, &mut inputs).unwrap();
         run_transforms(ctx, &mut self.render_graph, inputs.pts).unwrap();
@@ -120,7 +126,7 @@ impl Renderer {
         &mut self,
         scenes: Vec<scene::OutputScene>,
     ) -> Result<(), UpdateSceneError> {
-        let output_nodes = self.scene.update_scene(scenes)?;
+        let output_nodes = self.scene.update_scene(scenes, &self.renderers)?;
         self.render_graph.update(
             &RenderCtx {
                 wgpu_ctx: &self.wgpu_ctx,

--- a/compositor_render/src/renderer/node.rs
+++ b/compositor_render/src/renderer/node.rs
@@ -7,7 +7,7 @@ use compositor_common::scene::{NodeParams, NodeSpec};
 
 use crate::error::{CreateNodeError, UpdateSceneError};
 
-use crate::scene::{self, ShaderComponentParams};
+use crate::scene::{self, ImageComponent, ShaderComponentParams};
 use crate::transformations::layout::LayoutNode;
 use crate::transformations::shader::node::ShaderNode;
 
@@ -117,6 +117,26 @@ impl RenderNode {
         Ok(Self {
             renderer: node,
             inputs,
+            fallback: None,
+            output,
+        })
+    }
+
+    pub(super) fn new_image_node(
+        ctx: &RenderCtx,
+        image_component: ImageComponent,
+    ) -> Result<Self, CreateNodeError> {
+        let image = ctx
+            .renderers
+            .images
+            .get(&image_component.image_id)
+            .ok_or_else(|| CreateNodeError::ImageNotFound(image_component.image_id.clone()))?;
+        let node = InnerRenderNode::Image(ImageNode::new(image));
+        let output = NodeTexture::new();
+
+        Ok(Self {
+            renderer: node,
+            inputs: vec![],
             fallback: None,
             output,
         })

--- a/compositor_render/src/renderer/render_graph.rs
+++ b/compositor_render/src/renderer/render_graph.rs
@@ -93,8 +93,8 @@ impl RenderGraph {
         id_provider: &mut NodeIdProvider,
     ) -> Result<NodeId, UpdateSceneError> {
         // check if input stream already registered
-        if let scene::NodeParams::InputStream(input) = &node.params {
-            if let Some((node_id, _)) = inputs.get(&input.input_id) {
+        if let scene::NodeParams::InputStream(input_id) = &node.params {
+            if let Some((node_id, _)) = inputs.get(input_id) {
                 return Ok(*node_id);
             }
         }
@@ -107,19 +107,18 @@ impl RenderGraph {
             .collect::<Result<Vec<_>, _>>()?;
 
         match node.params {
-            scene::NodeParams::InputStream(input) => {
+            scene::NodeParams::InputStream(input_id) => {
                 let node = RenderNode::new_input();
                 new_nodes.insert(node_id, node);
-                inputs.insert(input.input_id.clone(), (node_id, InputTexture::new()));
+                inputs.insert(input_id.clone(), (node_id, InputTexture::new()));
             }
-            scene::NodeParams::Shader(shader) => {
-                let node = RenderNode::new_shader_node(ctx, input_pads, shader)
+            scene::NodeParams::Shader(shader_params, shader) => {
+                let node = RenderNode::new_shader_node(ctx, input_pads, shader_params, shader)
                     .map_err(|err| UpdateSceneError::CreateNodeError(err, node_id.0))?;
                 new_nodes.insert(node_id, node);
             }
             scene::NodeParams::Image(image) => {
-                let node = RenderNode::new_image_node(ctx, image)
-                    .map_err(|err| UpdateSceneError::CreateNodeError(err, node_id.0))?;
+                let node = RenderNode::new_image_node(image);
                 new_nodes.insert(node_id, node);
             }
             scene::NodeParams::Layout(layout) => {

--- a/compositor_render/src/renderer/render_graph.rs
+++ b/compositor_render/src/renderer/render_graph.rs
@@ -117,6 +117,11 @@ impl RenderGraph {
                     .map_err(|err| UpdateSceneError::CreateNodeError(err, node_id.0))?;
                 new_nodes.insert(node_id, node);
             }
+            scene::NodeParams::Image(image) => {
+                let node = RenderNode::new_image_node(ctx, image)
+                    .map_err(|err| UpdateSceneError::CreateNodeError(err, node_id.0))?;
+                new_nodes.insert(node_id, node);
+            }
             scene::NodeParams::Layout(layout) => {
                 let node = RenderNode::new_layout_node(ctx, input_pads, layout)
                     .map_err(|err| UpdateSceneError::CreateNodeError(err, node_id.0))?;

--- a/compositor_render/src/scene.rs
+++ b/compositor_render/src/scene.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use self::image_component::StatefulImageComponent;
 use self::input_stream_component::StatefulInputStreamComponent;
 use self::layout::StatefulLayoutComponent;
 use self::scene_state::{BuildStateTreeCtx, IntermediateNode};
@@ -14,6 +15,7 @@ pub(crate) use shader_component::ShaderComponentParams;
 pub use components::*;
 
 mod components;
+mod image_component;
 mod input_stream_component;
 mod layout;
 mod scene_state;
@@ -31,6 +33,7 @@ pub struct OutputScene {
 pub enum Component {
     InputStream(InputStreamComponent),
     Shader(ShaderComponent),
+    Image(ImageComponent),
     View(ViewComponent),
 }
 
@@ -42,6 +45,7 @@ pub enum Component {
 enum StatefulComponent {
     InputStream(StatefulInputStreamComponent),
     Shader(StatefulShaderComponent),
+    Image(StatefulImageComponent),
     Layout(StatefulLayoutComponent),
 }
 
@@ -65,6 +69,7 @@ pub(crate) struct Node {
 pub(crate) enum NodeParams {
     InputStream(InputStreamComponent),
     Shader(ShaderComponentParams),
+    Image(ImageComponent),
     Layout(LayoutNode),
 }
 
@@ -73,6 +78,7 @@ impl StatefulComponent {
         match self {
             StatefulComponent::InputStream(input) => input.size.map(|s| s.width),
             StatefulComponent::Shader(shader) => Some(shader.component.size.width),
+            StatefulComponent::Image(image) => image.size.map(|s| s.width),
             StatefulComponent::Layout(layout) => match layout.position(pts) {
                 Position::Static { width, .. } => width,
                 Position::Absolute(position) => Some(position.width),
@@ -84,6 +90,7 @@ impl StatefulComponent {
         match self {
             StatefulComponent::InputStream(input) => input.size.map(|s| s.height),
             StatefulComponent::Shader(shader) => Some(shader.component.size.height),
+            StatefulComponent::Image(image) => image.size.map(|s| s.height),
             StatefulComponent::Layout(layout) => match layout.position(pts) {
                 Position::Static { height, .. } => height,
                 Position::Absolute(position) => Some(position.height),
@@ -95,6 +102,7 @@ impl StatefulComponent {
         match self {
             StatefulComponent::InputStream(input) => input.intermediate_node(),
             StatefulComponent::Shader(shader) => shader.intermediate_node(),
+            StatefulComponent::Image(image) => image.intermediate_node(),
             StatefulComponent::Layout(layout) => match layout {
                 StatefulLayoutComponent::View(view) => view.intermediate_node(),
             },
@@ -113,6 +121,7 @@ impl Component {
             Component::InputStream(input) => input.stateful_component(ctx),
             Component::Shader(shader) => shader.stateful_component(ctx),
             Component::View(view) => view.stateful_component(ctx),
+            Component::Image(image) => image.stateful_component(ctx),
         }
     }
 }

--- a/compositor_render/src/scene/components.rs
+++ b/compositor_render/src/scene/components.rs
@@ -38,6 +38,12 @@ pub struct ShaderComponent {
 }
 
 #[derive(Debug, Clone)]
+pub struct ImageComponent {
+    pub id: Option<ComponentId>,
+    pub image_id: RendererId,
+}
+
+#[derive(Debug, Clone)]
 pub struct ViewComponent {
     pub id: Option<ComponentId>,
     pub children: Vec<Component>,

--- a/compositor_render/src/scene/image_component.rs
+++ b/compositor_render/src/scene/image_component.rs
@@ -1,0 +1,29 @@
+use super::{
+    scene_state::BuildStateTreeCtx, BuildSceneError, ComponentId, ImageComponent, IntermediateNode,
+    Size, StatefulComponent,
+};
+
+#[derive(Debug, Clone)]
+pub(super) struct StatefulImageComponent {
+    pub(super) component: ImageComponent,
+    pub(super) size: Option<Size>,
+}
+
+impl StatefulImageComponent {
+    pub(super) fn component_id(&self) -> Option<&ComponentId> {
+        self.component.id.as_ref()
+    }
+
+    pub(super) fn intermediate_node(&self) -> Result<IntermediateNode, BuildSceneError> {
+        Ok(IntermediateNode::Image(self.clone()))
+    }
+}
+
+impl ImageComponent {
+    pub(super) fn stateful_component(self, _ctx: &BuildStateTreeCtx) -> StatefulComponent {
+        StatefulComponent::Image(StatefulImageComponent {
+            component: self,
+            size: None, // TODO: get from ctx
+        })
+    }
+}

--- a/compositor_render/src/scene/input_stream_component.rs
+++ b/compositor_render/src/scene/input_stream_component.rs
@@ -1,3 +1,5 @@
+use compositor_common::scene::Resolution;
+
 use super::{
     scene_state::BuildStateTreeCtx, BuildSceneError, ComponentId, InputStreamComponent,
     IntermediateNode, Size, StatefulComponent,
@@ -6,7 +8,7 @@ use super::{
 #[derive(Debug, Clone)]
 pub(super) struct StatefulInputStreamComponent {
     pub(super) component: InputStreamComponent,
-    pub(super) size: Option<Size>,
+    pub(super) size: Size,
 }
 
 impl StatefulInputStreamComponent {
@@ -20,10 +22,23 @@ impl StatefulInputStreamComponent {
 }
 
 impl InputStreamComponent {
-    pub(super) fn stateful_component(self, _ctx: &BuildStateTreeCtx) -> StatefulComponent {
-        StatefulComponent::InputStream(StatefulInputStreamComponent {
-            component: self,
-            size: None, // TODO: get from ctx
-        })
+    pub(super) fn stateful_component(
+        self,
+        ctx: &BuildStateTreeCtx,
+    ) -> Result<StatefulComponent, BuildSceneError> {
+        let input = ctx
+            .input_resolutions
+            .get(&self.input_id)
+            .copied()
+            .unwrap_or(Resolution {
+                width: 0,
+                height: 0,
+            });
+        Ok(StatefulComponent::InputStream(
+            StatefulInputStreamComponent {
+                component: self,
+                size: input.into(),
+            },
+        ))
     }
 }

--- a/compositor_render/src/scene/layout.rs
+++ b/compositor_render/src/scene/layout.rs
@@ -99,6 +99,10 @@ impl StatefulLayoutComponent {
                 StatefulComponent::Shader(_) => {
                     child_index_offset += 1; // no state
                 }
+                StatefulComponent::Image(image) => {
+                    image.size = input_resolutions[child_index_offset].map(Into::into);
+                    child_index_offset += 1;
+                }
                 StatefulComponent::Layout(layout) => {
                     let node_children = layout.node_children().len();
                     layout.update_state(

--- a/compositor_render/src/scene/layout.rs
+++ b/compositor_render/src/scene/layout.rs
@@ -93,15 +93,17 @@ impl StatefulLayoutComponent {
         for child in self.children_mut().iter_mut() {
             match child {
                 StatefulComponent::InputStream(input) => {
-                    input.size = input_resolutions[child_index_offset].map(Into::into);
+                    // TODO
+                    input.size = input_resolutions[child_index_offset]
+                        .map(Into::into)
+                        .unwrap_or(Size {
+                            width: 0.0,
+                            height: 0.0,
+                        });
                     child_index_offset += 1;
                 }
-                StatefulComponent::Shader(_) => {
+                StatefulComponent::Shader(_) | StatefulComponent::Image(_) => {
                     child_index_offset += 1; // no state
-                }
-                StatefulComponent::Image(image) => {
-                    image.size = input_resolutions[child_index_offset].map(Into::into);
-                    child_index_offset += 1;
                 }
                 StatefulComponent::Layout(layout) => {
                     let node_children = layout.node_children().len();

--- a/compositor_render/src/scene/scene_state.rs
+++ b/compositor_render/src/scene/scene_state.rs
@@ -1,6 +1,8 @@
 use std::{collections::HashMap, time::Duration};
 
-use compositor_common::scene::{OutputId, Resolution};
+use compositor_common::scene::{InputId, OutputId, Resolution};
+
+use crate::renderer::renderers::Renderers;
 
 use super::{
     image_component::StatefulImageComponent,
@@ -13,11 +15,15 @@ use super::{
 pub(super) struct BuildStateTreeCtx<'a> {
     pub(super) prev_state: HashMap<ComponentId, &'a StatefulComponent>,
     pub(super) last_render_pts: Duration,
+    pub(super) renderers: &'a Renderers,
+    pub(super) input_resolutions: &'a HashMap<InputId, Resolution>,
 }
 
 pub(crate) struct SceneState {
     outputs: Vec<OutputSceneState>,
     last_pts: Duration,
+    // Input resolutions from the last render
+    input_resolutions: HashMap<InputId, Resolution>,
 }
 
 #[derive(Debug, Clone)]
@@ -38,17 +44,24 @@ impl SceneState {
         Self {
             outputs: vec![],
             last_pts: Duration::ZERO,
+            input_resolutions: HashMap::new(),
         }
     }
 
-    pub(crate) fn register_render_event(&mut self, pts: Duration) {
-        self.last_pts = pts
+    pub(crate) fn register_render_event(
+        &mut self,
+        pts: Duration,
+        input_resolutions: HashMap<InputId, Resolution>,
+    ) {
+        self.last_pts = pts;
+        self.input_resolutions = input_resolutions;
         // TODO: pass input stream sizes and populate it in the ComponentState tree
     }
 
     pub(crate) fn update_scene(
         &mut self,
         outputs: Vec<OutputScene>,
+        renderers: &Renderers,
     ) -> Result<Vec<OutputNode>, BuildSceneError> {
         let ctx = BuildStateTreeCtx {
             prev_state: self
@@ -61,15 +74,19 @@ impl SceneState {
                 })
                 .collect(),
             last_render_pts: self.last_pts,
+            input_resolutions: &self.input_resolutions,
+            renderers,
         };
         let output_states = outputs
             .into_iter()
-            .map(|o| OutputSceneState {
-                output_id: o.output_id,
-                root: o.root.stateful_component(&ctx),
-                resolution: o.resolution,
+            .map(|o| {
+                Ok(OutputSceneState {
+                    output_id: o.output_id,
+                    root: o.root.stateful_component(&ctx)?,
+                    resolution: o.resolution,
+                })
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, _>>()?;
         let nodes = output_states
             .iter()
             .map(|output| {
@@ -119,11 +136,11 @@ impl IntermediateNode {
         };
         match self {
             IntermediateNode::InputStream(input) => Ok(Node {
-                params: NodeParams::InputStream(input.component), // TODO: enforce resolution
+                params: NodeParams::InputStream(input.component.input_id), // TODO: enforce resolution
                 children: vec![],
             }),
             IntermediateNode::Shader { shader, children } => Ok(Node {
-                params: NodeParams::Shader(shader.component), // TODO: enforce resolution
+                params: NodeParams::Shader(shader.component, shader.shader), // TODO: enforce resolution
                 children: children
                     .into_iter()
                     .map(|node| node.build_tree(None, pts))
@@ -139,7 +156,7 @@ impl IntermediateNode {
                     .collect::<Result<_, _>>()?,
             }),
             IntermediateNode::Image(image) => Ok(Node {
-                params: NodeParams::Image(image.component),
+                params: NodeParams::Image(image.image),
                 children: vec![],
             }),
         }
@@ -147,18 +164,12 @@ impl IntermediateNode {
 
     fn node_size(&self, pts: Duration) -> Result<Size, BuildSceneError> {
         match self {
-            IntermediateNode::InputStream(input) => Ok(input.size.unwrap_or(Size {
-                width: 1.0,
-                height: 1.0,
-            })),
+            IntermediateNode::InputStream(input) => Ok(input.size),
             IntermediateNode::Shader {
                 shader,
                 children: _,
             } => Ok(shader.component.size),
-            IntermediateNode::Image(image) => Ok(image.size.unwrap_or(Size {
-                width: 1.0,
-                height: 1.0,
-            })),
+            IntermediateNode::Image(image) => Ok(image.size()),
             IntermediateNode::Layout { root, children: _ } => {
                 let (width, height) = match root.position(pts) {
                     Position::Static { width, height } => (width, height),

--- a/compositor_render/src/scene/view_component.rs
+++ b/compositor_render/src/scene/view_component.rs
@@ -98,7 +98,10 @@ impl StatefulViewComponent {
 }
 
 impl ViewComponent {
-    pub(super) fn stateful_component(self, ctx: &BuildStateTreeCtx) -> StatefulComponent {
+    pub(super) fn stateful_component(
+        self,
+        ctx: &BuildStateTreeCtx,
+    ) -> Result<StatefulComponent, BuildSceneError> {
         let previous_state = self
             .id
             .as_ref()
@@ -123,7 +126,7 @@ impl ViewComponent {
             };
             previous_state.transition.map(|_| Transition { duration })
         });
-        StatefulComponent::Layout(StatefulLayoutComponent::View(StatefulViewComponent {
+        let view = StatefulViewComponent {
             start,
             end: ViewComponentParam {
                 id: self.id,
@@ -136,8 +139,11 @@ impl ViewComponent {
                 .children
                 .into_iter()
                 .map(|c| Component::stateful_component(c, ctx))
-                .collect(),
+                .collect::<Result<_, _>>()?,
             start_pts: ctx.last_render_pts,
-        }))
+        };
+        Ok(StatefulComponent::Layout(StatefulLayoutComponent::View(
+            view,
+        )))
     }
 }

--- a/compositor_render/src/transformations.rs
+++ b/compositor_render/src/transformations.rs
@@ -1,6 +1,5 @@
 #[allow(dead_code)]
 pub mod builtin;
-#[allow(dead_code)]
 pub mod image_renderer;
 #[allow(dead_code)]
 pub mod layout;

--- a/compositor_render/src/transformations/image_renderer.rs
+++ b/compositor_render/src/transformations/image_renderer.rs
@@ -25,7 +25,7 @@ use crate::{
     },
 };
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum Image {
     Bitmap(Arc<BitmapAsset>),
     Animated(Arc<AnimatedAsset>),
@@ -61,6 +61,14 @@ impl Image {
             }
         };
         Ok(renderer)
+    }
+
+    pub fn resolution(&self) -> Resolution {
+        match self {
+            Image::Bitmap(asset) => asset.resolution(),
+            Image::Animated(asset) => asset.resolution(),
+            Image::Svg(asset) => asset.resolution(),
+        }
     }
 
     fn download_file(src: &ImageSrc) -> Result<bytes::Bytes, ImageError> {
@@ -139,6 +147,7 @@ pub struct BitmapNodeState {
     was_rendered: bool,
 }
 
+#[derive(Debug)]
 pub struct BitmapAsset {
     texture: RGBATexture,
 }
@@ -182,6 +191,7 @@ pub struct SvgNodeState {
     was_rendered: bool,
 }
 
+#[derive(Debug)]
 pub struct SvgAsset {
     texture: RGBATexture,
 }
@@ -251,11 +261,13 @@ pub struct AnimatedNodeState {
     first_pts: Option<Duration>,
 }
 
+#[derive(Debug)]
 pub struct AnimatedAsset {
     frames: Vec<AnimationFrame>,
     animation_duration: Duration,
 }
 
+#[derive(Debug)]
 struct AnimationFrame {
     texture: RGBATexture,
     pts: Duration,

--- a/compositor_render/src/transformations/image_renderer.rs
+++ b/compositor_render/src/transformations/image_renderer.rs
@@ -118,6 +118,7 @@ impl ImageNode {
     }
 
     pub fn render(&self, ctx: &mut RenderCtx, target: &mut NodeTexture, pts: Duration) {
+        target.ensure_size(ctx.wgpu_ctx, self.resolution());
         match self {
             ImageNode::Bitmap { asset, state } => asset.render(ctx.wgpu_ctx, target, state),
             ImageNode::Animated { asset, state } => asset.render(ctx.wgpu_ctx, target, state, pts),
@@ -125,7 +126,7 @@ impl ImageNode {
         }
     }
 
-    pub fn resolution(&self) -> Resolution {
+    fn resolution(&self) -> Resolution {
         match self {
             ImageNode::Bitmap { asset, .. } => asset.resolution(),
             ImageNode::Animated { asset, .. } => asset.resolution(),

--- a/compositor_render/src/transformations/shader.rs
+++ b/compositor_render/src/transformations/shader.rs
@@ -12,6 +12,7 @@ use crate::wgpu::{
 
 pub mod node;
 
+#[derive(Debug)]
 pub struct Shader {
     wgpu_shader: WgpuShader,
     fallback_strategy: FallbackStrategy,

--- a/compositor_render/src/transformations/shader/node.rs
+++ b/compositor_render/src/transformations/shader/node.rs
@@ -24,16 +24,11 @@ pub struct ShaderNode {
 impl ShaderNode {
     pub fn new(
         ctx: &RenderCtx,
+        shader: Arc<Shader>,
         shader_id: &RendererId,
         shader_params: &Option<ShaderParam>,
         resolution: &Resolution,
     ) -> Result<Self, CreateNodeError> {
-        let shader = ctx
-            .renderers
-            .shaders
-            .get(shader_id)
-            .ok_or_else(|| CreateNodeError::ShaderNotFound(shader_id.clone()))?;
-
         if let Some(params) = shader_params {
             shader.wgpu_shader.validate_params(params).map_err(|err| {
                 CreateNodeError::ShaderNodeParametersValidationError(err, shader_id.clone())

--- a/compositor_render/src/wgpu/texture/rgba.rs
+++ b/compositor_render/src/wgpu/texture/rgba.rs
@@ -4,6 +4,7 @@ use crate::wgpu::WgpuCtx;
 
 use super::base::Texture;
 
+#[derive(Debug)]
 pub struct RGBATexture(Texture);
 
 impl RGBATexture {

--- a/examples/long_ffmpeg.rs
+++ b/examples/long_ffmpeg.rs
@@ -89,6 +89,15 @@ fn start_example_client_code() -> Result<()> {
         ),
     };
 
+    info!("[example] Register static images");
+    common::post(&json!({
+        "type": "register",
+        "entity_type": "image",
+        "image_id": "example_gif",
+        "asset_type": "gif",
+        "url": "https://gifdb.com/images/high/rust-logo-on-fire-o41c0v9om8drr8dv.gif",
+    }))?;
+
     let shader_source = include_str!("./silly.wgsl");
     info!("[example] Register shader transform");
     common::post(&json!({
@@ -151,9 +160,8 @@ fn start_example_client_code() -> Result<()> {
                 "height": 1080,
                 "children": [
                     {
-                        "type": "input_stream",
-                        "input_id": "input_1",
-                        "id": "input_1"
+                        "type": "image",
+                        "image_id": "example_gif",
                     }
                 ]
             }

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -253,15 +253,6 @@
         {
           "additionalProperties": false,
           "properties": {
-            "children": {
-              "items": {
-                "$ref": "#/definitions/Component"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
             "id": {
               "anyOf": [
                 {

--- a/snapshot_tests/image/jpeg_as_root.scene.json
+++ b/snapshot_tests/image/jpeg_as_root.scene.json
@@ -1,0 +1,7 @@
+{
+    "root": {
+        "type": "image",
+        "image_id": "image_jpeg"
+    },
+    "output_id": "output_1"
+}

--- a/snapshot_tests/image/jpeg_in_view.scene.json
+++ b/snapshot_tests/image/jpeg_in_view.scene.json
@@ -1,0 +1,12 @@
+{
+    "root": {
+        "type": "view",
+        "children": [
+            {
+                "type": "image",
+                "image_id": "image_jpeg"
+            }
+        ]
+    },
+    "output_id": "output_1"
+}

--- a/src/snapshot_tests/tests.rs
+++ b/src/snapshot_tests/tests.rs
@@ -14,6 +14,7 @@ pub fn snapshot_tests() -> Vec<TestCase> {
     tests.append(&mut base_snapshot_tests());
     tests.append(&mut view_snapshot_tests());
     tests.append(&mut transition_snapshot_tests());
+    tests.append(&mut image_snapshot_tests());
     // tests.append(&mut text_snapshot_tests());
     // tests.append(&mut tiled_layout_tests());
     // tests.append(&mut stretch_to_resolution_tests());
@@ -570,6 +571,33 @@ pub fn snapshot_tests() -> Vec<TestCase> {
 //        },
 //    ])
 //}
+
+pub fn image_snapshot_tests() -> Vec<TestCase> {
+    let image_renderer = include_str!("../../snapshot_tests/register/image_jpeg.register.json");
+
+    Vec::from([
+        TestCase {
+            name: "image/jpeg_as_root",
+            outputs: Outputs::Scene(vec![(
+                include_str!("../../snapshot_tests/image/jpeg_as_root.scene.json"),
+                DEFAULT_RESOLUTION,
+            )]),
+            renderers: vec![image_renderer],
+            inputs: vec![TestInput::new(1)],
+            ..Default::default()
+        },
+        TestCase {
+            name: "image/jpeg_in_view",
+            outputs: Outputs::Scene(vec![(
+                include_str!("../../snapshot_tests/image/jpeg_in_view.scene.json"),
+                DEFAULT_RESOLUTION,
+            )]),
+            renderers: vec![image_renderer],
+            inputs: vec![TestInput::new(1)],
+            ..Default::default()
+        },
+    ])
+}
 
 pub fn transition_snapshot_tests() -> Vec<TestCase> {
     Vec::from([

--- a/src/types/component.rs
+++ b/src/types/component.rs
@@ -102,7 +102,6 @@ pub struct WebRenderer {
 #[serde(deny_unknown_fields)]
 pub struct Image {
     pub id: Option<ComponentId>,
-    pub children: Option<Vec<Component>>,
     pub image_id: RendererId,
 }
 

--- a/src/types/from_component.rs
+++ b/src/types/from_component.rs
@@ -15,7 +15,7 @@ impl TryFrom<Component> for scene::Component {
             Component::View(view) => Ok(Self::View(view.try_into()?)),
             Component::WebRenderer(_node) => todo!(),
             Component::Shader(shader) => Ok(Self::Shader(shader.try_into()?)),
-            Component::Image(_node) => todo!(),
+            Component::Image(node) => Ok(Self::Image(node.into())),
             Component::Text(_node) => todo!(),
             Component::FixedPositionLayout(_node) => {
                 todo!()
@@ -153,6 +153,15 @@ impl From<ShaderParam> for shader::ShaderParam {
             ShaderParam::Struct(v) => {
                 shader::ShaderParam::Struct(v.into_iter().map(from_struct_field).collect())
             }
+        }
+    }
+}
+
+impl From<Image> for scene::ImageComponent {
+    fn from(image: Image) -> Self {
+        Self {
+            id: image.id.map(Into::into),
+            image_id: image.image_id.into(),
         }
     }
 }


### PR DESCRIPTION
Tests - https://github.com/membraneframework-labs/video_compositor_snapshot_tests/pull/10

https://github.com/membraneframework/video_compositor/pull/254/commits/7d1061c0b18e8f9cd3cdb2b5bdcda770f8b1e01a - Adds image component 
https://github.com/membraneframework/video_compositor/pull/254/commits/f21132c492dde443b2cd44693e9436b6a0fd19ed - Refactors code, so size of the input stream/images is always known + pass Image/Arc<Shader> directly  using NodeParams