### PR TITLE
Send RTCP Goodbye when unregistering an input.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,6 +3137,7 @@ dependencies = [
  "image",
  "lazy_static",
  "log",
+ "rand",
  "reqwest",
  "rtcp",
  "rtp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ rtp = { workspace = true }
 smol = "1.3.0"
 webrtc-util = "0.8.0"
 rtcp = "0.10.0"
+rand = "0.8.5"
 
 [dev-dependencies]
 reqwest = { workspace = true }

--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -43,6 +43,7 @@ pub trait PipelineOutput: Send + Sync + Sized + Clone + 'static {
     type Context: 'static;
 
     fn send_packet(&self, context: &mut Self::Context, packet: Packet);
+    fn send_eos(&self, context: &mut Self::Context);
     fn new(
         opts: Self::Opts,
         codec: ffmpeg_next::Codec,

--- a/compositor_pipeline/src/pipeline/encoder.rs
+++ b/compositor_pipeline/src/pipeline/encoder.rs
@@ -254,6 +254,7 @@ impl<Output: PipelineOutput> Encoder<Output> {
                     output.send_packet(&mut context, packet);
                 }
             }
+            output.send_eos(&mut context);
         });
 
         Ok(Self {

--- a/src/rtp_sender.rs
+++ b/src/rtp_sender.rs
@@ -111,4 +111,21 @@ impl PipelineOutput for RtpSender {
             context.next_sequence_number = context.next_sequence_number.wrapping_add(1);
         }
     }
+
+    fn send_eos(&self, context: &mut RtpContext) {
+        let packet = rtcp::goodbye::Goodbye {
+            sources: vec![context.ssrc],
+            reason: Bytes::from("Unregister output stream"),
+        };
+
+        let raw_packet = match packet.marshal() {
+            Ok(raw_packet) => raw_packet,
+            Err(_err) => {
+                error!("Failed to construct");
+                return;
+            }
+        };
+
+        context.socket.send(&raw_packet).unwrap();
+    }
 }


### PR DESCRIPTION
Send RTCP goodbye packet when RTP output stream is unregistered. This solution assumes that RTP and RTCP are multiplexed on the same port.

I tested this by unregistering an output, but to verify if it's correct we would need to test that with membrane plugin