### PR TITLE
[docs] Replace generated docs + some style changes + update

### DIFF
--- a/docs/pages/api/components/Image.md
+++ b/docs/pages/api/components/Image.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+hide_table_of_contents: true
 ---
 import Docs from "@site/pages/api/generated/component-Image.md"
 

--- a/docs/pages/api/components/InputStream.md
+++ b/docs/pages/api/components/InputStream.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+hide_table_of_contents: true
 ---
 
 import Docs from "@site/pages/api/generated/component-InputStream.md"

--- a/docs/pages/api/components/Rescaler.md
+++ b/docs/pages/api/components/Rescaler.md
@@ -1,7 +1,9 @@
 ---
 sidebar_position: 3
+hide_table_of_contents: true
 ---
 import Docs from "@site/pages/api/generated/component-Rescaler.md"
+import AbsolutePositionDefinition from "@site/pages/common/absolute-position.md"
 
 # Rescaler
 
@@ -9,11 +11,9 @@ import Docs from "@site/pages/api/generated/component-Rescaler.md"
 
 ### Absolute positioning
 
-A component is absolutely positioned if it defines fields like `top`, `left`, `right`, `bottom`, or `rotation`.
-Those fields define the component's position relative to its parent. However, to respect those
-values, the parent component has to be a layout component that supports absolute positioning.
+<AbsolutePositionDefinition />
 
-- `Rescaler` **does not** support absolute positioning for its child components. All children will still be rendered, but all fields like `top`, `left`, `right`, `bottom`, and `rotation` will be ignored.
+- `Rescaler` **does not** support absolute positioning for its child components. A child component will still be rendered, but all fields like `top`, `left`, `right`, `bottom`, and `rotation` will be ignored.
 - `Rescaler` can be absolutely positioned relative to its parent, if the parent component supports it.
 
 ### Static positioning

--- a/docs/pages/api/components/Shader.md
+++ b/docs/pages/api/components/Shader.md
@@ -2,7 +2,6 @@
 sidebar_position: 6
 hide_table_of_contents: true
 ---
-import Docs from "@site/pages/api/generated/component-Shader.md"
 
 # Shader
 
@@ -35,10 +34,11 @@ type Shader = {
 - `shader_param` - Object that will be serialized into a `struct` and passed inside the shader as:
 
   ```wgsl
-  @group(1) @binding(0) var<uniform> user_defined_var UserDefinedStruct;
+  @group(1) @binding(0) var<uniform> user_defined_var: UserDefinedStruct;
   ```
   :::note
-  This object's structure must match the structure defined in a shader source code.
+  This object's structure must match the structure defined in a shader source code. Currently, we do not handle memory layout automatically.
+  To achieve the correct memory alignment, you might need to pad your data with additional fields. See [WGSL documentation](https://www.w3.org/TR/WGSL/#alignment-and-size) for more details.
   :::
 - `resolution` - Resolution of a texture where shader will be executed.
 

--- a/docs/pages/api/components/Shader.md
+++ b/docs/pages/api/components/Shader.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+hide_table_of_contents: true
 ---
 import Docs from "@site/pages/api/generated/component-Shader.md"
 
@@ -11,4 +12,49 @@ import Docs from "@site/pages/api/generated/component-Shader.md"
 To use this component, you need to first register the shader with matching `shader_id` using [`RegisterRenderer`](../routes#register-renderer) request.
 :::
 
-<Docs />
+## Shader
+
+```typescript
+type Shader = {
+  type: "shader";
+  id: string;
+  children?: Component[];
+  shader_id: string;
+  shader_param: ShaderParam;
+  resolution: {
+    width: u32,
+    height: u32,
+  }
+}
+```
+
+#### Properties
+- `id` - Id of a component.
+- `children` - List of component's children.
+- `shader_id` - Id of a shader. It identifies a shader registered using a [`RegisterRenderer`](../routes#register-renderer) request.
+- `shader_param` - Object that will be serialized into a `struct` and passed inside the shader as:
+
+  ```wgsl
+  @group(1) @binding(0) var<uniform> user_defined_var UserDefinedStruct;
+  ```
+  :::note
+  This object's structure must match the structure defined in a shader source code.
+  :::
+- `resolution` - Resolution of a texture where shader will be executed.
+
+## ShaderParam
+```typescript
+type ShaderParam =
+  | { type: "f32"; value: f32 }
+  | { type: "u32"; value: u32 }
+  | { type: "i32"; value: i32 }
+  | { type: "list"; value: ShaderParam[] }
+  | { type: "struct"; value: ShaderParamStructField[] }
+
+type ShaderParamStructField =
+  | { field_name: string; type: "f32"; value: f32 }
+  | { field_name: string; type: "u32"; value: u32 }
+  | { field_name: string; type: "i32"; value: i32 }
+  | { field_name: string; type: "list"; value: ShaderParam[] }
+  | { field_name: string; type: "struct"; value: ShaderParamStructField[] }
+```

--- a/docs/pages/api/components/Text.md
+++ b/docs/pages/api/components/Text.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+hide_table_of_contents: true
 ---
 import Docs from "@site/pages/api/generated/component-Text.md"
 

--- a/docs/pages/api/components/Tiles.md
+++ b/docs/pages/api/components/Tiles.md
@@ -1,13 +1,17 @@
 ---
 sidebar_position: 4
+hide_table_of_contents: true
 ---
 import Docs from "@site/pages/api/generated/component-Tiles.md"
+import AbsolutePositionDefinition from "@site/pages/common/absolute-position.md"
 
 # Tiles
 
 `Tiles` is a layout component that places all the child components next to each other while maximizing the use of available space. The component divides its area into multiple rectangles/tiles, one for each child component. All of those rectangles are the same size and do not overlap over each other.
 
 ### Absolute positioning
+
+<AbsolutePositionDefinition />
 
 - `Tiles` **does not** support absolute positioning for its child components. All children will still be rendered, but all fields like `top`, `left`, `right`, `bottom`, and `rotation` will be ignored.
 - `Tiles` **can not** be absolutely positioned relative to it's parent.

--- a/docs/pages/api/components/View.md
+++ b/docs/pages/api/components/View.md
@@ -1,7 +1,9 @@
 ---
 sidebar_position: 2
+hide_table_of_contents: true
 ---
 import Docs from "@site/pages/api/generated/component-View.md"
+import AbsolutePositionDefinition from "@site/pages/common/absolute-position.md"
 
 # View
 
@@ -10,9 +12,7 @@ import Docs from "@site/pages/api/generated/component-View.md"
 
 ### Absolute positioning
 
-A component is absolutely positioned if it defines fields like `top`, `left`, `right`, `bottom`, or `rotation`.
-Those fields define the component's position relative to its parent. However, to respect those
-values, the parent component has to be a layout component that supports absolute positioning.
+<AbsolutePositionDefinition />
 
 - `View` supports absolute positioning for its child components.
 - `View` can be absolutely positioned relative to its parent if the parent component supports it.

--- a/docs/pages/api/components/WebView.md
+++ b/docs/pages/api/components/WebView.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 8
+hide_table_of_contents: true
 ---
 import Docs from "@site/pages/api/generated/component-WebView.md"
 

--- a/docs/pages/api/io.md
+++ b/docs/pages/api/io.md
@@ -1,8 +1,0 @@
----
-description: Configuration and delivery of input and output streams.
----
-# Streams
-
-## Input stream
-
-## Output stream

--- a/docs/pages/api/renderers/image.md
+++ b/docs/pages/api/renderers/image.md
@@ -1,5 +1,31 @@
-import Docs from "@site/pages/api/generated/renderer-Image.md"
+# Image
 
-# Image 
+Represents an image asset uploaded available to compositor. Used by a [`Image` component](../components/Image).
 
-<Docs />
+## Image
+
+```typescript
+type Image = {
+  image_id: string;
+  url?: string;
+  path?: string;
+} & Asset
+
+type Asset =
+  | { asset_type: "png" }
+  | { asset_type: "jpeg" }
+  | { asset_type: "gif" }
+  | { 
+      asset_type: "svg";
+      resolution?: {
+        width: u32,
+        height: u32,
+      };
+    }
+```
+
+- `image_id` - Id of an image. It can be used in an [`Image`](../components/Image) component after registration.
+- `url` - Url to download an image. This field is mutually exclusive with the `path` field.
+- `path` - Path to an image. This field is mutually exclusive with the `url` field.
+- `asset_type` - Format of an image.
+- `resolution` - The resolution at which an SVG image should be rendered.

--- a/docs/pages/api/renderers/image.md
+++ b/docs/pages/api/renderers/image.md
@@ -1,6 +1,6 @@
 # Image
 
-Represents an image asset uploaded available to compositor. Used by a [`Image` component](../components/Image).
+Represents an image asset uploaded to the compositor. Used by a [`Image` component](../components/Image).
 
 ## Image
 

--- a/docs/pages/api/renderers/shader.md
+++ b/docs/pages/api/renderers/shader.md
@@ -2,4 +2,6 @@ import Docs from "@site/pages/api/generated/renderer-Shader.md"
 
 # Shader
 
+Represents compiled shader. Used by a [`Shader` component](../components/Shader).
+
 <Docs />

--- a/docs/pages/api/renderers/web.md
+++ b/docs/pages/api/renderers/web.md
@@ -2,4 +2,6 @@ import Docs from "@site/pages/api/generated/renderer-WebRenderer.md"
 
 # Web Renderer
 
+Represents an instance of a website opened with Chromimum embeded inside the compositor. Used by a [`WebView` component](../components/WebView). Only one `WebView` component can use a specific instance at a time.
+
 <Docs />

--- a/docs/pages/api/routes.md
+++ b/docs/pages/api/routes.md
@@ -74,8 +74,8 @@ type RegisterInputStream = {
 Register a new RTP input stream.
 
 - `input_id` - An identifier for the input stream. It can be used in the [`InputStream`](./components/InputStream) component to render the stream content.
-- `port` - UDP port or port range that the compositor should listen for stream. Integer value between 1 and 65535 representing specific port or
-  string in the `START:END` format for a port range.
+- `port` - UDP port or port range on which the compositor should listen for the stream. An integer value between 1 and 65535 that represents a specific port
+or string in the `START:END` format for a port range.
 
 ***
 
@@ -113,7 +113,7 @@ type EncoderPreset =
 Register a new RTP output stream.
 
 - `output_id` - An identifier for the output stream. It can be used in the `UpdateScene` request to define what to render for the output stream.
-- `port` / `ip` - UDP port and IP where compositor should send the stream. 
+- `port` / `ip` - UDP port and IP where compositor should send the stream.
 - `resolution` - Output resolution in pixels.
 - `encoder_settings.preset` - Preset for an encoder. See `FFmpeg` [docs](https://trac.ffmpeg.org/wiki/Encode/H.264#Preset) to learn more.
 

--- a/docs/pages/common/absolute-position.md
+++ b/docs/pages/common/absolute-position.md
@@ -1,0 +1,3 @@
+A component is absolutely positioned if it defines fields like top, left, right, bottom, or rotation.
+Those fields define the component's position relative to its parent. However, to respect those values,
+the parent component has to be a layout component that supports absolute positioning.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -33,11 +33,6 @@ const sidebars: SidebarsConfig = {
           label: 'HTTP Routes',
         },
         {
-          type: 'doc',
-          id: 'api/io',
-          label: 'Input/Output streams',
-        },
-        {
           type: 'category',
           label: 'Components',
           collapsible: false,

--- a/schemas/register.schema.json
+++ b/schemas/register.schema.json
@@ -75,9 +75,15 @@
           ]
         },
         "shader_id": {
-          "$ref": "#/definitions/RendererId"
+          "description": "Id of a shader. It can be used in a [`Shader`](../components/Shader) component after registration.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RendererId"
+            }
+          ]
         },
         "source": {
+          "description": "Shader source code. [Learn more.](../../concept/shaders)",
           "type": "string"
         }
       }
@@ -98,15 +104,27 @@
           ]
         },
         "instance_id": {
-          "$ref": "#/definitions/RendererId"
+          "description": "Id of a web renderer instance. It can be used in a [`WebView`](../components/WebView) component after registration.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RendererId"
+            }
+          ]
         },
         "url": {
+          "description": "Url of a website that you want to render.",
           "type": "string"
         },
         "resolution": {
-          "$ref": "#/definitions/Resolution"
+          "description": "Resolution.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Resolution"
+            }
+          ]
         },
         "embedding_method": {
+          "description": "Mechanism used to render input frames on the website.",
           "anyOf": [
             {
               "$ref": "#/definitions/WebEmbeddingMethod"
@@ -343,11 +361,28 @@
       "type": "string"
     },
     "WebEmbeddingMethod": {
-      "type": "string",
-      "enum": [
-        "chromium_embedding",
-        "native_embedding_over_content",
-        "native_embedding_under_content"
+      "oneOf": [
+        {
+          "description": "Pass raw input frames as JS buffers so they can be rendered, for example, using a `<canvas>` component.\n\n<br/> <br/>\n\n:::warning\n\nThis method might have a significant performance impact, especially for a large number of inputs.\n\n:::",
+          "type": "string",
+          "enum": [
+            "chromium_embedding"
+          ]
+        },
+        {
+          "description": "Render a website without any inputs and overlay them over the website content.",
+          "type": "string",
+          "enum": [
+            "native_embedding_over_content"
+          ]
+        },
+        {
+          "description": "Render a website without any inputs and overlay them under the website content.",
+          "type": "string",
+          "enum": [
+            "native_embedding_under_content"
+          ]
+        }
       ]
     }
   }

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -105,7 +105,7 @@
               "format": "float"
             },
             "direction": {
-              "description": "Direction defines how static children are positioned inside a View component.\n\n- `\"row\"` - Children positioned from left to right.\n\n- `\"column\"` - Children positioned from top to bottom.",
+              "description": "Direction defines how static children are positioned inside a View component.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/ViewDirection"
@@ -167,7 +167,7 @@
               ]
             },
             "overflow": {
-              "description": "(default=`\"hidden\"`) Controls what happens to content that is too big to fit into an area.",
+              "description": "(**default=`\"hidden\"`**) Controls what happens to content that is too big to fit into an area.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/Overflow"
@@ -178,7 +178,7 @@
               ]
             },
             "background_color_rgba": {
-              "description": "(default=`\"#00000000\"`) Background color in a `\"#RRGGBBAA\"` format.",
+              "description": "(**default=`\"#00000000\"`**) Background color in a `\"#RRGGBBAA\"` format.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/RGBAColor"
@@ -382,7 +382,7 @@
               "format": "float"
             },
             "max_width": {
-              "description": "(default=`7682`) Maximal `width`. Limits the width of the texture that the text will be rendered on. Value is ignored if `width` is defined.",
+              "description": "(**default=`7682`**) Maximal `width`. Limits the width of the texture that the text will be rendered on. Value is ignored if `width` is defined.",
               "type": [
                 "number",
                 "null"
@@ -390,7 +390,7 @@
               "format": "float"
             },
             "max_height": {
-              "description": "(default=`4320`) Maximal height. Limits the height of the texture that the text will be rendered on. Value is ignored if height is defined.",
+              "description": "(**default=`4320`**) Maximal `height`. Limits the height of the texture that the text will be rendered on. Value is ignored if height is defined.",
               "type": [
                 "number",
                 "null"
@@ -411,7 +411,7 @@
               "format": "float"
             },
             "color_rgba": {
-              "description": "(default=`\"#FFFFFFFF\"`) Font color in `#RRGGBBAA` format.",
+              "description": "(**default=`\"#FFFFFFFF\"`**) Font color in `#RRGGBBAA` format.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/RGBAColor"
@@ -422,7 +422,7 @@
               ]
             },
             "background_color_rgba": {
-              "description": "(default=`\"#00000000\"`) Background color in `#RRGGBBAA` format.",
+              "description": "(**default=`\"#00000000\"`**) Background color in `#RRGGBBAA` format.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/RGBAColor"
@@ -433,14 +433,14 @@
               ]
             },
             "font_family": {
-              "description": "(default=`\"Verdana\"`) Font family. Provide [family-name](https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#family-name-value) for a specific font. \"generic-family\" values like e.g. \"sans-serif\" will not work.",
+              "description": "(**default=`\"Verdana\"`**) Font family. Provide [family-name](https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#family-name-value) for a specific font. \"generic-family\" values like e.g. \"sans-serif\" will not work.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "style": {
-              "description": "(default=`\"normal\"`) Font style. The selected font needs to support the specified style.",
+              "description": "(**default=`\"normal\"`**) Font style. The selected font needs to support the specified style.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/TextStyle"
@@ -451,7 +451,7 @@
               ]
             },
             "align": {
-              "description": "(default=`\"left\"`) Text align.",
+              "description": "(**default=`\"left\"`**) Text align.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/HorizontalAlign"
@@ -462,7 +462,7 @@
               ]
             },
             "wrap": {
-              "description": "(default=`\"none\"`) Text wrapping options.",
+              "description": "(**default=`\"none\"`**) Text wrapping options.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/TextWrapMode"
@@ -473,7 +473,7 @@
               ]
             },
             "weight": {
-              "description": "(default=`\"normal\"`) Font weight. The selected font needs to support the specified weight.",
+              "description": "(**default=`\"normal\"`**) Font weight. The selected font needs to support the specified weight.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/TextWeight"
@@ -536,7 +536,7 @@
               "format": "float"
             },
             "background_color_rgba": {
-              "description": "(default=`\"#00000000\"`) Background color in a `\"#RRGGBBAA\"` format.",
+              "description": "(**default=`\"#00000000\"`**) Background color in a `\"#RRGGBBAA\"` format.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/RGBAColor"
@@ -547,7 +547,7 @@
               ]
             },
             "tile_aspect_ratio": {
-              "description": "(default=`\"16:9\"`) Aspect ratio of a tile in `\"W:H\"` format, where W and H are integers.",
+              "description": "(**default=`\"16:9\"`**) Aspect ratio of a tile in `\"W:H\"` format, where W and H are integers.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/AspectRatio"
@@ -558,7 +558,7 @@
               ]
             },
             "margin": {
-              "description": "(default=`0`) Margin of each tile in pixels.",
+              "description": "(**default=`0`**) Margin of each tile in pixels.",
               "type": [
                 "number",
                 "null"
@@ -566,7 +566,7 @@
               "format": "float"
             },
             "padding": {
-              "description": "(default=`0`) Padding on each tile in pixels.",
+              "description": "(**default=`0`**) Padding on each tile in pixels.",
               "type": [
                 "number",
                 "null"
@@ -574,7 +574,7 @@
               "format": "float"
             },
             "horizontal_align": {
-              "description": "(default=`\"center\"`) Horizontal alignment of tiles.",
+              "description": "(**default=`\"center\"`**) Horizontal alignment of tiles.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/HorizontalAlign"
@@ -585,7 +585,7 @@
               ]
             },
             "vertical_align": {
-              "description": "(default=`\"center\"`) Vertical alignment of tiles.",
+              "description": "(**default=`\"center\"`**) Vertical alignment of tiles.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/VerticalAlign"
@@ -631,7 +631,7 @@
               ]
             },
             "mode": {
-              "description": "Resize mode:\n\n- `\"fit\"` - Resize the component proportionally, so one of the dimensions is the same as its parent, but it still fits inside it.\n\n- `\"fill\"` - Resize the component proportionally, so one of the dimensions is the same as its parent and the entire area of the parent is covered. Parts of a child that do not fit inside the parent are not rendered.",
+              "description": "(**default=`\"fit\"`**) Resize mode:",
               "anyOf": [
                 {
                   "$ref": "#/definitions/RescaleMode"
@@ -642,7 +642,7 @@
               ]
             },
             "horizontal_align": {
-              "description": "(default=`\"center\"`) Horizontal alignment.",
+              "description": "(**default=`\"center\"`**) Horizontal alignment.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/HorizontalAlign"
@@ -653,7 +653,7 @@
               ]
             },
             "vertical_align": {
-              "description": "(default=`\"center\"`) Vertical alignment.",
+              "description": "(**default=`\"center\"`**) Vertical alignment.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/VerticalAlign"
@@ -742,10 +742,21 @@
       "type": "string"
     },
     "ViewDirection": {
-      "type": "string",
-      "enum": [
-        "row",
-        "column"
+      "oneOf": [
+        {
+          "description": "Children positioned from left to right.",
+          "type": "string",
+          "enum": [
+            "row"
+          ]
+        },
+        {
+          "description": "Children positioned from top to bottom.",
+          "type": "string",
+          "enum": [
+            "column"
+          ]
+        }
       ]
     },
     "Transition": {
@@ -778,7 +789,7 @@
           ]
         },
         {
-          "description": "If children components are too big to fit inside the parent, resize everything inside to fit.\n\nComponents that have unknown sizes will be treated as if they had a size 0 when calculating scaling factor.\n\n:::warning\n\nThis will resize everything inside, even absolutely positioned elements. For example, if you have an element in the bottom right corner and the content will be rescaled by a factor 0.5x, then that component will end up in the middle of its parent\n\n:::",
+          "description": "If children components are too big to fit inside the parent, resize everything inside to fit.\n\nComponents that have unknown sizes will be treated as if they had a size 0 when calculating scaling factor.\n\n<br/><br/>\n\n:::warning\n\nThis will resize everything inside, even absolutely positioned elements. For example, if you have an element in the bottom right corner and the content will be rescaled by a factor 0.5x, then that component will end up in the middle of its parent\n\n:::",
           "type": "string",
           "enum": [
             "fit"
@@ -1178,10 +1189,21 @@
       ]
     },
     "RescaleMode": {
-      "type": "string",
-      "enum": [
-        "fit",
-        "fill"
+      "oneOf": [
+        {
+          "description": "Resize the component proportionally, so one of the dimensions is the same as its parent, but it still fits inside it.",
+          "type": "string",
+          "enum": [
+            "fit"
+          ]
+        },
+        {
+          "description": "Resize the component proportionally, so one of the dimensions is the same as its parent and the entire area of the parent is covered. Parts of a child that do not fit inside the parent are not rendered.",
+          "type": "string",
+          "enum": [
+            "fill"
+          ]
+        }
       ]
     }
   }

--- a/src/bin/generate_docs/main.rs
+++ b/src/bin/generate_docs/main.rs
@@ -1,8 +1,7 @@
 use parsing::generate_docs;
 use std::{fs, path::PathBuf};
 use video_compositor::types::{
-    Image, ImageSpec, InputStream, RegisterInputRequest, RegisterOutputRequest, Rescaler, Shader,
-    ShaderSpec, Text, Tiles, View, WebRendererSpec, WebView,
+    Image, InputStream, Rescaler, Shader, ShaderSpec, Text, Tiles, View, WebRendererSpec, WebView,
 };
 
 mod parsing;
@@ -16,11 +15,8 @@ fn main() {
     fs::create_dir(&docs_path).unwrap();
 
     let renderer_pages = [
-        generate_docs::<RegisterInputRequest>("InputStream"),
-        generate_docs::<RegisterOutputRequest>("OutputStream"),
         generate_docs::<ShaderSpec>("Shader"),
         generate_docs::<WebRendererSpec>("WebRenderer"),
-        generate_docs::<ImageSpec>("Image"),
     ];
 
     let component_pages = [

--- a/src/bin/generate_docs/main.rs
+++ b/src/bin/generate_docs/main.rs
@@ -1,7 +1,7 @@
 use parsing::generate_docs;
 use std::{fs, path::PathBuf};
 use video_compositor::types::{
-    Image, InputStream, Rescaler, Shader, ShaderSpec, Text, Tiles, View, WebRendererSpec, WebView,
+    Image, InputStream, Rescaler, ShaderSpec, Text, Tiles, View, WebRendererSpec, WebView,
 };
 
 mod parsing;
@@ -23,7 +23,6 @@ fn main() {
         generate_docs::<InputStream>("InputStream"),
         generate_docs::<View>("View"),
         generate_docs::<WebView>("WebView"),
-        generate_docs::<Shader>("Shader"),
         generate_docs::<Image>("Image"),
         generate_docs::<Text>("Text"),
         generate_docs::<Tiles>("Tiles"),

--- a/src/bin/generate_docs/type_definition.rs
+++ b/src/bin/generate_docs/type_definition.rs
@@ -80,7 +80,7 @@ impl TypeDefinition {
                 _ => 0,
             };
             out += &format!(
-                "{}{}: {},\n",
+                "{}{}: {};\n",
                 INDENT.repeat(base_indent + 2),
                 name,
                 prop.type_def.to_pretty_string(indent)

--- a/src/types/component.rs
+++ b/src/types/component.rs
@@ -42,10 +42,6 @@ pub struct View {
     pub height: Option<f32>,
 
     /// Direction defines how static children are positioned inside a View component.
-    ///
-    /// - `"row"` - Children positioned from left to right.
-    ///
-    /// - `"column"` - Children positioned from top to bottom.
     pub direction: Option<ViewDirection>,
 
     /// Distance in pixels between this component's top edge and its parent's top edge.
@@ -71,10 +67,10 @@ pub struct View {
     /// effect if the previous scene already contained a View component with the same id.
     pub transition: Option<Transition>,
 
-    /// (default=`"hidden"`) Controls what happens to content that is too big to fit into an area.
+    /// (**default=`"hidden"`**) Controls what happens to content that is too big to fit into an area.
     pub overflow: Option<Overflow>,
 
-    /// (default=`"#00000000"`) Background color in a `"#RRGGBBAA"` format.
+    /// (**default=`"#00000000"`**) Background color in a `"#RRGGBBAA"` format.
     pub background_color_rgba: Option<RGBAColor>,
 }
 
@@ -90,6 +86,8 @@ pub enum Overflow {
     /// Components that have unknown sizes will be treated as if they had a size 0 when calculating
     /// scaling factor.
     ///
+    /// <br/><br/>
+    ///
     /// :::warning
     ///
     /// This will resize everything inside, even absolutely positioned elements. For example, if
@@ -103,7 +101,9 @@ pub enum Overflow {
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ViewDirection {
+    /// Children positioned from left to right.
     Row,
+    /// Children positioned from top to bottom.
     Column,
 }
 
@@ -115,17 +115,11 @@ pub struct Rescaler {
     /// List of component's children.
     pub child: Box<Component>,
 
-    /// Resize mode:
-    ///
-    /// - `"fit"` - Resize the component proportionally, so one of the dimensions is the same as its parent,
-    /// but it still fits inside it.
-    ///
-    /// - `"fill"` - Resize the component proportionally, so one of the dimensions is the same as its
-    /// parent and the entire area of the parent is covered. Parts of a child that do not fit inside the parent are not rendered.
+    /// (**default=`"fit"`**) Resize mode:
     pub mode: Option<RescaleMode>,
-    /// (default=`"center"`) Horizontal alignment.
+    /// (**default=`"center"`**) Horizontal alignment.
     pub horizontal_align: Option<HorizontalAlign>,
-    /// (default=`"center"`) Vertical alignment.
+    /// (**default=`"center"`**) Vertical alignment.
     pub vertical_align: Option<VerticalAlign>,
 
     /// Width of a component in pixels. Required when using absolute positioning.
@@ -160,7 +154,11 @@ pub struct Rescaler {
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum RescaleMode {
+    /// Resize the component proportionally, so one of the dimensions is the same as its parent,
+    /// but it still fits inside it.
     Fit,
+    /// Resize the component proportionally, so one of the dimensions is the same as its parent
+    /// and the entire area of the parent is covered. Parts of a child that do not fit inside the parent are not rendered.
     Fill,
 }
 
@@ -262,10 +260,10 @@ pub struct Text {
     ///
     /// It's an error to provide `height` if `width` is not defined.
     pub height: Option<f32>,
-    /// (default=`7682`) Maximal `width`. Limits the width of the texture that the text will be rendered on.
+    /// (**default=`7682`**) Maximal `width`. Limits the width of the texture that the text will be rendered on.
     /// Value is ignored if `width` is defined.
     pub max_width: Option<f32>,
-    /// (default=`4320`) Maximal height. Limits the height of the texture that the text will be rendered on.
+    /// (**default=`4320`**) Maximal `height`. Limits the height of the texture that the text will be rendered on.
     /// Value is ignored if height is defined.
     pub max_height: Option<f32>,
 
@@ -273,20 +271,20 @@ pub struct Text {
     pub font_size: f32,
     /// Distance between lines in pixels. Defaults to the value of the `font_size` property.
     pub line_height: Option<f32>,
-    /// (default=`"#FFFFFFFF"`) Font color in `#RRGGBBAA` format.
+    /// (**default=`"#FFFFFFFF"`**) Font color in `#RRGGBBAA` format.
     pub color_rgba: Option<RGBAColor>,
-    /// (default=`"#00000000"`) Background color in `#RRGGBBAA` format.
+    /// (**default=`"#00000000"`**) Background color in `#RRGGBBAA` format.
     pub background_color_rgba: Option<RGBAColor>,
-    /// (default=`"Verdana"`) Font family. Provide [family-name](https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#family-name-value)
+    /// (**default=`"Verdana"`**) Font family. Provide [family-name](https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#family-name-value)
     /// for a specific font. "generic-family" values like e.g. "sans-serif" will not work.
     pub font_family: Option<Arc<str>>,
-    /// (default=`"normal"`) Font style. The selected font needs to support the specified style.
+    /// (**default=`"normal"`**) Font style. The selected font needs to support the specified style.
     pub style: Option<TextStyle>,
-    /// (default=`"left"`) Text align.
+    /// (**default=`"left"`**) Text align.
     pub align: Option<HorizontalAlign>,
-    /// (default=`"none"`) Text wrapping options.
+    /// (**default=`"none"`**) Text wrapping options.
     pub wrap: Option<TextWrapMode>,
-    /// (default=`"normal"`) Font weight. The selected font needs to support the specified weight.
+    /// (**default=`"normal"`**) Font weight. The selected font needs to support the specified weight.
     pub weight: Option<TextWeight>,
 }
 
@@ -353,16 +351,16 @@ pub struct Tiles {
     /// Height of a component in pixels.
     pub height: Option<f32>,
 
-    /// (default=`"#00000000"`) Background color in a `"#RRGGBBAA"` format.
+    /// (**default=`"#00000000"`**) Background color in a `"#RRGGBBAA"` format.
     pub background_color_rgba: Option<RGBAColor>,
-    /// (default=`"16:9"`) Aspect ratio of a tile in `"W:H"` format, where W and H are integers.
+    /// (**default=`"16:9"`**) Aspect ratio of a tile in `"W:H"` format, where W and H are integers.
     pub tile_aspect_ratio: Option<AspectRatio>,
-    /// (default=`0`) Margin of each tile in pixels.
+    /// (**default=`0`**) Margin of each tile in pixels.
     pub margin: Option<f32>,
-    /// (default=`0`) Padding on each tile in pixels.
+    /// (**default=`0`**) Padding on each tile in pixels.
     pub padding: Option<f32>,
-    /// (default=`"center"`) Horizontal alignment of tiles.
+    /// (**default=`"center"`**) Horizontal alignment of tiles.
     pub horizontal_align: Option<HorizontalAlign>,
-    /// (default=`"center"`) Vertical alignment of tiles.
+    /// (**default=`"center"`**) Vertical alignment of tiles.
     pub vertical_align: Option<VerticalAlign>,
 }

--- a/src/types/renderer.rs
+++ b/src/types/renderer.rs
@@ -15,24 +15,43 @@ pub enum FallbackStrategy {
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ShaderSpec {
+    /// Id of a shader. It can be used in a [`Shader`](../components/Shader) component after registration.
     pub shader_id: RendererId,
+    /// Shader source code. [Learn more.](../../concept/shaders)
     pub source: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct WebRendererSpec {
+    /// Id of a web renderer instance. It can be used in a [`WebView`](../components/WebView) component after registration.
     pub instance_id: RendererId,
+    /// Url of a website that you want to render.
     pub url: String,
+    /// Resolution.
     pub resolution: Resolution,
+    /// Mechanism used to render input frames on the website.
     pub embedding_method: Option<WebEmbeddingMethod>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub enum WebEmbeddingMethod {
+    /// Pass raw input frames as JS buffers so they can be rendered, for example, using a `<canvas>` component.
+    ///
+    /// <br/> <br/>
+    ///
+    /// :::warning
+    ///
+    /// This method might have a significant performance impact, especially for a large number of inputs.
+    ///
+    /// :::
     ChromiumEmbedding,
+
+    /// Render a website without any inputs and overlay them over the website content.
     NativeEmbeddingOverContent,
+
+    /// Render a website without any inputs and overlay them under the website content.
     NativeEmbeddingUnderContent,
 }
 


### PR DESCRIPTION
- hide table of contents for generated pages
- change coma to semicolon in the type definitions
- update main routes page (it had old info + links pointing to wiki)
- replace Image renderer definition with custom text
- replace Shader component definition with custom text
- extract common text fragment explaining absolute positioning
- change `(default=sth` to `(**default=sth**)`. I tried to move `**` outside of `()` but one of star is cut of when genering schema.