### PR TITLE
Add location in parse shader error message

### DIFF
--- a/compositor_render/src/transformations/shader.rs
+++ b/compositor_render/src/transformations/shader.rs
@@ -25,7 +25,7 @@ pub struct Shader {
 #[derive(Debug)]
 pub struct ShaderSpec {
     pub shader_id: RendererId,
-    pub source: String,
+    pub source: Arc<str>,
     pub fallback_strategy: FallbackStrategy,
 }
 
@@ -33,7 +33,7 @@ impl Shader {
     pub fn new(wgpu_ctx: &Arc<WgpuCtx>, spec: ShaderSpec) -> Result<Self, CreateShaderError> {
         let fallback_strategy = spec.fallback_strategy;
         let clear_color = None;
-        let pipeline = ShaderPipeline::new(wgpu_ctx, &spec.source)?;
+        let pipeline = ShaderPipeline::new(wgpu_ctx, spec.source)?;
 
         Ok(Self {
             pipeline,

--- a/compositor_render/src/transformations/shader/pipeline.rs
+++ b/compositor_render/src/transformations/shader/pipeline.rs
@@ -32,10 +32,10 @@ pub(super) struct ShaderPipeline {
 }
 
 impl ShaderPipeline {
-    pub fn new(wgpu_ctx: &Arc<WgpuCtx>, shader_src: &str) -> Result<Self, CreateShaderError> {
+    pub fn new(wgpu_ctx: &Arc<WgpuCtx>, shader_src: Arc<str>) -> Result<Self, CreateShaderError> {
         let scope = WgpuErrorScope::push(&wgpu_ctx.device);
 
-        let module = naga::front::wgsl::parse_str(shader_src)
+        let module = naga::front::wgsl::parse_str(&shader_src)
             .map_err(|err| CreateShaderError::ParseError(ShaderParseError::new(err, shader_src)))?;
 
         validate_contains_header(&wgpu_ctx.shader_header, &module)?;

--- a/compositor_render/src/transformations/shader/validation/error.rs
+++ b/compositor_render/src/transformations/shader/validation/error.rs
@@ -27,10 +27,11 @@ impl ShaderParseError {
 impl Display for ShaderParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.parse_error.location(&self.source) {
-            Some(location) => f.write_str(&format!(
+            Some(location) => write!(
+                f,
                 "Shader parsing error in line {} column {}.",
                 location.line_number, location.line_position
-            )),
+            ),
             None => f.write_str("Shader parsing error."),
         }
     }

--- a/compositor_render/src/transformations/shader/validation/error.rs
+++ b/compositor_render/src/transformations/shader/validation/error.rs
@@ -28,10 +28,10 @@ impl Display for ShaderParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.parse_error.location(&self.source) {
             Some(location) => f.write_str(&format!(
-                "Shader parsing error in line {} column {}: {}.",
-                location.line_number, location.line_position, self.parse_error
+                "Shader parsing error in line {} column {}.",
+                location.line_number, location.line_position
             )),
-            None => f.write_str(&format!("Shader parsing error: {}.", self.parse_error)),
+            None => f.write_str("Shader parsing error."),
         }
     }
 }

--- a/compositor_render/src/wgpu/common_pipeline.rs
+++ b/compositor_render/src/wgpu/common_pipeline.rs
@@ -10,7 +10,7 @@ pub const PRIMITIVE_STATE: wgpu::PrimitiveState = wgpu::PrimitiveState {
     unclipped_depth: false,
 };
 
-use crate::transformations::shader::validation::error::ShaderValidationError;
+use crate::transformations::shader::validation::error::{ShaderParseError, ShaderValidationError};
 
 use super::WgpuError;
 
@@ -25,8 +25,8 @@ pub enum CreateShaderError {
     #[error(transparent)]
     Validation(#[from] ShaderValidationError),
 
-    #[error("Shader parse error: {0}")]
-    ParseError(naga::front::wgsl::ParseError),
+    #[error(transparent)]
+    ParseError(#[from] ShaderParseError),
 }
 
 #[repr(C)]

--- a/src/types/from_renderer.rs
+++ b/src/types/from_renderer.rs
@@ -25,7 +25,7 @@ impl TryFrom<ShaderSpec> for compositor_render::RendererSpec {
     fn try_from(spec: ShaderSpec) -> Result<Self, Self::Error> {
         let spec = shader::ShaderSpec {
             shader_id: spec.shader_id.into(),
-            source: spec.source,
+            source: spec.source.into(),
             fallback_strategy: compositor_render::FallbackStrategy::FallbackIfAllInputsMissing,
         };
         Ok(Self::Shader(spec))


### PR DESCRIPTION
Before:
```console
Error stack:
     - Failed to register shader "shader_example_1".
     - Shader parse error: expected ';', found 'return'
```

After:
```console
Error stack:
     - Failed to register shader "shader_example_1".
     - Shader parsing error in line 18 column 5.
     - expected ';', found 'return'
```

The last line is not formatted according to the convention, due to using `naga::front::wgsl::ParseError` as a source (the error message comes directly from naga). I don't want to manually change it, because this might make errors less readable (e.g. first word is case sensitive variable name, the dot at the end interferes with the provided syntax error making it misleading, etc.)