### PR TITLE
Improve latency when reading from UDP buffer

### DIFF
--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -50,7 +50,7 @@ pub trait PipelineOutput: Send + Sync + Sized + Clone + 'static {
 
 pub trait PipelineInput: Send + Sync + Sized + 'static {
     type Opts: Send + Sync;
-    type PacketIterator: Iterator<Item = rtp::packet::Packet> + Send;
+    type PacketIterator: Iterator<Item = Arc<rtp::packet::Packet>> + Send;
 
     fn new(opts: Self::Opts) -> Result<(Self, Self::PacketIterator), CustomError>;
     fn decoder_parameters(&self) -> decoder::DecoderParameters;

--- a/compositor_pipeline/src/pipeline/decoder.rs
+++ b/compositor_pipeline/src/pipeline/decoder.rs
@@ -138,7 +138,7 @@ enum DepayloadingError {
 const H264_DEFAULT_PAYLOAD_TYPE: u8 = 96;
 
 fn packet_to_av(
-    packet: rtp::packet::Packet,
+    packet: Arc<rtp::packet::Packet>,
     ctx: &mut rtp::codecs::h264::H264Packet,
 ) -> Result<Option<ffmpeg_next::packet::Packet>, DepayloadingError> {
     if packet.header.payload_type != H264_DEFAULT_PAYLOAD_TYPE {


### PR DESCRIPTION
Fixes an issue with lost frames when the UDP buffer is small.

The main fix is to change the channel of size 1 to an unbound channel. Decoding was a bottleneck for reading. Not sure if adding `Arc` helps much.