### PR TITLE
Switch to env based configuration + remove `"init"` request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,6 +1234,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,8 +1847,17 @@ checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.3.4",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1850,8 +1868,14 @@ checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2604,12 +2628,16 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ rtcp = "0.10.0"
 rand = "0.8.5"
 socket2 = "0.5.5"
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["json"] }
+tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter"] }
 libc = "0.2.151"
 
 [dev-dependencies]

--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -70,6 +70,7 @@ pub struct Pipeline<Input: PipelineInput, Output: PipelineOutput> {
     is_started: bool,
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct Options {
     pub framerate: Framerate,
     pub stream_fallback_timeout: Duration,

--- a/compositor_render/src/transformations/web_renderer.rs
+++ b/compositor_render/src/transformations/web_renderer.rs
@@ -35,18 +35,10 @@ pub const GET_FRAME_POSITIONS_MESSAGE: &str = "GET_FRAME_POSITIONS";
 pub(super) type FrameData = Arc<Mutex<Bytes>>;
 pub(super) type SourceTransforms = Arc<Mutex<Vec<Mat4>>>;
 
+#[derive(Debug, Clone, Copy)]
 pub struct WebRendererInitOptions {
-    pub init: bool,
-    pub disable_gpu: bool,
-}
-
-impl Default for WebRendererInitOptions {
-    fn default() -> Self {
-        Self {
-            init: cfg!(feature = "web_renderer"),
-            disable_gpu: false,
-        }
-    }
+    pub enable: bool,
+    pub enable_gpu: bool,
 }
 
 #[derive(Debug)]

--- a/compositor_render/src/transformations/web_renderer/chromium_context.rs
+++ b/compositor_render/src/transformations/web_renderer/chromium_context.rs
@@ -27,7 +27,7 @@ impl ChromiumContext {
         let instance_id = random_string(30);
         #[cfg(not(feature = "web_renderer"))]
         {
-            if opts.init {
+            if opts.enable {
                 return Err(WebRendererContextError::WebRenderingNotAvailable);
             }
             return Ok(Self {
@@ -38,7 +38,7 @@ impl ChromiumContext {
 
         #[cfg(feature = "web_renderer")]
         {
-            if !opts.init {
+            if !opts.enable {
                 info!("Chromium context disabled");
                 return Ok(Self {
                     instance_id,
@@ -51,7 +51,7 @@ impl ChromiumContext {
 
             let app = ChromiumApp {
                 show_fps: false,
-                disable_gpu: opts.disable_gpu,
+                enable_gpu: opts.enable_gpu,
             };
             let settings = cef::Settings {
                 windowless_rendering_enabled: true,
@@ -118,7 +118,7 @@ impl ChromiumContext {
 
 struct ChromiumApp {
     show_fps: bool,
-    disable_gpu: bool,
+    enable_gpu: bool,
 }
 
 #[cfg(feature = "web_renderer")]
@@ -142,7 +142,7 @@ impl cef::App for ChromiumApp {
         if self.show_fps {
             command_line.append_switch("show-fps-counter")
         }
-        if self.disable_gpu {
+        if !self.enable_gpu {
             command_line.append_switch("disable-gpu");
             // TODO: This is probably only needed in docker container
             command_line.append_switch("disable-software-rasterizer");

--- a/docs/pages/api/api.md
+++ b/docs/pages/api/api.md
@@ -2,7 +2,7 @@
 
 Compositor exposes HTTP API. After spawning a compositor process the first request has to be [an init request](https://github.com/membraneframework/video_compositor/wiki/API-%E2%80%90-general#init). After the compositor is initialized you can configure the processing pipeline using `RegisterInputStream`, `RegisterOutputStre`, `UpdateScene`, and other requests. When you are ready to start receiving the output stream from the compositor you can send a [`Start`](https://github.com/membraneframework/video_compositor/wiki/API-%E2%80%90-general#start) request.
 
-API is served by default on port `8001`, but it can be configured via `MEMBRANE_VIDEO_COMPOSITOR_API_PORT` environment variable.
+API is served by default on port `8001`, but it can be configured via `LIVE_COMPOSITOR_API_PORT` environment variable.
 
 After the compositor is started with a [`Start`](https://github.com/membraneframework/video_compositor/wiki/API-%E2%80%90-general#start) request you can keep using `RegisterInputStream`, `RegisterOutputStream`, `UpdateScene` and others to modify the pipeline in real-time.
 

--- a/docs/pages/api/routes.md
+++ b/docs/pages/api/routes.md
@@ -4,30 +4,6 @@ description: API routes to configure the compositor.
 
 # Routes
 
-### Init
-
-```typescript
-type Init = {
-  type: "init";
-  web_renderer?: {
-    init?: boolean;
-    disable_gpu?: boolean;
-  };
-  framerate: number;
-  stream_fallback_timeout_ms?: number;
-}
-```
-
-Init request triggers the initial setup of a compositor. It defines the base settings of a compositor that need to be evaluated before any other work happens.
-
-- `web_renderer` - Web renderer specific options. [Learn more](./renderers/web).
-  - `web_renderer.init` - (**default=`true`**). Enable web rendering capabilities. With this option disabled, you can not use [`WebView` components](./components/WebView) or register [`WebRenderer` instances](./renderers/web).
-  - `web_renderer.disable_gpu` - (**default=`false`**). Disable GPU support inside embedded Chromium instance.
-- `framerate` - Target framerate of the output streams.
-- `stream_fallback_timeout_ms` (**default: 1000**) - Timeout that defines when the compositor should switch to fallback on the input stream that stopped sending frames.
-
-***
-
 ### Start
 
 ```typescript

--- a/docs/pages/deployment/configuration.md
+++ b/docs/pages/deployment/configuration.md
@@ -48,5 +48,5 @@ Enable web rendering capabilities. With this option disabled, you can not use [`
 
 ### `LIVE_COMPOSITOR_WEB_RENDERER_GPU_ENABLE`
 
-Disable GPU support inside the embedded Chromium instance.
+Enable GPU support inside the embedded Chromium instance.
 

--- a/docs/pages/deployment/configuration.md
+++ b/docs/pages/deployment/configuration.md
@@ -1,0 +1,52 @@
+# Configuration
+
+## Environment variables
+
+### `LIVE_COMPOSITOR_API_PORT`
+
+API port. Defaults to 8001.
+
+### `LIVE_COMPOSITOR_OUTPUT_FRAMERATE`
+
+Output framerate for all output streams. This value can be a number or string in the `NUM/DEN` format , where both `NUM` and `DEN` are unsigned integers.
+
+### `LIVE_COMPOSITOR_STREAM_FALLBACK_TIMEOUT_MS`
+
+A timeout that defines when the compositor should switch to fallback on the input stream that stopped sending frames.
+
+### `LIVE_COMPOSITOR_LOGGER_LEVEL`
+
+Logger level. Value can be defined as `error`/`warn`/`info`/`debug`/`trace`.
+
+This value also supports syntax for more detailed configuration. See [`tracing-subscriber` crate documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax) for more info.
+
+### `LIVE_COMPOSITOR_LOGGER_FORMAT`
+
+Logger format. Supported options:
+- `json`
+- `compact`
+- `pretty`
+
+:::warning
+This option does not apply to logs produced by `FFmpeg` or the embedded Chromium instance used for web rendering.
+:::
+
+### `LIVE_COMPOSITOR_FFMPEG_LOGGER_LEVEL`
+
+Minimal log level that should be logged. Supported options:
+- `error` - equivalent to FFmpeg's `error, 16`
+- `warn` - equivalent to FFmpeg's `warning, 24`
+- `info` - equivalent to FFmpeg's `info, 32`
+- `debug` - equivalent to FFmpeg's `debug, 48`
+ 
+
+See `-loglevel` option in [FFmpeg documentation](https://ffmpeg.org/ffmpeg.html).
+
+### `LIVE_COMPOSITOR_WEB_RENDERER_ENABLE`
+
+Enable web rendering capabilities. With this option disabled, you can not use [`WebView` components](../api/components/WebView) or register [`WebRenderer` instances](../api/renderers/web).
+
+### `LIVE_COMPOSITOR_WEB_RENDERER_GPU_ENABLE`
+
+Disable GPU support inside the embedded Chromium instance.
+

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -21,6 +21,21 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: 'Deployment',
+      collapsible: true,
+      link: {
+        type: 'generated-index',
+      },
+      items: [
+        {
+          type: 'doc',
+          id: 'deployment/configuration',
+          label: 'Configuration',
+        },
+      ],
+    },
+    {
+      type: 'category',
       label: 'API Reference',
       collapsible: false,
       link: {

--- a/examples/common/common.rs
+++ b/examples/common/common.rs
@@ -8,6 +8,7 @@ use std::{
     path::{Path, PathBuf},
     time::Duration,
 };
+use video_compositor::config::config;
 
 use serde::Serialize;
 
@@ -41,7 +42,7 @@ pub fn write_example_sdp_file(ip: &str, port: u16) -> Result<String> {
 pub fn post<T: Serialize + ?Sized>(json: &T) -> Result<Response> {
     let client = reqwest::blocking::Client::new();
     let response = client
-        .post("http://127.0.0.1:8001")
+        .post(format!("http://127.0.0.1:{}", config().api_port))
         .timeout(Duration::from_secs(100))
         .json(json)
         .send()

--- a/examples/docker.rs
+++ b/examples/docker.rs
@@ -8,7 +8,7 @@ use std::{
     thread,
     time::Duration,
 };
-use video_compositor::{logger, types::Resolution};
+use video_compositor::{config::config, logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -19,7 +19,6 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
     width: 1920,
     height: 1080,
 };
-const FRAMERATE: u32 = 30;
 
 fn main() {
     logger::init_logger();
@@ -71,7 +70,7 @@ fn build_and_start_docker(skip_build: bool) -> Result<()> {
         "-p",
         "8004:8004/udp",
         "-p",
-        "8001:8001",
+        format!("{}:{}", config().api_port, config().api_port).leak(),
         "--rm",
     ];
 
@@ -94,15 +93,6 @@ fn build_and_start_docker(skip_build: bool) -> Result<()> {
 
 fn start_example_client_code(host_ip: String) -> Result<()> {
     thread::sleep(Duration::from_secs(5));
-
-    info!("[example] Sending init request.");
-    common::post(&json!({
-        "type": "init",
-        "framerate": FRAMERATE,
-        "web_renderer": {
-            "init": false
-        },
-    }))?;
 
     info!("[example] Start listening on output port.");
     let output_sdp = write_example_sdp_file(&host_ip, 8002)?;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -7,7 +7,7 @@ use std::{
     thread,
     time::Duration,
 };
-use video_compositor::{http, logger, types::Resolution};
+use video_compositor::{config::config, http, logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -20,7 +20,6 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
     width: 1280,
     height: 720,
 };
-const FRAMERATE: u32 = 30;
 
 fn main() {
     ffmpeg_next::format::network::init();
@@ -32,21 +31,10 @@ fn main() {
         }
     });
 
-    http::Server::new(8001).run();
+    http::Server::new(config().api_port).run();
 }
 
 fn start_example_client_code() -> Result<()> {
-    thread::sleep(Duration::from_secs(2));
-
-    info!("[example] Sending init request.");
-    common::post(&json!({
-        "type": "init",
-        "framerate": FRAMERATE,
-        "web_renderer": {
-            "init": false
-        },
-    }))?;
-
     info!("[example] Start listening on output port.");
     let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
@@ -54,6 +42,7 @@ fn start_example_client_code() -> Result<()> {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()?;
+    thread::sleep(Duration::from_secs(2));
 
     info!("[example] Download sample.");
     let sample_path = env::current_dir()?.join(SAMPLE_FILE_PATH);

--- a/examples/test_pattern.rs
+++ b/examples/test_pattern.rs
@@ -6,7 +6,7 @@ use std::{
     thread,
     time::Duration,
 };
-use video_compositor::{api::Response, http, logger, types::Resolution};
+use video_compositor::{api::Response, config::config, http, logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -17,7 +17,6 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
     width: 1920,
     height: 1080,
 };
-const FRAMERATE: u32 = 30;
 
 fn main() {
     ffmpeg_next::format::network::init();
@@ -29,22 +28,10 @@ fn main() {
         }
     });
 
-    http::Server::new(8001).run();
+    http::Server::new(config().api_port).run();
 }
 
 fn start_example_client_code() -> Result<()> {
-    thread::sleep(Duration::from_secs(2));
-
-    info!("[example] Sending init request.");
-    common::post(&json!({
-        "type": "init",
-        "web_renderer": {
-            "init": false
-        },
-        "framerate": FRAMERATE,
-        "stream_fallback_timeout_ms": 2000
-    }))?;
-
     info!("[example] Start listening on output port.");
     let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
@@ -52,6 +39,8 @@ fn start_example_client_code() -> Result<()> {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()?;
+
+    thread::sleep(Duration::from_secs(2));
 
     info!("[example] Send register output request.");
     common::post(&json!({

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -6,7 +6,7 @@ use std::{
     thread,
     time::Duration,
 };
-use video_compositor::{http, logger, types::Resolution};
+use video_compositor::{config::config, http, logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -18,8 +18,6 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
     height: 1080,
 };
 
-const FRAMERATE: u32 = 30;
-
 fn main() {
     ffmpeg_next::format::network::init();
     logger::init_logger();
@@ -30,21 +28,10 @@ fn main() {
         }
     });
 
-    http::Server::new(8001).run();
+    http::Server::new(config().api_port).run();
 }
 
 fn start_example_client_code() -> Result<()> {
-    thread::sleep(Duration::from_secs(2));
-
-    info!("[example] Sending init request.");
-    common::post(&json!({
-        "type": "init",
-        "framerate": FRAMERATE,
-        "web_renderer": {
-            "init": false
-        }
-    }))?;
-
     info!("[example] Start listening on output port.");
     let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
@@ -52,6 +39,8 @@ fn start_example_client_code() -> Result<()> {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()?;
+
+    thread::sleep(Duration::from_secs(2));
 
     info!("[example] Send register output request.");
     common::post(&json!({

--- a/examples/tiles.rs
+++ b/examples/tiles.rs
@@ -6,7 +6,7 @@ use std::{
     thread,
     time::Duration,
 };
-use video_compositor::{http, logger, types::Resolution};
+use video_compositor::{config::config, http, logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -18,8 +18,6 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
     height: 1080,
 };
 
-const FRAMERATE: u32 = 30;
-
 fn main() {
     ffmpeg_next::format::network::init();
     logger::init_logger();
@@ -30,24 +28,10 @@ fn main() {
         }
     });
 
-    http::Server::new(8001).run();
+    http::Server::new(config().api_port).run();
 }
 
 fn start_example_client_code() -> Result<()> {
-    thread::sleep(Duration::from_secs(2));
-
-    info!("[example] Sending init request.");
-    common::post(&json!({
-        "type": "init",
-        "web_renderer": {
-            "init": false
-        },
-        "framerate": FRAMERATE,
-        "stream_fallback_timeout_ms": 2000
-    }))?;
-
-    thread::sleep(Duration::from_secs(1));
-
     info!("[example] Start listening on output port.");
     let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
@@ -55,6 +39,8 @@ fn start_example_client_code() -> Result<()> {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()?;
+
+    thread::sleep(Duration::from_secs(2));
 
     info!("[example] Send register output request.");
     common::post(&json!({

--- a/examples/transition.rs
+++ b/examples/transition.rs
@@ -6,7 +6,7 @@ use std::{
     thread,
     time::Duration,
 };
-use video_compositor::{http, logger, types::Resolution};
+use video_compositor::{config::config, http, logger, types::Resolution};
 
 use crate::common::write_example_sdp_file;
 
@@ -18,8 +18,6 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
     height: 1080,
 };
 
-const FRAMERATE: u32 = 30;
-
 fn main() {
     ffmpeg_next::format::network::init();
     logger::init_logger();
@@ -30,22 +28,10 @@ fn main() {
         }
     });
 
-    http::Server::new(8001).run();
+    http::Server::new(config().api_port).run();
 }
 
 fn start_example_client_code() -> Result<()> {
-    thread::sleep(Duration::from_secs(2));
-
-    info!("[example] Sending init request.");
-    common::post(&json!({
-        "type": "init",
-        "web_renderer": {
-            "init": false
-        },
-        "framerate": FRAMERATE,
-        "stream_fallback_timeout_ms": 2000
-    }))?;
-
     info!("[example] Start listening on output port.");
     let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
@@ -53,6 +39,7 @@ fn start_example_client_code() -> Result<()> {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()?;
+    thread::sleep(Duration::from_secs(2));
 
     info!("[example] Send register output request.");
     common::post(&json!({

--- a/src/bin/main_process.rs
+++ b/src/bin/main_process.rs
@@ -1,8 +1,7 @@
-use std::env;
-
 use log::info;
 use video_compositor::{
-    http::{self, API_PORT_ENV},
+    config::config,
+    http::{self},
     logger,
 };
 
@@ -10,8 +9,7 @@ fn main() {
     ffmpeg_next::format::network::init();
     logger::init_logger();
 
-    let port = env::var(API_PORT_ENV).unwrap_or_else(|_| "8001".to_string());
-    http::Server::new(port.parse::<u16>().unwrap()).run();
+    http::Server::new(config().api_port).run();
 
     info!("Received exit signal. Terminating...")
     // TODO: add graceful shutdown

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,148 @@
+use std::{env, str::FromStr, sync::OnceLock, time::Duration};
+
+use compositor_render::{web_renderer::WebRendererInitOptions, Framerate};
+use log::error;
+
+use crate::logger::FfmpegLogLevel;
+
+pub struct Config {
+    pub api_port: u16,
+    pub logger: LoggerConfig,
+    pub framerate: Framerate,
+    pub stream_fallback_timeout: Duration,
+    pub web_renderer: WebRendererInitOptions,
+}
+
+pub struct LoggerConfig {
+    pub ffmpeg_logger_level: FfmpegLogLevel,
+    pub format: LoggerFormat,
+    pub level: String,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum LoggerFormat {
+    Pretty,
+    Json,
+    Compact,
+}
+
+impl FromStr for LoggerFormat {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "json" => Ok(LoggerFormat::Json),
+            "pretty" => Ok(LoggerFormat::Pretty),
+            "compact" => Ok(LoggerFormat::Compact),
+            _ => Err("invalid logger format"),
+        }
+    }
+}
+
+pub fn config() -> &'static Config {
+    static CONFIG: OnceLock<Config> = OnceLock::new();
+
+    CONFIG.get_or_init(|| {
+        read_config().expect("Failed to read the config from environment variables.")
+    })
+}
+
+fn read_config() -> Result<Config, &'static str> {
+    let api_port = match env::var("LIVE_COMPOSITOR_API_PORT") {
+        Ok(api_port) => api_port
+            .parse::<u16>()
+            .map_err(|_| "LIVE_COMPOSITOR_API_PORT has to be valid port number")?,
+        Err(_) => 8081,
+    };
+
+    let ffmpeg_logger_level = match env::var("LIVE_COMPOSITOR_FFMPEG_LOGGER_LEVEL") {
+        Ok(ffmpeg_log_level) => {
+            FfmpegLogLevel::from_str(&ffmpeg_log_level).unwrap_or(FfmpegLogLevel::Warn)
+        }
+        Err(_) => FfmpegLogLevel::Warn,
+    };
+
+    let logger_level = match env::var("LIVE_COMPOSITOR_LOGGER_LEVEL") {
+        Ok(level) => level,
+        Err(_) => "info".to_string(),
+    };
+
+    // When building in repo use compact logger
+    let default_logger_format = match env::var("CARGO_MANIFEST_DIR") {
+        Ok(_) => LoggerFormat::Compact,
+        Err(_) => LoggerFormat::Json,
+    };
+    let logger_format = match env::var("LIVE_COMPOSITOR_LOGGER_FORMAT") {
+        Ok(format) => LoggerFormat::from_str(&format).unwrap_or(default_logger_format),
+        Err(_) => default_logger_format,
+    };
+
+    const DEFAULT_FRAMERATE: Framerate = Framerate { num: 30, den: 1 };
+    let framerate = match env::var("LIVE_COMPOSITOR_OUTPUT_FRAMERATE") {
+        Ok(framerate) => framerate_from_str(&framerate).unwrap_or(DEFAULT_FRAMERATE),
+        Err(_) => DEFAULT_FRAMERATE,
+    };
+
+    const DEFAULT_WEB_RENDERER_ENABLED: bool = cfg!(feature = "web_renderer");
+    let web_renderer_enable = match env::var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE") {
+        Ok(enable) => bool_env_from_str(&enable).unwrap_or(DEFAULT_WEB_RENDERER_ENABLED),
+        Err(_) => DEFAULT_WEB_RENDERER_ENABLED,
+    };
+
+    let web_renderer_gpu_enable = match env::var("LIVE_COMPOSITOR_WEB_RENDERER_GPU_ENABLE") {
+        Ok(enable) => bool_env_from_str(&enable).unwrap_or(true),
+        Err(_) => true,
+    };
+
+    const DEFAULT_STREAM_FALLBACK_TIMEOUT: Duration = Duration::from_millis(2000);
+    let stream_fallback_timeout = match env::var("LIVE_COMPOSITOR_STREAM_FALLBACK_TIMEOUT_MS") {
+        Ok(timeout_ms) => match timeout_ms.parse::<f64>() {
+            Ok(timeout_ms) => Duration::from_secs_f64(timeout_ms),
+            Err(_) => {
+                error!("Invalid value provided for \"LIVE_COMPOSITOR_STREAM_FALLBACK_TIMEOUT_MS\". Falling back to default value 2000ms.");
+                DEFAULT_STREAM_FALLBACK_TIMEOUT
+            }
+        },
+        Err(_) => DEFAULT_STREAM_FALLBACK_TIMEOUT,
+    };
+
+    Ok(Config {
+        api_port,
+        logger: LoggerConfig {
+            ffmpeg_logger_level,
+            format: logger_format,
+            level: logger_level,
+        },
+        framerate,
+        stream_fallback_timeout,
+        web_renderer: WebRendererInitOptions {
+            enable: web_renderer_enable,
+            enable_gpu: web_renderer_gpu_enable,
+        },
+    })
+}
+
+fn framerate_from_str(s: &str) -> Result<Framerate, &'static str> {
+    const ERROR_MESSAGE: &str = "Framerate needs to be an unsigned integer or a string in the \"NUM/DEN\" format, where NUM and DEN are both unsigned integers.";
+    if s.contains('/') {
+        let Some((num_str, den_str)) = s.split_once('/') else {
+            return Err(ERROR_MESSAGE);
+        };
+        let num = num_str.parse::<u32>().map_err(|_| ERROR_MESSAGE)?;
+        let den = den_str.parse::<u32>().map_err(|_| ERROR_MESSAGE)?;
+        Ok(compositor_render::Framerate { num, den })
+    } else {
+        Ok(compositor_render::Framerate {
+            num: s.parse::<u32>().map_err(|_| ERROR_MESSAGE)?,
+            den: 1,
+        })
+    }
+}
+
+fn bool_env_from_str(s: &str) -> Option<bool> {
+    match s {
+        "1" | "true" => Some(true),
+        "0" | "false" => Some(false),
+        _ => None,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod config;
 pub mod error;
 pub mod http;
 pub mod logger;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,24 +1,33 @@
-use std::{env, sync::OnceLock};
+use std::{str::FromStr, sync::OnceLock};
+
+use crate::config::{config, LoggerFormat};
 
 #[derive(Debug, Clone, Copy)]
-enum FfmpegLogLevel {
+pub enum FfmpegLogLevel {
     Error,
     Warn,
     Info,
     Debug,
 }
 
-fn ffmpeg_log_level() -> FfmpegLogLevel {
+fn ffmpeg_logger_level() -> FfmpegLogLevel {
     static LOG_LEVEL: OnceLock<FfmpegLogLevel> = OnceLock::new();
 
-    *LOG_LEVEL.get_or_init(|| match env::var("FFMPEG_LOG_LEVEL") {
-        Ok(debug) if debug == "debug" => FfmpegLogLevel::Debug,
-        Ok(info) if info == "info" => FfmpegLogLevel::Info,
-        Ok(warn) if warn == "warn" => FfmpegLogLevel::Warn,
-        Ok(error) if error == "error" => FfmpegLogLevel::Error,
-        Ok(_) => FfmpegLogLevel::Warn,
-        Err(_) => FfmpegLogLevel::Warn,
-    })
+    *LOG_LEVEL.get_or_init(|| config().logger.ffmpeg_logger_level)
+}
+
+impl FromStr for FfmpegLogLevel {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "debug" => Ok(FfmpegLogLevel::Debug),
+            "info" => Ok(FfmpegLogLevel::Info),
+            "warn" => Ok(FfmpegLogLevel::Warn),
+            "error" => Ok(FfmpegLogLevel::Error),
+            _ => Err("Invalid FFmpeg logger level."),
+        }
+    }
 }
 
 extern "C" fn ffmpeg_log_callback(
@@ -29,7 +38,7 @@ extern "C" fn ffmpeg_log_callback(
     #[cfg(target_arch = "aarch64")] va_list_tag: ffmpeg_next::sys::va_list,
 ) {
     unsafe {
-        match ffmpeg_log_level() {
+        match ffmpeg_logger_level() {
             FfmpegLogLevel::Error if log_level <= 16 => {
                 ffmpeg_next::sys::av_log_default_callback(arg1, log_level, fmt, va_list_tag)
             }
@@ -48,10 +57,26 @@ extern "C" fn ffmpeg_log_callback(
 }
 
 pub fn init_logger() {
-    if env::var("CARGO_MANIFEST_DIR").is_ok() {
-        tracing_subscriber::fmt().init();
-    } else {
-        tracing_subscriber::fmt().json().init();
+    let env_filter = tracing_subscriber::EnvFilter::new(&config().logger.level);
+    match config().logger.format {
+        LoggerFormat::Pretty => {
+            tracing_subscriber::fmt()
+                .pretty()
+                .with_env_filter(env_filter)
+                .init();
+        }
+        LoggerFormat::Json => {
+            tracing_subscriber::fmt()
+                .json()
+                .with_env_filter(env_filter)
+                .init();
+        }
+        LoggerFormat::Compact => {
+            tracing_subscriber::fmt()
+                .compact()
+                .with_env_filter(env_filter)
+                .init();
+        }
     }
     unsafe {
         ffmpeg_next::sys::av_log_set_callback(Some(ffmpeg_log_callback));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
-use std::env;
-
 use log::info;
 
-use crate::http::API_PORT_ENV;
+use crate::config::config;
 
 mod api;
+mod config;
 mod error;
 mod http;
 mod logger;
@@ -34,8 +33,7 @@ fn main() {
 
     ffmpeg_next::format::network::init();
 
-    let port = env::var(API_PORT_ENV).unwrap_or_else(|_| "8001".to_string());
-    http::Server::new(port.parse::<u16>().unwrap()).run();
+    http::Server::new(config().api_port).run();
 
     info!("Received exit signal. Terminating...")
     // TODO: add graceful shutdown

--- a/src/snapshot_tests/utils.rs
+++ b/src/snapshot_tests/utils.rs
@@ -58,8 +58,8 @@ pub(super) fn create_renderer(
 ) -> Renderer {
     let (mut renderer, _event_loop) = Renderer::new(RendererOptions {
         web_renderer: web_renderer::WebRendererInitOptions {
-            init: false,
-            disable_gpu: false,
+            enable: false,
+            enable_gpu: false,
         },
         framerate: Framerate { num: 30, den: 1 },
         stream_fallback_timeout: Duration::from_secs(3),

--- a/src/types.rs
+++ b/src/types.rs
@@ -50,8 +50,6 @@ pub use renderer::WebRendererSpec;
 pub use util::Resolution;
 pub use util::TypeError;
 
-use self::util::Framerate;
-
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct ComponentId(Arc<str>);
 
@@ -68,19 +66,6 @@ pub struct InputId(Arc<str>);
 pub struct OutputScene {
     pub output_id: OutputId,
     pub root: Component,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
-pub struct InitOptions {
-    pub framerate: Framerate,
-    pub stream_fallback_timeout_ms: Option<f64>,
-    pub web_renderer: Option<WebRendererOptions>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
-pub struct WebRendererOptions {
-    pub init: Option<bool>,
-    pub disable_gpu: Option<bool>,
 }
 
 impl Display for InputId {

--- a/src/types/convert.rs
+++ b/src/types/convert.rs
@@ -1,7 +1,4 @@
-use std::time::Duration;
-
-use compositor_pipeline::pipeline;
-use compositor_render::{scene, web_renderer};
+use compositor_render::scene;
 
 use crate::api::{self, UpdateScene};
 
@@ -76,31 +73,6 @@ impl TryFrom<OutputScene> for compositor_pipeline::pipeline::OutputScene {
             output_id: scene.output_id.into(),
             root: scene.root.try_into()?,
         })
-    }
-}
-
-impl TryFrom<InitOptions> for pipeline::Options {
-    type Error = TypeError;
-    fn try_from(opts: InitOptions) -> Result<Self, Self::Error> {
-        let result = Self {
-            framerate: opts.framerate.try_into()?,
-            stream_fallback_timeout: Duration::from_millis(
-                opts.stream_fallback_timeout_ms.unwrap_or(1000.0) as u64,
-            ),
-            web_renderer: web_renderer::WebRendererInitOptions {
-                init: opts
-                    .web_renderer
-                    .as_ref()
-                    .and_then(|r| r.init)
-                    .unwrap_or(true),
-                disable_gpu: opts
-                    .web_renderer
-                    .as_ref()
-                    .and_then(|r| r.disable_gpu)
-                    .unwrap_or(false),
-            },
-        };
-        Ok(result)
     }
 }
 


### PR DESCRIPTION
Switch to env base config


### Why envs

Why not init request:
- some values need to be set before e.g. API PORT, so it requires using both methods of configuration
- it's very non-standard config method, even if it was the best option it could be perceived as hack.

Why not config files:
- hard to work with in prod environment, to add config inside k8s or any other container-based platform you would need to: create some volume entity from that file, attach/mount that volume to the container, and pass some env that defines the path where compositor should look for the file. 
- hard to work with in a dev environment. To tests some other configuration you need to modify a file. If we want to persist the config we can always use `.env` file. 
