### PR TITLE
Remove RTC.ON workshops url

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ For better performance, build examples with the [release compilation profile](ht
 cargo run --release --example <example_name>
 ```
 
-You can also check out [RTC.ON 2023 workshops repo](https://github.com/membraneframework-labs/rtcon_video_compositor_workshops) for more examples / exercises.
-
 ## Supported platforms
 
 Linux and MacOS.


### PR DESCRIPTION
API has changed significantly and the workshop repo is no longer a good place to look up examples