### PR TITLE
Disable web renderer in non-web examples

### DIFF
--- a/examples/image.rs
+++ b/examples/image.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use log::{error, info};
 use serde_json::json;
 use std::{
+    env,
     path::PathBuf,
     process::{Command, Stdio},
     thread,
@@ -20,6 +21,7 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 };
 
 fn main() {
+    env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
     ffmpeg_next::format::network::init();
     logger::init_logger();
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -22,6 +22,7 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 };
 
 fn main() {
+    env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
     ffmpeg_next::format::network::init();
     logger::init_logger();
 

--- a/examples/test_pattern.rs
+++ b/examples/test_pattern.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use log::{error, info};
 use serde_json::json;
 use std::{
+    env,
     process::{Command, Stdio},
     thread,
     time::Duration,
@@ -19,6 +20,7 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 };
 
 fn main() {
+    env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
     ffmpeg_next::format::network::init();
     logger::init_logger();
 

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use log::{error, info};
 use serde_json::json;
 use std::{
+    env,
     process::{Command, Stdio},
     thread,
     time::Duration,
@@ -19,6 +20,7 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 };
 
 fn main() {
+    env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
     ffmpeg_next::format::network::init();
     logger::init_logger();
 

--- a/examples/tiles.rs
+++ b/examples/tiles.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use log::{error, info};
 use serde_json::json;
 use std::{
+    env,
     process::{Command, Stdio},
     thread,
     time::Duration,
@@ -19,6 +20,7 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 };
 
 fn main() {
+    env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
     ffmpeg_next::format::network::init();
     logger::init_logger();
 

--- a/examples/transition.rs
+++ b/examples/transition.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use log::{error, info};
 use serde_json::json;
 use std::{
+    env,
     process::{Command, Stdio},
     thread,
     time::Duration,
@@ -19,6 +20,7 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 };
 
 fn main() {
+    env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
     ffmpeg_next::format::network::init();
     logger::init_logger();
 


### PR DESCRIPTION
In every example we either need to set LIVE_COMPOSITOR_WEB_RENDERER_ENABLE to 0 or run `compositor_chromium::cef::bundle_for_development`

I decided to disable it everywhere except `web_view` example. Note that those examples are still building compositor with `web_renderer` feature enabled it's just not initialized in runtime.