### PR TITLE
Fix `XDG_RUNTIME_DIR` env error in Docker

### DIFF
--- a/build-tools/docker/full.Dockerfile
+++ b/build-tools/docker/full.Dockerfile
@@ -37,7 +37,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=compute,graphics,utility
 ENV MEMBRANE_VIDEO_COMPOSITOR_MAIN_EXECUTABLE_PATH=/home/$USERNAME/video_compositor/main_process
 ENV MEMBRANE_VIDEO_COMPOSITOR_PROCESS_HELPER_PATH=/home/$USERNAME/video_compositor/process_helper
 ENV LD_LIBRARY_PATH=/home/$USERNAME/video_compositor/lib
-ENV XDG_RUNTIME_DIR=/tmp
+ENV XDG_RUNTIME_DIR=/home/$USERNAME
 
 RUN apt-get update -y -qq && \
   apt-get install -y \

--- a/build-tools/docker/full.Dockerfile
+++ b/build-tools/docker/full.Dockerfile
@@ -37,7 +37,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=compute,graphics,utility
 ENV MEMBRANE_VIDEO_COMPOSITOR_MAIN_EXECUTABLE_PATH=/home/$USERNAME/video_compositor/main_process
 ENV MEMBRANE_VIDEO_COMPOSITOR_PROCESS_HELPER_PATH=/home/$USERNAME/video_compositor/process_helper
 ENV LD_LIBRARY_PATH=/home/$USERNAME/video_compositor/lib
-ENV XDG_RUNTIME_DIR=/home/$USERNAME
+ENV XDG_RUNTIME_DIR=/home/$USERNAME/video_compositor/xdg_runtime
 
 RUN apt-get update -y -qq && \
   apt-get install -y \
@@ -49,6 +49,7 @@ RUN useradd -ms /bin/bash $USERNAME && adduser $USERNAME sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER $USERNAME
 RUN mkdir -p /home/$USERNAME/video_compositor
+RUN mkdir -p /home/$USERNAME/video_compositor/xdg_runtime
 WORKDIR /home/$USERNAME/video_compositor
 
 COPY --from=builder --chown=$USERNAME:$USERNAME /root/project/target/release/main_process /home/$USERNAME/video_compositor/main_process


### PR DESCRIPTION
```
Unable to set up transient service directory: XDG_RUNTIME_DIR "/tmp" is owned by uid 0, not our uid 1001
```