### PR TITLE
Fixed running web renderer in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,12 @@ ENV NVIDIA_DRIVER_CAPABILITIES compute,graphics,utility
 ENV MEMBRANE_VIDEO_COMPOSITOR_MAIN_EXECUTABLE_PATH=/home/$USERNAME/video_compositor/main_process
 ENV MEMBRANE_VIDEO_COMPOSITOR_PROCESS_HELPER_PATH=/home/$USERNAME/video_compositor/process_helper
 ENV LD_LIBRARY_PATH=/home/$USERNAME/video_compositor/lib
+ENV XDG_RUNTIME_DIR=/tmp
 
 RUN apt-get update -y -qq && \
   apt-get install -y \
     sudo adduser ffmpeg \
-    libnss3 libatk1.0-0 libatk-bridge2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0 && \
+    libnss3 libatk1.0-0 libatk-bridge2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0 xvfb && \
   rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash $USERNAME && adduser $USERNAME sudo

--- a/compositor_render/src/transformations/web_renderer/chromium_context.rs
+++ b/compositor_render/src/transformations/web_renderer/chromium_context.rs
@@ -144,8 +144,11 @@ impl cef::App for ChromiumApp {
         }
         if self.disable_gpu {
             command_line.append_switch("disable-gpu");
+            // TODO: This is probably only needed in docker container
+            command_line.append_switch("disable-software-rasterizer");
         }
 
+        command_line.append_switch("disable-dev-shm-usage");
         command_line.append_switch("disable-gpu-shader-disk-cache");
         command_line.append_switch_with_value("autoplay-policy", "no-user-gesture-required");
     }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,4 +5,8 @@ set -x
 
 sleep 2
 
-exec "$MEMBRANE_VIDEO_COMPOSITOR_MAIN_EXECUTABLE_PATH"
+export DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus
+sudo service dbus start
+dbus-daemon --session --address=$DBUS_SESSION_BUS_ADDRESS --nofork --nopidfile --syslog-only &
+
+xvfb-run "$MEMBRANE_VIDEO_COMPOSITOR_MAIN_EXECUTABLE_PATH"


### PR DESCRIPTION
The main problem was that the `/dev/shm` partition was too small inside the container. `disable-dev-shm-usage` flag works around the issue by using a temporary directory instead.


Closes #307 