### PR TITLE
Add `resize_content` option

### DIFF
--- a/compositor_render/src/scene/components.rs
+++ b/compositor_render/src/scene/components.rs
@@ -129,6 +129,7 @@ pub struct ViewComponent {
     pub position: Position,
     pub transition: Option<Transition>,
     pub overflow: Overflow,
+    pub resize_content: ResizeMode,
 
     pub background_color: RGBAColor,
 }
@@ -138,6 +139,13 @@ pub enum Overflow {
     Visible,
     Hidden,
     Fit,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ResizeMode {
+    None,
+    Fit,
+    Fill,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/compositor_render/src/scene/view_component.rs
+++ b/compositor_render/src/scene/view_component.rs
@@ -6,7 +6,7 @@ use crate::{scene::ViewChildrenDirection, transformations::layout::NestedLayout}
 
 use super::{
     components::ViewComponent, layout::StatefulLayoutComponent, scene_state::BuildStateTreeCtx,
-    Component, ComponentId, IntermediateNode, Overflow, Position, SceneError, Size,
+    Component, ComponentId, IntermediateNode, Overflow, Position, ResizeMode, SceneError, Size,
     StatefulComponent, Transition,
 };
 
@@ -29,6 +29,7 @@ struct ViewComponentParam {
     direction: ViewChildrenDirection,
     position: Position,
     overflow: Overflow,
+    resize_content: ResizeMode,
 
     background_color: RGBAColor,
 }
@@ -132,6 +133,7 @@ impl ViewComponent {
                 position: self.position,
                 background_color: self.background_color,
                 overflow: self.overflow,
+                resize_content: self.resize_content,
             },
             transition,
             children: self

--- a/compositor_render/src/scene/view_component/interpolation.rs
+++ b/compositor_render/src/scene/view_component/interpolation.rs
@@ -10,6 +10,7 @@ impl ContinuousValue for ViewComponentParam {
             position: ContinuousValue::interpolate(&start.position, &end.position, state),
             background_color: end.background_color,
             overflow: end.overflow,
+            resize_content: end.resize_content,
         }
     }
 }

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -115,6 +115,17 @@
               ],
               "description": "(default=\"hidden\") Controls what happens to content that is too big to fit into an area."
             },
+            "resize_content": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ResizeMode"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "(default=\"none\") Controls how content of an element should be resized."
+            },
             "right": {
               "description": "Distance between the right edge of this component and the right edge of its parent. If this field is defined, this element will be absolutely positioned, instead of being laid out by it's parent.",
               "format": "float",
@@ -606,7 +617,7 @@
           "type": "string"
         },
         {
-          "description": "If children component are to big to fit inside the parent resize everything inside to fit.\n\nComponents that have dynamic size will be treated as if they had a size 0 when calculating scaling factor.\n\nWarning: This will resize everything inside even absolutely positioned elements. For example, if you have an element in the bottom right corner and content will be rescaled by a factor 0.5x then that component will end up in the middle of it's parent",
+          "description": "If children component are to big to fit inside the parent resize everything inside to fit.\n\nComponents that have do not have defined size will be treated as if they had a size 0 when calculating scaling factor.\n\nWarning: This will resize everything inside even absolutely positioned elements. For example, if you have an element in the bottom right corner and content will be rescaled by a factor 0.5x then that component will end up in the middle of it's parent",
           "enum": [
             "fit"
           ],
@@ -619,6 +630,31 @@
     },
     "RendererId": {
       "type": "string"
+    },
+    "ResizeMode": {
+      "oneOf": [
+        {
+          "description": "Never resize.\n\nNote: Setting `overflow=fit` might still cause elements to be resized even if this mode is selected",
+          "enum": [
+            "none"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Resize elements while preserving aspect ratio, so width or height of a content is the same as its parent's, but entire content is still inside.",
+          "enum": [
+            "fit"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Resize elements while preserving aspect ratio, so width or height of a content is the same as its parent's, and parts of the content are outside of the parent.",
+          "enum": [
+            "fill"
+          ],
+          "type": "string"
+        }
+      ]
     },
     "Resolution": {
       "properties": {

--- a/src/types/component.rs
+++ b/src/types/component.rs
@@ -69,6 +69,9 @@ pub struct View {
     /// (default="hidden") Controls what happens to content that is too big to fit into an area.
     pub overflow: Option<Overflow>,
 
+    /// (default="none") Controls how content of an element should be resized.
+    pub resize_content: Option<ResizeMode>,
+
     /// (default="#00000000") Background color in a "#RRGGBBAA" format.
     pub background_color_rgba: Option<RGBAColor>,
 }
@@ -82,13 +85,29 @@ pub enum Overflow {
     Hidden,
     /// If children component are to big to fit inside the parent resize everything inside to fit.
     ///
-    /// Components that have dynamic size will be treated as if they had a size 0 when calculating
-    /// scaling factor.
+    /// Components that have do not have defined size will be treated as if they had a size 0 when
+    /// calculating scaling factor.
     ///
     /// Warning: This will resize everything inside even absolutely positioned
     /// elements. For example, if you have an element in the bottom right corner and content will
     /// be rescaled by a factor 0.5x then that component will end up in the middle of it's parent
     Fit,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ResizeMode {
+    /// Never resize.
+    ///
+    /// Note: Setting `overflow=fit` might still cause elements to be resized even if this mode is
+    /// selected
+    None,
+    /// Resize elements while preserving aspect ratio, so width or height of a content is the same
+    /// as its parent's, but entire content is still inside.
+    Fit,
+    /// Resize elements while preserving aspect ratio, so width or height of a content is the same
+    /// as its parent's, and parts of the content are outside of the parent.
+    Fill,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]

--- a/src/types/from_component.rs
+++ b/src/types/from_component.rs
@@ -94,6 +94,12 @@ impl TryFrom<View> for scene::ViewComponent {
             Some(Overflow::Fit) => scene::Overflow::Fit,
             None => scene::Overflow::Hidden,
         };
+        let resize_content = match view.resize_content {
+            Some(ResizeMode::None) => scene::ResizeMode::None,
+            Some(ResizeMode::Fit) => scene::ResizeMode::Fit,
+            Some(ResizeMode::Fill) => scene::ResizeMode::Fill,
+            None => scene::ResizeMode::None,
+        };
         Ok(Self {
             id: view.id.map(Into::into),
             children: view
@@ -105,6 +111,7 @@ impl TryFrom<View> for scene::ViewComponent {
             direction,
             position,
             overflow,
+            resize_content,
             background_color: view
                 .background_color_rgba
                 .map(TryInto::try_into)


### PR DESCRIPTION
Still need to test it. I opened this to get early feedback on API.

The behavior of a `resize_content` option:
- `fit` with  image inside view will produce that image aligned to top left
- `fit` with multiple children where some of them are `View` that do not have width/height.
  - if summary width(direction=row) is larger than parents then rescale to fit. All dynamic components will have width 0.
  - if summary width(direction=row) is smaller than parents do not scale because it will always fit
- `fill` with image inside view will produce that image centered inside the view
- `fill` with multiple children  where some of them are `View`s that do not have width specified
  - if summary width(direction=row) is larger than parents then rescale to fit. All dynamic components will have width 0.
  - if the summary width(direction=row) is smaller than the parents do not scale because the dynamic component will scale.
- Yes I know fit and fill are inconsistent (I'm open to suggestions). The main problem here is that in most cases users will want to align to the center when it's a non-layout component and to the top-left when it's a layout, but I don't want to add logic like that in code, it would be hard to explain in docs.

Alternative approaches:
- Separate component that can only take one child.
  - API is more intuitive. There is an easy way to add more options.
  - A lot more work overall. The new component would be a LayoutComponent, so eventually we would have to support a lot of the same fields as in View e.g. width/height/top/left/right/bottom. Respect top/left/right/bottom in its children etc...
- We could remove the current inconsistency between fit and fill and
   - always center the image (both for fit and fill)
   - always align to the top left
   - provide options on how to align (I want to avoid nested objects in API and it would be hard to name those additional fields so it's clear that they refer to alignment after resizing
- Make `resize_content` only work if it has only one child
  - Pro: Clean API, (overflow=fit and resize_content) has its own use cases and a bit different behavior)
  - Pro: We don't need to worry about dynamically sized components. (We only have one so it's a lot easier to handle all the cases)
  - Pro: We don't need to implement totally new LayoutComponent, so the maintenance burden is not increased
  - Con: I don't like it. It seems wrong. :D