### PR TITLE
[in-progress] Add `flake.nix` and describe dependencies.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1705403940,
+        "narHash": "sha256-bl7E3w35Bleiexg01WsN0RuAQEL23HaQeNBC2zjt+9w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f0326542989e1bdac955ad6269b334a8da4b0c95",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,11 @@
+{ outputs = { self, nixpkgs }: let
+  arch = "x86_64-linux";
+  pkgs = import nixpkgs { system = arch; };
+  in with pkgs; {
+    packages.${arch}.default = cargo;
+    devShells.${arch}.default = mkShell {
+      env.LIBCLANG_PATH = "${libclang.lib}/lib";
+      buildInputs = with pkgs; [ pkg-config openssl ffmpeg libclang.lib ];
+      packages = [ cargo ]; };
+  };
+}


### PR DESCRIPTION
Hello! I'm amazed by how simple you're making media processing for an old web-app coder like me. You all are my heroes.

I'm exploring your library more and more, using https://base.bingo/code/channel as a base.
You can see in there that I include a `flake.nix` - this helps me manage all the app's dependencies securely.
The `nix develop` command in the README prepares a local shell that includes all the dependencies I need;
and the codebase is able to play a Daft Punk mp3, streamed from archive.org .

Since I am really eager to upgrade my video streaming process,
I searched and came across the video compositor plugin.
Someday, this could help me surpass some of the clunkiness of streaming in OBS.

Problem is, the nix package manager and NixOS are super picky about how binaries can link dynamic libraries.
This helps Nix be reliable and secure, and also means the video compositor is unable to run as a precompiled binary.
In my `channel` codebase^ I handled a similar issue for the `portaudio` library;
I added `portaudio` to `flake.nix`, and applied an option to disable the precompiled download:

```
# config/config.exs
import Config
config :bundlex, :disable_precompiled_os_deps, apps: [:membrane_portaudio_plugin]
```

I need a similar option included in the `membrane_video_compositor_plugin` package,
and a means of compiling the `video_compositor` binary from scratch inside the Nix package manager.

So! Here's the idea to package up `videocompositor` as a nix package,
so I can pass on the precompiled download.
You can copy my lead once you acquire Nix: https://nixos.org/download

---
To begin, I made a simple `flake.nix` to compile the package.
You can open up a shell that includes necessary dependencies, using:

```shell
# copy the codebase
git clone https://github.com/membraneframework/video_compositor
cd video_compositor

# pull assembleco's `flake.nix` and `flake.lock`
git remote add assembleco https://github.com/assembleco/video_compositor
git fetch assembleco
git diff HEAD assembleco/nix
git checkout assembleco/nix -b nix

# load a local shell using `nix`, dependencies included
sudo echo "extra-experimental-features = flakes nix-command" >> /etc/nix/nix.conf
nix develop
```

Once you're in the shell, the command to build the binary is:
```shell
rm -rf target; clear; # clean up old builds
cargo run --bin package_for_release
```

Here my progress has been blocked; I am seeing a couple build errors:

```
  --- stderr
  In file included from /nix/store/68qbq5jzwljpl0w6i1qj2l66k129l0ii-glibc-2.38-27-dev/include/bits/libc-header-start.h:33,
                   from /nix/store/68qbq5jzwljpl0w6i1qj2l66k129l0ii-glibc-2.38-27-dev/include/stdio.h:27,
                   from check.c:2:
  /nix/store/68qbq5jzwljpl0w6i1qj2l66k129l0ii-glibc-2.38-27-dev/include/features.h:414:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
    414 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
        |    ^~~~~~~
  /nix/store/0sfprc9ras3nv0ycl438bdlp2ppqi79r-ffmpeg-6.1-dev/include/libavutil/samplefmt.h:22:10: fatal error: 'stdint.h' file not found
  thread 'main' panicked at /home/calliope/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ffmpeg-sys-next-6.1.0/build.rs:1291:10:
  Unable to generate bindings: ClangDiagnostic("/nix/store/0sfprc9ras3nv0ycl438bdlp2ppqi79r-ffmpeg-6.1-dev/include/libavutil/samplefmt.h:22:10: fatal error: 'stdint.h' file not found\n")
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...

# ...

  --- stderr
  /home/calliope/base/code/video_compositor/target/debug/build/chromium_sys-faa796c8bf06a6d6/out/cef_root/include/capi/cef_base_capi.h:33:10: fatal error: 'stdint.h' file not found
  Error: clang diagnosed error: /home/calliope/base/code/video_compositor/target/debug/build/chromium_sys-faa796c8bf06a6d6/out/cef_root/include/capi/cef_base_capi.h:33:10: fatal error: 'stdint.h' file not found
```

I'm going to ask around some experienced Nix users and see if anyone has a simple repair -
if you can help guess any missing libraries, go ahead and add them to `buildInputs` in `flake.nix`;
you can look up all the Nix packages on https://search.nixos.org .

Aside from the packages that are included in `flake.nix`, I had no luck including any of:

* `glibc`, `glibc.dev`, `glibc.static`
* `libcxx`, `libcxx.dev`, `libstdcxx5`

The error barely changes when I included `libav` (marked as an insecure package),
and the build seems happier using the `libav` copy already included inside `ffmpeg`.

---

A nix build is a key phase in packaging your code for cloud and embedded users;
this recipe ensures that `video_compositor` has a proper build process on any machine.