### PR TITLE
Refactor the input architecture.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,8 +374,11 @@ dependencies = [
  "crossbeam-channel",
  "ffmpeg-next",
  "log",
+ "rtcp",
  "rtp",
+ "socket2 0.5.5",
  "thiserror",
+ "webrtc-util",
 ]
 
 [[package]]
@@ -2849,14 +2852,12 @@ dependencies = [
  "log",
  "rand",
  "reqwest",
- "rtcp",
  "rtp",
  "schemars",
  "serde",
  "serde_json",
  "shared_memory",
  "signal-hook",
- "socket2 0.5.5",
  "thiserror",
  "tiny_http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,7 @@ image = { workspace = true }
 thiserror = { workspace = true }
 rtp = { workspace = true }
 webrtc-util = "0.8.0"
-rtcp = "0.10.0"
 rand = "0.8.5"
-socket2 = "0.5.5"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter"] }
 libc = "0.2.151"

--- a/compositor_pipeline/Cargo.toml
+++ b/compositor_pipeline/Cargo.toml
@@ -13,3 +13,7 @@ thiserror = { workspace = true }
 log = { workspace = true }
 ffmpeg-next = { workspace = true }
 rtp = { workspace = true }
+webrtc-util = "0.8.0"
+socket2 = "0.5.5"
+rtcp = "0.10.0"
+

--- a/compositor_pipeline/src/lib.rs
+++ b/compositor_pipeline/src/lib.rs
@@ -2,4 +2,4 @@ pub mod error;
 pub mod pipeline;
 pub mod queue;
 
-pub type Pipeline<Input, Output> = pipeline::Pipeline<Input, Output>;
+pub type Pipeline<Output> = pipeline::Pipeline<Output>;

--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -16,7 +16,6 @@ use compositor_render::{
     scene, EventLoop, Framerate, InputId, OutputId, RendererId, RendererSpec, Resolution,
 };
 use crossbeam_channel::unbounded;
-use ffmpeg_next::Packet;
 use log::{error, warn};
 
 use crate::error::{
@@ -25,11 +24,13 @@ use crate::error::{
 };
 use crate::queue::Queue;
 
-use self::decoder::Decoder;
 use self::encoder::{Encoder, EncoderSettings};
+use self::structs::Codec;
 
 pub mod decoder;
 pub mod encoder;
+pub mod input;
+pub mod structs;
 
 #[derive(Debug, Clone)]
 pub struct OutputScene {
@@ -41,19 +42,13 @@ pub trait PipelineOutput: Send + Sync + Sized + Clone + 'static {
     type Opts: Send + Sync + 'static;
     type Context: 'static;
 
-    fn send_packet(&self, context: &mut Self::Context, packet: Packet);
-    fn new(
-        opts: Self::Opts,
-        codec: ffmpeg_next::Codec,
-    ) -> Result<(Self, Self::Context), CustomError>;
+    fn send_data(&self, context: &mut Self::Context, chunk: structs::EncodedChunk);
+    fn new(opts: Self::Opts, codec: structs::Codec) -> Result<(Self, Self::Context), CustomError>;
 }
 
-pub trait PipelineInput: Send + Sync + Sized + 'static {
-    type Opts: Send + Sync;
-    type PacketIterator: Iterator<Item = rtp::packet::Packet> + Send;
-
-    fn new(opts: Self::Opts) -> Result<(Self, Self::PacketIterator), CustomError>;
-    fn decoder_parameters(&self) -> decoder::DecoderParameters;
+pub struct PipelineInput {
+    pub input: input::Input,
+    pub decoder: decoder::Decoder,
 }
 
 pub struct OutputOptions<Output: PipelineOutput> {
@@ -62,8 +57,8 @@ pub struct OutputOptions<Output: PipelineOutput> {
     pub resolution: Resolution,
 }
 
-pub struct Pipeline<Input: PipelineInput, Output: PipelineOutput> {
-    inputs: HashMap<InputId, Arc<Decoder<Input>>>,
+pub struct Pipeline<Output: PipelineOutput> {
+    inputs: HashMap<InputId, Arc<PipelineInput>>,
     outputs: OutputRegistry<Encoder<Output>>,
     queue: Arc<Queue>,
     renderer: Renderer,
@@ -77,7 +72,8 @@ pub struct Options {
     pub web_renderer: WebRendererInitOptions,
 }
 
-impl<Input: PipelineInput, Output: PipelineOutput> Pipeline<Input, Output> {
+
+impl<Output: PipelineOutput> Pipeline<Output> {
     pub fn new(opts: Options) -> Result<(Self, Arc<dyn EventLoop>), InitRendererEngineError> {
         let (renderer, event_loop) = Renderer::new(RendererOptions {
             web_renderer: opts.web_renderer,
@@ -106,18 +102,24 @@ impl<Input: PipelineInput, Output: PipelineOutput> Pipeline<Input, Output> {
     pub fn register_input(
         &mut self,
         input_id: InputId,
-        input_opts: Input::Opts,
+        input_opts: input::InputOptions,
+        decoder_opts: decoder::DecoderOptions,
     ) -> Result<(), RegisterInputError> {
         if self.inputs.contains_key(&input_id) {
             return Err(RegisterInputError::AlreadyRegistered(input_id));
         }
 
-        self.inputs.insert(
-            input_id.clone(),
-            Decoder::new(self.queue.clone(), input_opts, input_id.clone())
-                .map_err(|e| RegisterInputError::DecoderError(input_id.clone(), e))?
-                .into(),
-        );
+        let (input, chunks) = input::Input::new(input_opts)
+            .map_err(|e| RegisterInputError::InputError(input_id.clone(), e))?;
+
+        let decoder =
+            decoder::Decoder::new(decoder_opts, chunks, self.queue.clone(), input_id.clone())
+                .map_err(|e| RegisterInputError::DecoderError(input_id.clone(), e))?;
+
+        let pipeline_input = PipelineInput { input, decoder };
+
+        self.inputs.insert(input_id.clone(), pipeline_input.into());
+
         self.queue.add_input(input_id);
         Ok(())
     }
@@ -145,7 +147,7 @@ impl<Input: PipelineInput, Output: PipelineOutput> Pipeline<Input, Output> {
             return Err(RegisterOutputError::UnsupportedResolution(output_id));
         }
 
-        let output = Encoder::new(output_opts)
+        let output = Encoder::new(output_opts, Codec::H264)
             .map_err(|e| RegisterOutputError::EncoderError(output_id.clone(), e))?;
 
         self.outputs.insert(output_id, output.into());
@@ -238,8 +240,8 @@ impl<Input: PipelineInput, Output: PipelineOutput> Pipeline<Input, Output> {
         });
     }
 
-    pub fn inputs(&self) -> impl Iterator<Item = (&InputId, &Input)> {
-        self.inputs.iter().map(|(id, node)| (id, node.input()))
+    pub fn inputs(&self) -> impl Iterator<Item = (&InputId, &PipelineInput)> {
+        self.inputs.iter().map(|(id, node)| (id, &**node))
     }
 
     pub fn with_outputs<F, R>(&self, f: F) -> R

--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -1,4 +1,5 @@
 use std::collections::{hash_map, HashMap};
+use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::{Mutex, MutexGuard};
 use std::thread;
@@ -71,7 +72,6 @@ pub struct Options {
     pub stream_fallback_timeout: Duration,
     pub web_renderer: WebRendererInitOptions,
 }
-
 
 impl<Output: PipelineOutput> Pipeline<Output> {
     pub fn new(opts: Options) -> Result<(Self, Arc<dyn EventLoop>), InitRendererEngineError> {
@@ -241,7 +241,7 @@ impl<Output: PipelineOutput> Pipeline<Output> {
     }
 
     pub fn inputs(&self) -> impl Iterator<Item = (&InputId, &PipelineInput)> {
-        self.inputs.iter().map(|(id, node)| (id, &**node))
+        self.inputs.iter().map(|(id, node)| (id, node.deref()))
     }
 
     pub fn with_outputs<F, R>(&self, f: F) -> R

--- a/compositor_pipeline/src/pipeline/decoder.rs
+++ b/compositor_pipeline/src/pipeline/decoder.rs
@@ -1,231 +1,34 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
-use crate::{error::InputInitError, queue::Queue};
+use crate::{error::DecoderInitError, queue::Queue};
 
-use super::PipelineInput;
-use compositor_render::{error::ErrorStack, Frame, InputId, Resolution, YuvData};
-use ffmpeg_next::{
-    codec::{Context, Id},
-    ffi::AV_CODEC_FLAG2_CHUNKS,
-    frame::Video,
-    media::Type,
-};
-use log::{error, warn};
-use rtp::packetizer::Depacketizer;
+use self::ffmpeg_h264::H264FfmpegDecoder;
 
-pub struct Decoder<Input: PipelineInput> {
-    input: Input,
+use super::structs::EncodedChunk;
+use compositor_render::InputId;
+
+pub mod ffmpeg_h264;
+
+pub enum Decoder {
+    H264(H264FfmpegDecoder),
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct DecoderParameters {
-    pub codec: Codec,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum Codec {
-    H264,
-}
-
-#[derive(Debug, thiserror::Error)]
-enum DecoderError {
-    #[error("Error converting frame: {0}")]
-    FrameConversionError(String),
-}
-
-impl<Input: PipelineInput> Decoder<Input> {
+impl Decoder {
     pub fn new(
+        parameters: DecoderOptions,
+        chunks: Box<dyn Iterator<Item = EncodedChunk> + Send>,
         queue: Arc<Queue>,
-        input_options: Input::Opts,
         input_id: InputId,
-    ) -> Result<Self, InputInitError> {
-        let (input, packets) = Input::new(input_options)?;
-        let (init_result_sender, init_result_receiver) = crossbeam_channel::bounded(0);
-
-        let parameters = input.decoder_parameters();
-
-        std::thread::spawn(move || {
-            let mut h264_depayloader = rtp::codecs::h264::H264Packet::default();
-
-            let decoder = Context::from_parameters(parameters)
-                .map_err(InputInitError::FfmpegError)
-                .and_then(|mut decoder| {
-                    // this flag allows us to send the packets in the form they come out of the depayloader
-                    // wasted 6 hrs looking into this. I hate ffmpeg.
-                    // and the bindings don't even expose `flags2` so we have to do the unsafe manually
-                    unsafe {
-                        (*decoder.as_mut_ptr()).flags2 |= AV_CODEC_FLAG2_CHUNKS;
-                    }
-
-                    let decoder = decoder.decoder();
-                    decoder
-                        .open_as(Into::<Id>::into(parameters.codec))
-                        .map_err(InputInitError::FfmpegError)
-                });
-
-            let mut decoder = match decoder {
-                Ok(decoder) => {
-                    init_result_sender.send(Ok(())).unwrap();
-                    decoder
-                }
-                Err(err) => {
-                    init_result_sender.send(Err(err)).unwrap();
-                    return;
-                }
-            };
-
-            let mut decoded_frame = ffmpeg_next::frame::Video::empty();
-            let mut pts_offset = None;
-            for packet in packets {
-                let av_packet = match packet_to_av(packet.clone(), &mut h264_depayloader) {
-                    Ok(Some(packet)) => packet,
-                    Ok(None) => continue,
-                    Err(err) => {
-                        warn!("Failed to depayload packet: {}", err);
-                        continue;
-                    }
-                };
-
-                match decoder.send_packet(&av_packet) {
-                    Ok(()) => {}
-                    Err(e) => {
-                        warn!(
-                            "Failed to send packet with sequence no {} to decoder: {}",
-                            packet.header.sequence_number, e
-                        );
-                        continue;
-                    }
-                }
-
-                while decoder.receive_frame(&mut decoded_frame).is_ok() {
-                    let frame = match frame_from_av(&mut decoded_frame, &mut pts_offset) {
-                        Ok(frame) => frame,
-                        Err(err) => {
-                            warn!("Dropping frame: {}", err);
-                            continue;
-                        }
-                    };
-
-                    if let Err(err) = queue.enqueue_frame(input_id.clone(), frame) {
-                        error!(
-                            "Failed to push frame: {}",
-                            ErrorStack::new(&err).into_string()
-                        );
-                    }
-                }
-            }
-        });
-
-        init_result_receiver.recv().unwrap()?;
-
-        Ok(Self { input })
-    }
-
-    pub fn input(&self) -> &Input {
-        &self.input
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-enum DepayloadingError {
-    #[error(transparent)]
-    Rtp(#[from] rtp::Error),
-
-    #[error("Payload type {0} indicates a different payload type than h264-encoded video")]
-    BadPayloadType(u8),
-}
-
-const H264_DEFAULT_PAYLOAD_TYPE: u8 = 96;
-
-fn packet_to_av(
-    packet: rtp::packet::Packet,
-    ctx: &mut rtp::codecs::h264::H264Packet,
-) -> Result<Option<ffmpeg_next::packet::Packet>, DepayloadingError> {
-    if packet.header.payload_type != H264_DEFAULT_PAYLOAD_TYPE {
-        return Err(DepayloadingError::BadPayloadType(
-            packet.header.payload_type,
-        ));
-    }
-
-    let h264_packet = ctx.depacketize(&packet.payload)?;
-
-    if h264_packet.is_empty() {
-        return Ok(None);
-    }
-
-    let mut ffmpeg_packet = ffmpeg_next::packet::Packet::new(h264_packet.len());
-    ffmpeg_packet
-        .data_mut()
-        .unwrap()
-        .copy_from_slice(&h264_packet);
-
-    ffmpeg_packet.set_pts(Some(packet.header.timestamp.into()));
-    ffmpeg_packet.set_stream(0); // TODO: not sure if this is entirely correct
-
-    Ok(Some(ffmpeg_packet))
-}
-
-fn frame_from_av(decoded: &mut Video, pts_offset: &mut Option<i64>) -> Result<Frame, DecoderError> {
-    if decoded.format() != ffmpeg_next::format::pixel::Pixel::YUV420P {
-        panic!("only YUV420P is supported");
-    }
-    let original_pts = decoded.pts();
-    if let (Some(pts), None) = (decoded.pts(), &pts_offset) {
-        *pts_offset = Some(-pts)
-    }
-    let pts = original_pts
-        .map(|original_pts| original_pts + pts_offset.unwrap_or(0))
-        .ok_or_else(|| DecoderError::FrameConversionError("missing pts".to_owned()))?;
-    let pts = Duration::from_secs_f64(f64::max((pts as f64) / 90000.0, 0.0));
-    Ok(Frame {
-        data: YuvData {
-            y_plane: copy_plane_from_av(decoded, 0),
-            u_plane: copy_plane_from_av(decoded, 1),
-            v_plane: copy_plane_from_av(decoded, 2),
-        },
-        resolution: Resolution {
-            width: decoded.width().try_into().unwrap(),
-            height: decoded.height().try_into().unwrap(),
-        },
-        pts,
-    })
-}
-
-fn copy_plane_from_av(decoded: &Video, plane: usize) -> bytes::Bytes {
-    let mut output_buffer = bytes::BytesMut::with_capacity(
-        decoded.plane_width(plane) as usize * decoded.plane_height(plane) as usize,
-    );
-
-    decoded
-        .data(plane)
-        .chunks(decoded.stride(plane))
-        .map(|chunk| &chunk[..decoded.plane_width(plane) as usize])
-        .for_each(|chunk| output_buffer.extend_from_slice(chunk));
-
-    output_buffer.freeze()
-}
-
-impl From<DecoderParameters> for ffmpeg_next::codec::Parameters {
-    fn from(parameters: DecoderParameters) -> Self {
-        match parameters.codec {
-            Codec::H264 => {
-                let mut parameters = ffmpeg_next::codec::Parameters::new();
-                unsafe {
-                    let parameters = &mut *parameters.as_mut_ptr();
-
-                    parameters.codec_type = Type::Video.into();
-                    parameters.codec_id = Id::H264.into();
-                };
-                parameters
+    ) -> Result<Self, DecoderInitError> {
+        match parameters {
+            DecoderOptions::H264 => {
+                Ok(Self::H264(H264FfmpegDecoder::new(chunks, queue, input_id)?))
             }
         }
     }
 }
 
-impl From<Codec> for ffmpeg_next::codec::Id {
-    fn from(codec: Codec) -> Self {
-        match codec {
-            Codec::H264 => Id::H264,
-        }
-    }
+#[derive(Debug, Clone, Copy)]
+pub enum DecoderOptions {
+    H264,
 }

--- a/compositor_pipeline/src/pipeline/decoder/ffmpeg_h264.rs
+++ b/compositor_pipeline/src/pipeline/decoder/ffmpeg_h264.rs
@@ -1,0 +1,182 @@
+use std::{sync::Arc, time::Duration};
+
+use crate::{
+    error::DecoderInitError,
+    pipeline::structs::{Codec, EncodedChunk, EncodedChunkKind},
+    queue::Queue,
+};
+
+use compositor_render::{error::ErrorStack, Frame, InputId, Resolution, YuvData};
+use ffmpeg_next::{
+    codec::{Context, Id},
+    ffi::AV_CODEC_FLAG2_CHUNKS,
+    frame::Video,
+    media::Type,
+};
+use log::{error, warn};
+
+pub struct H264FfmpegDecoder;
+
+impl H264FfmpegDecoder {
+    pub fn new(
+        chunks: Box<dyn Iterator<Item = EncodedChunk> + Send>,
+        queue: Arc<Queue>,
+        input_id: InputId,
+    ) -> Result<Self, DecoderInitError> {
+        let (init_result_sender, init_result_receiver) = crossbeam_channel::bounded(0);
+
+        let mut parameters = ffmpeg_next::codec::Parameters::new();
+        unsafe {
+            let parameters = &mut *parameters.as_mut_ptr();
+
+            parameters.codec_type = Type::Video.into();
+            parameters.codec_id = Id::H264.into();
+        };
+
+        std::thread::Builder::new()
+            .name(format!("h264 ffmpeg decoder {}", input_id.0))
+            .spawn(move || {
+                let decoder = Context::from_parameters(parameters.clone())
+                    .map_err(DecoderInitError::FfmpegError)
+                    .and_then(|mut decoder| {
+                        // this flag allows us to send the packets in the form they come out of the depayloader
+                        // wasted 6 hrs looking into this. I hate ffmpeg.
+                        // and the bindings don't even expose `flags2` so we have to do the unsafe manually
+                        unsafe {
+                            (*decoder.as_mut_ptr()).flags2 |= AV_CODEC_FLAG2_CHUNKS;
+                        }
+
+                        let decoder = decoder.decoder();
+                        decoder
+                            .open_as(Into::<Id>::into(parameters.id()))
+                            .map_err(DecoderInitError::FfmpegError)
+                    });
+
+                let mut decoder = match decoder {
+                    Ok(decoder) => {
+                        init_result_sender.send(Ok(())).unwrap();
+                        decoder
+                    }
+                    Err(err) => {
+                        init_result_sender.send(Err(err)).unwrap();
+                        return;
+                    }
+                };
+
+                let mut decoded_frame = ffmpeg_next::frame::Video::empty();
+                let mut pts_offset = None;
+                for chunk in chunks {
+                    let av_packet: ffmpeg_next::Packet = match chunk_to_av(chunk) {
+                        Ok(packet) => packet,
+                        Err(err) => {
+                            warn!("Dropping frame: {}", err);
+                            continue;
+                        }
+                    };
+
+                    match decoder.send_packet(&av_packet) {
+                        Ok(()) => {}
+                        Err(e) => {
+                            warn!("Failed to send a packet to decoder: {}", e);
+                            continue;
+                        }
+                    }
+
+                    while decoder.receive_frame(&mut decoded_frame).is_ok() {
+                        let frame = match frame_from_av(&mut decoded_frame, &mut pts_offset) {
+                            Ok(frame) => frame,
+                            Err(err) => {
+                                warn!("Dropping frame: {}", err);
+                                continue;
+                            }
+                        };
+
+                        if let Err(err) = queue.enqueue_frame(input_id.clone(), frame) {
+                            error!(
+                                "Failed to push frame: {}",
+                                ErrorStack::new(&err).into_string()
+                            );
+                        }
+                    }
+                }
+            })
+            .unwrap();
+
+        init_result_receiver.recv().unwrap()?;
+
+        Ok(Self)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum DecoderChunkConversionError {
+    #[error(
+        "Cannot send a chunk of kind {0:?} to the decoder. The decoder only handles H264-encoded video."
+    )]
+    BadPayloadType(EncodedChunkKind),
+}
+
+fn chunk_to_av(chunk: EncodedChunk) -> Result<ffmpeg_next::Packet, DecoderChunkConversionError> {
+    if chunk.kind != EncodedChunkKind::Video(Codec::H264) {
+        return Err(DecoderChunkConversionError::BadPayloadType(chunk.kind));
+    }
+
+    let mut packet = ffmpeg_next::Packet::new(chunk.data.len());
+
+    packet.data_mut().unwrap().copy_from_slice(&chunk.data);
+    packet.set_pts(Some(chunk.pts));
+    packet.set_dts(chunk.dts);
+
+    Ok(packet)
+}
+
+#[derive(Debug, thiserror::Error)]
+enum DecoderFrameConversionError {
+    #[error("Error converting frame: {0}")]
+    FrameConversionError(String),
+}
+
+fn frame_from_av(
+    decoded: &mut Video,
+    pts_offset: &mut Option<i64>,
+) -> Result<Frame, DecoderFrameConversionError> {
+    if decoded.format() != ffmpeg_next::format::pixel::Pixel::YUV420P {
+        panic!("only YUV420P is supported");
+    }
+    let original_pts = decoded.pts();
+    if let (Some(pts), None) = (decoded.pts(), &pts_offset) {
+        *pts_offset = Some(-pts)
+    }
+    let pts = original_pts
+        .map(|original_pts| original_pts + pts_offset.unwrap_or(0))
+        .ok_or_else(|| {
+            DecoderFrameConversionError::FrameConversionError("missing pts".to_owned())
+        })?;
+    let pts = Duration::from_secs_f64(f64::max((pts as f64) / 90000.0, 0.0));
+    Ok(Frame {
+        data: YuvData {
+            y_plane: copy_plane_from_av(decoded, 0),
+            u_plane: copy_plane_from_av(decoded, 1),
+            v_plane: copy_plane_from_av(decoded, 2),
+        },
+        resolution: Resolution {
+            width: decoded.width().try_into().unwrap(),
+            height: decoded.height().try_into().unwrap(),
+        },
+        pts,
+    })
+}
+
+fn copy_plane_from_av(decoded: &Video, plane: usize) -> bytes::Bytes {
+    let mut output_buffer = bytes::BytesMut::with_capacity(
+        decoded.plane_width(plane) as usize * decoded.plane_height(plane) as usize,
+    );
+
+    decoded
+        .data(plane)
+        .chunks(decoded.stride(plane))
+        .map(|chunk| &chunk[..decoded.plane_width(plane) as usize])
+        .for_each(|chunk| output_buffer.extend_from_slice(chunk));
+
+    output_buffer.freeze()
+}

--- a/compositor_pipeline/src/pipeline/encoder.rs
+++ b/compositor_pipeline/src/pipeline/encoder.rs
@@ -166,10 +166,7 @@ impl<'a> Iterator for PacketIterator<'a> {
             match EncodedChunk::from_av_packet(&packet, EncodedChunkKind::Video(Codec::H264)) {
                 Ok(chunk) => Some(chunk),
                 Err(e) => {
-                    warn!(
-                        "failed to parse an ffmpeg packet received from encoder: {}",
-                        e
-                    );
+                    warn!("failed to parse an ffmpeg packet received from encoder: {e}",);
                     None // TODO: this will terminate iteration. Is this what we want?
                 }
             }

--- a/compositor_pipeline/src/pipeline/input.rs
+++ b/compositor_pipeline/src/pipeline/input.rs
@@ -1,0 +1,28 @@
+use crate::{error::InputInitError, pipeline::structs::EncodedChunk};
+
+use rtp::{RtpReceiver, RtpReceiverOptions};
+
+pub mod rtp;
+
+pub enum Input {
+    Rtp(RtpReceiver),
+}
+
+impl Input {
+    pub fn new(
+        options: InputOptions,
+    ) -> Result<(Self, Box<dyn Iterator<Item = EncodedChunk> + Send>), InputInitError> {
+        match options {
+            InputOptions::Rtp(opts) => Ok(RtpReceiver::new(opts).map(|(receiver, iter)| {
+                (
+                    Self::Rtp(receiver),
+                    Box::new(iter) as Box<dyn Iterator<Item = EncodedChunk> + Send>,
+                )
+            })?),
+        }
+    }
+}
+
+pub enum InputOptions {
+    Rtp(RtpReceiverOptions),
+}

--- a/compositor_pipeline/src/pipeline/input/rtp.rs
+++ b/compositor_pipeline/src/pipeline/input/rtp.rs
@@ -43,10 +43,15 @@ impl RtpReceiver {
         )
         .map_err(RtpReceiverError::SocketOptions)?;
 
-        // This doesn't fail if the requested size is larger than the system limit
-        socket
+        match socket
             .set_recv_buffer_size(16 * 1024 * 1024)
-            .map_err(RtpReceiverError::SocketOptions)?;
+            .map_err(RtpReceiverError::SocketOptions)
+        {
+            Ok(_) => {}
+            Err(e) => {
+                warn!("Failed to set socket receive buffer size: {e}. This may cause packet loss, especially on high-bitrate streams.");
+            }
+        }
 
         socket
             .bind(

--- a/compositor_pipeline/src/pipeline/structs.rs
+++ b/compositor_pipeline/src/pipeline/structs.rs
@@ -1,0 +1,66 @@
+use bytes::Bytes;
+
+/// A struct representing a chunk of encoded data.
+///
+/// Many codecs specify that encoded data is split into chunks.
+/// For example, H264 splits the data into NAL units and AV1 splits the data into OBU frames.
+pub struct EncodedChunk {
+    pub data: Bytes,
+    pub pts: i64,
+    pub dts: Option<i64>,
+    pub kind: EncodedChunkKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncodedChunkKind {
+    Video(Codec),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChunkFromFfmpegError {
+    #[error("No data")]
+    NoData,
+    #[error("No pts")]
+    NoPts,
+}
+
+impl EncodedChunk {
+    pub fn from_av_packet(
+        value: &ffmpeg_next::Packet,
+        kind: EncodedChunkKind,
+    ) -> Result<Self, ChunkFromFfmpegError> {
+        let data = match value.data() {
+            Some(data) => Bytes::copy_from_slice(data),
+            None => return Err(ChunkFromFfmpegError::NoData),
+        };
+
+        Ok(Self {
+            data,
+            pts: value.pts().ok_or(ChunkFromFfmpegError::NoPts)?,
+            dts: value.dts(),
+            kind,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Codec {
+    H264,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CodecFromFfmpegError {
+    #[error("Unsupported codec {0:?}")]
+    UnsupportedCodec(ffmpeg_next::codec::Id),
+}
+
+impl TryFrom<ffmpeg_next::Codec> for Codec {
+    type Error = CodecFromFfmpegError;
+
+    fn try_from(value: ffmpeg_next::Codec) -> Result<Self, Self::Error> {
+        match value.id() {
+            ffmpeg_next::codec::Id::H264 => Ok(Self::H264),
+            v => Err(CodecFromFfmpegError::UnsupportedCodec(v)),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,6 @@ pub mod config;
 pub mod error;
 pub mod http;
 pub mod logger;
-pub mod rtp_receiver;
+
 pub mod rtp_sender;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod config;
 mod error;
 mod http;
 mod logger;
-mod rtp_receiver;
+
 mod rtp_sender;
 mod types;
 


### PR DESCRIPTION
This patch makes it simple to add more inputs and more decoders. It also removes the generics from the pipeline in favor of simple enums. The implementation of the RTP receiver was also moved to the `compositor_pipeline` crate.

A big fault of this patch is that it doesn't address attaching multiple decoders to a single input, but this requires further discussion.