### PR TITLE
Switch from `env_logger` to `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,6 @@ dependencies = [
  "bytes",
  "compositor_chromium",
  "crossbeam-channel",
- "env_logger",
  "glyphon",
  "image",
  "log",
@@ -543,19 +542,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1016,12 +1002,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,17 +1101,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,9 +1164,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libloading"
@@ -1476,6 +1445,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1580,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -2169,6 +2154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_memory"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,6 +2413,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,22 +2548,72 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.31"
+name = "tracing-attributes"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2734,6 +2788,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,11 +2815,10 @@ dependencies = [
  "compositor_pipeline",
  "compositor_render",
  "crossbeam-channel",
- "env_logger",
  "ffmpeg-next",
  "fs_extra",
  "image",
- "lazy_static",
+ "libc",
  "log",
  "rand",
  "reqwest",
@@ -2773,6 +2832,8 @@ dependencies = [
  "socket2 0.5.5",
  "thiserror",
  "tiny_http",
+ "tracing",
+ "tracing-subscriber",
  "webrtc-util",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ resolver = "2"
 
 [workspace.dependencies]
 bytes = "1.4.0"
-env_logger = "0.10.0"
 serde_json = { version = "1.0.99", features = ["preserve_order"] }
 serde = { version = "1.0.164", features = ["derive", "rc"] }
 log = "0.4.19"
@@ -40,11 +39,9 @@ bytes = { workspace = true }
 tiny_http = "0.12.0"
 ffmpeg-next = { workspace = true }
 crossbeam-channel = { workspace = true }
-env_logger = { workspace = true }
 log = { workspace = true }
 signal-hook = { workspace = true }
 shared_memory = { workspace = true }
-lazy_static = "1.4.0"
 fs_extra = "1.3.0"
 schemars = { version = "0.8.15", features = ["preserve_order"] }
 image = { workspace = true }
@@ -54,6 +51,9 @@ webrtc-util = "0.8.0"
 rtcp = "0.10.0"
 rand = "0.8.5"
 socket2 = "0.5.5"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["json"] }
+libc = "0.2.151"
 
 [dev-dependencies]
 reqwest = { workspace = true }

--- a/compositor_render/Cargo.toml
+++ b/compositor_render/Cargo.toml
@@ -22,6 +22,3 @@ nalgebra-glm = { version = "0.18.0", features = ["convert-bytemuck"] }
 shared_memory = { workspace = true }
 naga = "0.12.0"
 rand = "0.8.5"
-
-[dev-dependencies]
-env_logger = { workspace = true }

--- a/examples/docker.rs
+++ b/examples/docker.rs
@@ -8,7 +8,7 @@ use std::{
     thread,
     time::Duration,
 };
-use video_compositor::types::Resolution;
+use video_compositor::{logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -22,9 +22,7 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 const FRAMERATE: u32 = 30;
 
 fn main() {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
+    logger::init_logger();
 
     let Ok(host_ip) = env::var("DOCKER_HOST_IP") else {
         if cfg!(target_os = "macos") {

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -7,7 +7,7 @@ use std::{
     thread,
     time::Duration,
 };
-use video_compositor::{http, types::Resolution};
+use video_compositor::{http, logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -21,10 +21,8 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 const FRAMERATE: u32 = 30;
 
 fn main() {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
     ffmpeg_next::format::network::init();
+    logger::init_logger();
 
     thread::spawn(|| {
         if let Err(err) = start_example_client_code() {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -7,7 +7,7 @@ use std::{
     thread,
     time::Duration,
 };
-use video_compositor::{http, types::Resolution};
+use video_compositor::{http, logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -23,10 +23,8 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 const FRAMERATE: u32 = 30;
 
 fn main() {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
     ffmpeg_next::format::network::init();
+    logger::init_logger();
 
     thread::spawn(|| {
         if let Err(err) = start_example_client_code() {

--- a/examples/test_pattern.rs
+++ b/examples/test_pattern.rs
@@ -6,7 +6,7 @@ use std::{
     thread,
     time::Duration,
 };
-use video_compositor::{api::Response, http, types::Resolution};
+use video_compositor::{api::Response, http, logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -20,10 +20,8 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 const FRAMERATE: u32 = 30;
 
 fn main() {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
     ffmpeg_next::format::network::init();
+    logger::init_logger();
 
     thread::spawn(|| {
         if let Err(err) = start_example_client_code() {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -6,7 +6,7 @@ use std::{
     thread,
     time::Duration,
 };
-use video_compositor::{http, types::Resolution};
+use video_compositor::{http, logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -21,10 +21,8 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 const FRAMERATE: u32 = 30;
 
 fn main() {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
     ffmpeg_next::format::network::init();
+    logger::init_logger();
 
     thread::spawn(|| {
         if let Err(err) = start_example_client_code() {

--- a/examples/tiles.rs
+++ b/examples/tiles.rs
@@ -6,7 +6,7 @@ use std::{
     thread,
     time::Duration,
 };
-use video_compositor::{http, types::Resolution};
+use video_compositor::{http, logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -21,10 +21,8 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 const FRAMERATE: u32 = 30;
 
 fn main() {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
     ffmpeg_next::format::network::init();
+    logger::init_logger();
 
     thread::spawn(|| {
         if let Err(err) = start_example_client_code() {

--- a/examples/transition.rs
+++ b/examples/transition.rs
@@ -6,7 +6,7 @@ use std::{
     thread,
     time::Duration,
 };
-use video_compositor::{http, types::Resolution};
+use video_compositor::{http, logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -21,10 +21,8 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 const FRAMERATE: u32 = 30;
 
 fn main() {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
     ffmpeg_next::format::network::init();
+    logger::init_logger();
 
     thread::spawn(|| {
         if let Err(err) = start_example_client_code() {

--- a/examples/web_view.rs
+++ b/examples/web_view.rs
@@ -8,7 +8,7 @@ use std::{
     thread::{self, sleep},
     time::Duration,
 };
-use video_compositor::{http, types::Resolution};
+use video_compositor::{http, logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -27,10 +27,9 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 const FRAMERATE: u32 = 60;
 
 fn main() {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
     ffmpeg_next::format::network::init();
+    logger::init_logger();
+
     let target_path = &std::env::current_exe()
         .unwrap()
         .parent()

--- a/src/bin/main_process.rs
+++ b/src/bin/main_process.rs
@@ -1,14 +1,14 @@
 use std::env;
 
 use log::info;
-use video_compositor::http::{self, API_PORT_ENV};
+use video_compositor::{
+    http::{self, API_PORT_ENV},
+    logger,
+};
 
 fn main() {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
-
     ffmpeg_next::format::network::init();
+    logger::init_logger();
 
     let port = env::var(API_PORT_ENV).unwrap_or_else(|_| "8001".to_string());
     http::Server::new(port.parse::<u16>().unwrap()).run();

--- a/src/bin/package_for_release/bundle_linux.rs
+++ b/src/bin/package_for_release/bundle_linux.rs
@@ -10,9 +10,8 @@ use crate::utils;
 const X86_TARGET: &str = "x86_64-unknown-linux-gnu";
 
 pub fn bundle_linux_app() -> Result<()> {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
+    tracing_subscriber::fmt().init();
+
     let root_dir_str = env!("CARGO_MANIFEST_DIR");
     let root_dir: PathBuf = root_dir_str.into();
     let release_dir = root_dir.join("target/x86_64-unknown-linux-gnu/release");

--- a/src/bin/package_for_release/bundle_macos.rs
+++ b/src/bin/package_for_release/bundle_macos.rs
@@ -26,9 +26,8 @@ pub fn bundle_macos_app() -> Result<()> {
 }
 
 fn bundle_app(target: &'static str, output_name: &'static str) -> Result<()> {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
+    tracing_subscriber::fmt().init();
+
     let root_dir_str = env!("CARGO_MANIFEST_DIR");
     let root_dir: PathBuf = root_dir_str.into();
     let build_dir = root_dir.join(format!("target/{target}/release"));

--- a/src/bin/process_helper/main.rs
+++ b/src/bin/process_helper/main.rs
@@ -9,9 +9,7 @@ mod state;
 
 // Subprocess used by chromium
 fn main() -> Result<(), Box<dyn Error>> {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
+    tracing_subscriber::fmt().json().init();
 
     let app = App::new();
     let context = cef::Context::new_helper()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod error;
 pub mod http;
+pub mod logger;
 pub mod rtp_receiver;
 pub mod rtp_sender;
 pub mod types;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -25,7 +25,10 @@ extern "C" fn ffmpeg_log_callback(
     arg1: *mut libc::c_void,
     log_level: libc::c_int,
     fmt: *const libc::c_char,
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
     va_list_tag: *mut ffmpeg_next::sys::__va_list_tag,
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    va_list_tag: ffmpeg_next::sys::va_list,
 ) {
     unsafe {
         match ffmpeg_log_level() {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,58 @@
+use std::{env, sync::OnceLock};
+
+#[derive(Debug, Clone, Copy)]
+enum FfmpegLogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
+
+fn ffmpeg_log_level() -> FfmpegLogLevel {
+    static LOG_LEVEL: OnceLock<FfmpegLogLevel> = OnceLock::new();
+
+    *LOG_LEVEL.get_or_init(|| match env::var("FFMPEG_LOG_LEVEL") {
+        Ok(debug) if debug == "debug" => FfmpegLogLevel::Debug,
+        Ok(info) if info == "info" => FfmpegLogLevel::Info,
+        Ok(warn) if warn == "warn" => FfmpegLogLevel::Warn,
+        Ok(error) if error == "error" => FfmpegLogLevel::Error,
+        Ok(_) => FfmpegLogLevel::Warn,
+        Err(_) => FfmpegLogLevel::Warn,
+    })
+}
+
+extern "C" fn ffmpeg_log_callback(
+    arg1: *mut libc::c_void,
+    log_level: libc::c_int,
+    fmt: *const libc::c_char,
+    va_list_tag: *mut ffmpeg_next::sys::__va_list_tag,
+) {
+    unsafe {
+        match ffmpeg_log_level() {
+            FfmpegLogLevel::Error if log_level <= 16 => {
+                ffmpeg_next::sys::av_log_default_callback(arg1, log_level, fmt, va_list_tag)
+            }
+            FfmpegLogLevel::Warn if log_level <= 24 => {
+                ffmpeg_next::sys::av_log_default_callback(arg1, log_level, fmt, va_list_tag)
+            }
+            FfmpegLogLevel::Info if log_level <= 32 => {
+                ffmpeg_next::sys::av_log_default_callback(arg1, log_level, fmt, va_list_tag)
+            }
+            FfmpegLogLevel::Debug if log_level <= 48 => {
+                ffmpeg_next::sys::av_log_default_callback(arg1, log_level, fmt, va_list_tag)
+            }
+            _ => (),
+        }
+    }
+}
+
+pub fn init_logger() {
+    if env::var("CARGO_MANIFEST_DIR").is_ok() {
+        tracing_subscriber::fmt().init();
+    } else {
+        tracing_subscriber::fmt().json().init();
+    }
+    unsafe {
+        ffmpeg_next::sys::av_log_set_callback(Some(ffmpeg_log_callback));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use crate::http::API_PORT_ENV;
 mod api;
 mod error;
 mod http;
+mod logger;
 mod rtp_receiver;
 mod rtp_sender;
 mod types;
@@ -16,9 +17,7 @@ mod types;
 mod snapshot_tests;
 
 fn main() {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
+    logger::init_logger();
 
     let target_path = std::env::current_exe()
         .unwrap()


### PR DESCRIPTION
- Use tracing library
- Default to json logger when not building from source (based on CARGO_MANIFEST_DIR env)
- Add env `FFMPEG_LOG_LEVEL` that controll ffmpeg logs (default to warn)