### PR TITLE
Fix interpolation abstraction for non linear transitions

### DIFF
--- a/compositor_render/src/scene.rs
+++ b/compositor_render/src/scene.rs
@@ -32,6 +32,7 @@ mod scene_state;
 mod shader_component;
 mod text_component;
 mod tiles_component;
+mod transition;
 mod types;
 mod validation;
 mod view_component;

--- a/compositor_render/src/scene/components/interpolation.rs
+++ b/compositor_render/src/scene/components/interpolation.rs
@@ -1,4 +1,4 @@
-use crate::scene::interpolation::{ContinuousValue, InterpolationState};
+use crate::scene::types::interpolation::{ContinuousValue, InterpolationState};
 
 use super::{AbsolutePosition, Position};
 

--- a/compositor_render/src/scene/rescaler_component.rs
+++ b/compositor_render/src/scene/rescaler_component.rs
@@ -99,7 +99,7 @@ impl RescalerComponent {
         // TODO: to handle cases like transition from top to bottom this view needs
         // to be further processed to use the same type of coordinates as end
         let start = previous_state.map(|state| state.transition_snapshot(ctx.last_render_pts));
-        let transition = TransitionState::from_previous_transition(
+        let transition = TransitionState::new(
             self.transition.map(|transition| TransitionOptions {
                 duration: transition.duration,
                 interpolation_kind: super::InterpolationKind::Linear,

--- a/compositor_render/src/scene/rescaler_component/interpolation.rs
+++ b/compositor_render/src/scene/rescaler_component/interpolation.rs
@@ -1,4 +1,4 @@
-use crate::scene::interpolation::{ContinuousValue, InterpolationState};
+use crate::scene::types::interpolation::{ContinuousValue, InterpolationState};
 
 use super::RescalerComponentParam;
 

--- a/compositor_render/src/scene/tiles_component.rs
+++ b/compositor_render/src/scene/tiles_component.rs
@@ -131,7 +131,7 @@ impl TilesComponent {
             });
 
         let start = previous_state.and_then(|state| state.last_layout.clone());
-        let transition = TransitionState::from_previous_transition(
+        let transition = TransitionState::new(
             self.transition.map(|transition| TransitionOptions {
                 duration: transition.duration,
                 interpolation_kind: super::InterpolationKind::Linear,

--- a/compositor_render/src/scene/tiles_component.rs
+++ b/compositor_render/src/scene/tiles_component.rs
@@ -1,4 +1,4 @@
-use std::{ops::Add, time::Duration};
+use std::time::Duration;
 
 use crate::transformations::layout::NestedLayout;
 
@@ -8,11 +8,12 @@ use self::{
 };
 
 use super::{
-    interpolation::{ContinuousValue, InterpolationState},
     layout::StatefulLayoutComponent,
     scene_state::BuildStateTreeCtx,
+    transition::{TransitionOptions, TransitionState},
+    types::interpolation::ContinuousValue,
     Component, ComponentId, HorizontalAlign, IntermediateNode, Position, RGBAColor, SceneError,
-    Size, StatefulComponent, TilesComponent, Transition, VerticalAlign,
+    Size, StatefulComponent, TilesComponent, VerticalAlign,
 };
 
 mod interpolation;
@@ -29,8 +30,7 @@ pub(super) struct StatefulTilesComponent {
     /// `start` value after scene update.
     last_layout: Option<(Vec<Option<Tile>>, Size)>,
 
-    transition: Option<Transition>,
-    start_pts: Duration,
+    transition: Option<TransitionState>,
 
     component: TilesComponentParams,
     children: Vec<StatefulComponent>,
@@ -58,25 +58,12 @@ impl StatefulTilesComponent {
 
     fn tiles(&self, size: Size, pts: Duration) -> Vec<Option<Tile>> {
         let end = self.component.tiles(size, &self.children);
-        let (Some((start, start_size)), Some(transition)) = (&self.start, self.transition) else {
+        let (Some((start, start_size)), Some(transition)) = (&self.start, &self.transition) else {
             return end.clone();
         };
         let start = resize_tiles(start, start_size, &size);
-        let interpolation_progress = InterpolationState(f64::min(
-            1.0,
-            (pts.as_secs_f64() - self.start_pts.as_secs_f64()) / transition.duration.as_secs_f64(),
-        ));
+        let interpolation_progress = transition.state(pts);
         ContinuousValue::interpolate(&start, &end, interpolation_progress)
-    }
-
-    fn remaining_transition_duration(&self, pts: Duration) -> Option<Duration> {
-        self.transition.and_then(|transition| {
-            if self.start_pts + transition.duration > pts {
-                self.start_pts.add(transition.duration).checked_sub(pts)
-            } else {
-                None
-            }
-        })
     }
 
     pub(super) fn position(&self, _pts: Duration) -> Position {
@@ -144,17 +131,14 @@ impl TilesComponent {
             });
 
         let start = previous_state.and_then(|state| state.last_layout.clone());
-        // TODO: this is incorrect for non linear transformations
-        let transition = self.transition.or_else(|| {
-            let Some(previous_state) = previous_state else {
-                return None;
-            };
-            let Some(duration) = previous_state.remaining_transition_duration(ctx.last_render_pts)
-            else {
-                return None;
-            };
-            previous_state.transition.map(|_| Transition { duration })
-        });
+        let transition = TransitionState::from_previous_transition(
+            self.transition.map(|transition| TransitionOptions {
+                duration: transition.duration,
+                interpolation_kind: super::InterpolationKind::Linear,
+            }),
+            previous_state.and_then(|s| s.transition.clone()),
+            ctx.last_render_pts,
+        );
 
         let tiles = StatefulTilesComponent {
             start,
@@ -171,7 +155,6 @@ impl TilesComponent {
                 vertical_align: self.vertical_align,
             },
             transition,
-            start_pts: ctx.last_render_pts,
             children: self
                 .children
                 .into_iter()

--- a/compositor_render/src/scene/tiles_component/interpolation.rs
+++ b/compositor_render/src/scene/tiles_component/interpolation.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::scene::{
-    interpolation::{ContinuousValue, InterpolationState},
+    types::interpolation::{ContinuousValue, InterpolationState},
     ComponentId,
 };
 

--- a/compositor_render/src/scene/transition.rs
+++ b/compositor_render/src/scene/transition.rs
@@ -31,7 +31,7 @@ pub(super) struct TransitionOptions {
 }
 
 impl TransitionState {
-    pub fn from_previous_transition(
+    pub fn new(
         current_transition: Option<TransitionOptions>,
         previous_transition: Option<TransitionState>,
         last_pts: Duration,

--- a/compositor_render/src/scene/transition.rs
+++ b/compositor_render/src/scene/transition.rs
@@ -1,0 +1,96 @@
+use std::time::Duration;
+
+use super::{types::interpolation::InterpolationState, InterpolationKind};
+
+/// Similar concept to InterpolationState, but it represents a time instead.
+/// Values between 0 and 1 represent transition and larger than 1 post transition.
+///
+/// If interpolation_kind is linear then InterpolationState and TransitionProgress
+/// have the same numerical value.
+#[derive(Debug, Clone, Copy)]
+struct TransitionProgress(f64);
+
+#[derive(Debug, Clone)]
+pub(super) struct TransitionState {
+    /// Additional offset for transition. It is non zero if you want to start
+    /// a transition in the middle of the interpolation curve.
+    initial_offset: (TransitionProgress, InterpolationState),
+
+    // PTS of a first frame of transition.
+    start_pts: Duration,
+
+    /// Duration of the transition.
+    duration: Duration,
+
+    interpolation_kind: InterpolationKind,
+}
+
+pub(super) struct TransitionOptions {
+    pub duration: Duration,
+    pub interpolation_kind: InterpolationKind,
+}
+
+impl TransitionState {
+    pub fn from_previous_transition(
+        current_transition: Option<TransitionOptions>,
+        previous_transition: Option<TransitionState>,
+        last_pts: Duration,
+    ) -> Option<Self> {
+        let previous_transition = previous_transition.and_then(|transition| {
+            if transition.start_pts + transition.duration < last_pts {
+                return None;
+            }
+            Some(transition)
+        });
+        match (current_transition, previous_transition) {
+            (None, None) => None,
+            (None, Some(previous_transition)) => {
+                let remaining_duration = (previous_transition.start_pts
+                    + previous_transition.duration)
+                    .saturating_sub(last_pts);
+                let progress_offset = TransitionProgress(
+                    1.0 - (remaining_duration.as_secs_f64()
+                        / previous_transition.duration.as_secs_f64()),
+                );
+                let state_offset = previous_transition
+                    .interpolation_kind
+                    .state(progress_offset.0);
+                Some(Self {
+                    initial_offset: (progress_offset, state_offset),
+                    start_pts: last_pts,
+                    duration: remaining_duration,
+                    interpolation_kind: previous_transition.interpolation_kind,
+                })
+            }
+            (Some(current_transition), _) => Some(Self {
+                initial_offset: (TransitionProgress(0.0), InterpolationState(0.0)),
+                start_pts: last_pts,
+                duration: current_transition.duration,
+                interpolation_kind: current_transition.interpolation_kind,
+            }),
+        }
+    }
+
+    pub fn state(&self, pts: Duration) -> InterpolationState {
+        // Value in range [0, 1], where 1 means end of transition.
+        let progress =
+            (pts.as_secs_f64() - self.start_pts.as_secs_f64()) / self.duration.as_secs_f64();
+        // Value in range [initial_offset.0 , 1]. Previous progress ([0, 1]) is rescaled to fit
+        // smaller ranger and offset is added.
+        let progress = self.initial_offset.0 .0 + progress * (1.0 - self.initial_offset.0 .0);
+        // Clamp just to handle a case where this function is called after transition is finished.
+        let progress = f64::clamp(progress, 0.0, 1.0);
+        // Value in range [initial_offset.1, 1] or [state(initial_offset.0), 1].
+        let state = self.interpolation_kind.state(progress);
+        // Value in range [0, 1].
+        InterpolationState((state.0 - self.initial_offset.1 .0) / (1.0 - self.initial_offset.1 .0))
+    }
+}
+
+impl InterpolationKind {
+    fn state(&self, t: f64) -> InterpolationState {
+        match self {
+            InterpolationKind::Linear => InterpolationState(t),
+        }
+    }
+}

--- a/compositor_render/src/scene/types.rs
+++ b/compositor_render/src/scene/types.rs
@@ -67,3 +67,8 @@ pub enum HorizontalPosition {
     LeftOffset(f32),
     RightOffset(f32),
 }
+
+#[derive(Debug, Clone, Copy)]
+pub enum InterpolationKind {
+    Linear,
+}

--- a/compositor_render/src/scene/view_component.rs
+++ b/compositor_render/src/scene/view_component.rs
@@ -103,7 +103,7 @@ impl ViewComponent {
         // TODO: to handle cases like transition from top to bottom this view needs
         // to be further processed to use the same type of coordinates as end
         let start = previous_state.map(|state| state.view(ctx.last_render_pts));
-        let transition = TransitionState::from_previous_transition(
+        let transition = TransitionState::new(
             self.transition.map(|transition| TransitionOptions {
                 duration: transition.duration,
                 interpolation_kind: super::InterpolationKind::Linear,

--- a/compositor_render/src/scene/view_component.rs
+++ b/compositor_render/src/scene/view_component.rs
@@ -1,14 +1,15 @@
-use std::{ops::Add, time::Duration};
+use std::time::Duration;
 
 use crate::{scene::ViewChildrenDirection, transformations::layout::NestedLayout};
 
 use super::{
     components::ViewComponent,
-    interpolation::{ContinuousValue, InterpolationState},
     layout::StatefulLayoutComponent,
     scene_state::BuildStateTreeCtx,
+    transition::{TransitionOptions, TransitionState},
+    types::interpolation::ContinuousValue,
     Component, ComponentId, IntermediateNode, Overflow, Position, RGBAColor, SceneError, Size,
-    StatefulComponent, Transition,
+    StatefulComponent,
 };
 
 mod interpolation;
@@ -18,9 +19,8 @@ mod layout;
 pub(super) struct StatefulViewComponent {
     start: Option<ViewComponentParam>,
     end: ViewComponentParam,
-    transition: Option<Transition>,
+    transition: Option<TransitionState>,
     children: Vec<StatefulComponent>,
-    start_pts: Duration,
 }
 
 #[derive(Debug, Clone)]
@@ -36,24 +36,11 @@ struct ViewComponentParam {
 
 impl StatefulViewComponent {
     fn view(&self, pts: Duration) -> ViewComponentParam {
-        let (Some(transition), Some(start)) = (self.transition, &self.start) else {
+        let (Some(transition), Some(start)) = (&self.transition, &self.start) else {
             return self.end.clone();
         };
-        let interpolation_progress = InterpolationState(f64::min(
-            1.0,
-            (pts.as_secs_f64() - self.start_pts.as_secs_f64()) / transition.duration.as_secs_f64(),
-        ));
+        let interpolation_progress = transition.state(pts);
         ContinuousValue::interpolate(start, &self.end, interpolation_progress)
-    }
-
-    fn remaining_transition_duration(&self, pts: Duration) -> Option<Duration> {
-        self.transition.and_then(|transition| {
-            if self.start_pts + transition.duration > pts {
-                self.start_pts.add(transition.duration).checked_sub(pts)
-            } else {
-                None
-            }
-        })
     }
 
     pub(super) fn children(&self) -> Vec<&StatefulComponent> {
@@ -92,7 +79,8 @@ impl StatefulViewComponent {
     }
 
     pub(super) fn layout(&mut self, size: Size, pts: Duration) -> NestedLayout {
-        self.view(pts).layout(size, &mut self.children, pts)
+        let view = self.view(pts);
+        view.layout(size, &mut self.children, pts)
     }
 }
 
@@ -115,17 +103,14 @@ impl ViewComponent {
         // TODO: to handle cases like transition from top to bottom this view needs
         // to be further processed to use the same type of coordinates as end
         let start = previous_state.map(|state| state.view(ctx.last_render_pts));
-        // TODO: this is incorrect for non linear transformations
-        let transition = self.transition.or_else(|| {
-            let Some(previous_state) = previous_state else {
-                return None;
-            };
-            let Some(duration) = previous_state.remaining_transition_duration(ctx.last_render_pts)
-            else {
-                return None;
-            };
-            previous_state.transition.map(|_| Transition { duration })
-        });
+        let transition = TransitionState::from_previous_transition(
+            self.transition.map(|transition| TransitionOptions {
+                duration: transition.duration,
+                interpolation_kind: super::InterpolationKind::Linear,
+            }),
+            previous_state.and_then(|s| s.transition.clone()),
+            ctx.last_render_pts,
+        );
         let view = StatefulViewComponent {
             start,
             end: ViewComponentParam {
@@ -141,7 +126,6 @@ impl ViewComponent {
                 .into_iter()
                 .map(|c| Component::stateful_component(c, ctx))
                 .collect::<Result<_, _>>()?,
-            start_pts: ctx.last_render_pts,
         };
         Ok(StatefulComponent::Layout(StatefulLayoutComponent::View(
             view,

--- a/compositor_render/src/scene/view_component/interpolation.rs
+++ b/compositor_render/src/scene/view_component/interpolation.rs
@@ -1,4 +1,4 @@
-use crate::scene::interpolation::{ContinuousValue, InterpolationState};
+use crate::scene::types::interpolation::{ContinuousValue, InterpolationState};
 
 use super::ViewComponentParam;
 


### PR DESCRIPTION
- Remove duplicated code around transitions (and recover old transitions)
- Add type that represents interpolation type
- Fix calculation when recovering the transition state from the previous state. Old implementation worked only for linear transitions.

I started implementing transition based on cubic bezier curve, but it appears to be more complicated than I expected so I left it for now with just linear.