### PR TITLE
Add option to force GPU rendering

### DIFF
--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -79,6 +79,7 @@ pub struct Options {
     pub framerate: Framerate,
     pub stream_fallback_timeout: Duration,
     pub web_renderer: WebRendererInitOptions,
+    pub force_gpu: bool,
 }
 
 impl Pipeline {
@@ -87,6 +88,7 @@ impl Pipeline {
             web_renderer: opts.web_renderer,
             framerate: opts.framerate,
             stream_fallback_timeout: opts.stream_fallback_timeout,
+            force_gpu: opts.force_gpu,
         })?;
         let pipeline = Pipeline {
             outputs: OutputRegistry::new(),

--- a/compositor_pipeline/src/pipeline/output/rtp.rs
+++ b/compositor_pipeline/src/pipeline/output/rtp.rs
@@ -1,5 +1,5 @@
 use compositor_render::OutputId;
-use log::error;
+use log::{debug, error};
 use std::sync::Arc;
 
 use rand::Rng;
@@ -115,7 +115,7 @@ impl RtpSender {
             };
 
             if let Err(err) = context.socket.send(&packet) {
-                error!("Failed to send packet: {err}");
+                debug!("Failed to send packet: {err}");
             }
 
             context.next_sequence_number = context.next_sequence_number.wrapping_add(1);

--- a/compositor_render/src/state.rs
+++ b/compositor_render/src/state.rs
@@ -38,6 +38,7 @@ pub struct RendererOptions {
     pub web_renderer: web_renderer::WebRendererInitOptions,
     pub framerate: Framerate,
     pub stream_fallback_timeout: Duration,
+    pub force_gpu: bool,
 }
 
 #[derive(Clone)]
@@ -150,7 +151,7 @@ impl Renderer {
 
 impl InnerRenderer {
     pub fn new(opts: RendererOptions) -> Result<Self, InitRendererEngineError> {
-        let wgpu_ctx = Arc::new(WgpuCtx::new()?);
+        let wgpu_ctx = Arc::new(WgpuCtx::new(opts.force_gpu)?);
 
         Ok(Self {
             wgpu_ctx: wgpu_ctx.clone(),

--- a/docs/pages/api/routes.md
+++ b/docs/pages/api/routes.md
@@ -36,7 +36,7 @@ type OutputScene = {
 
 ***
 
-### RegisterInputRequest
+### Register input stream
 
 ```typescript
 type RegisterInputStream = {

--- a/docs/pages/deployment/configuration.md
+++ b/docs/pages/deployment/configuration.md
@@ -10,6 +10,10 @@ API port. Defaults to 8001.
 
 Output framerate for all output streams. This value can be a number or string in the `NUM/DEN` format , where both `NUM` and `DEN` are unsigned integers.
 
+### `LIVE_COMPOSITOR_FORCE_GPU`
+
+If enabled, GPU will be required for rendering. If only CPU based adapters will be found then process will exit with an error. Defaults to `false`.
+
 ### `LIVE_COMPOSITOR_STREAM_FALLBACK_TIMEOUT_MS`
 
 A timeout that defines when the compositor should switch to fallback on the input stream that stopped sending frames.
@@ -19,6 +23,8 @@ A timeout that defines when the compositor should switch to fallback on the inpu
 Logger level. Value can be defined as `error`/`warn`/`info`/`debug`/`trace`.
 
 This value also supports syntax for more detailed configuration. See [`tracing-subscriber` crate documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax) for more info.
+
+Defaults to `info,wgpu_hal=warn,wgpu_core=warn`.
 
 ### `LIVE_COMPOSITOR_LOGGER_FORMAT`
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -88,12 +88,14 @@ impl Api {
             framerate,
             stream_fallback_timeout,
             web_renderer,
+            force_gpu,
             ..
         } = config();
         let (pipeline, event_loop) = Pipeline::new(pipeline::Options {
             framerate: *framerate,
             stream_fallback_timeout: *stream_fallback_timeout,
             web_renderer: *web_renderer,
+            force_gpu: *force_gpu,
         })?;
         Ok((Api { pipeline }, event_loop))
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub framerate: Framerate,
     pub stream_fallback_timeout: Duration,
     pub web_renderer: WebRendererInitOptions,
+    pub force_gpu: bool,
 }
 
 pub struct LoggerConfig {
@@ -64,7 +65,7 @@ fn read_config() -> Result<Config, &'static str> {
 
     let logger_level = match env::var("LIVE_COMPOSITOR_LOGGER_LEVEL") {
         Ok(level) => level,
-        Err(_) => "info".to_string(),
+        Err(_) => "info,wgpu_hal=warn,wgpu_core=warn".to_string(),
     };
 
     // When building in repo use compact logger
@@ -94,6 +95,11 @@ fn read_config() -> Result<Config, &'static str> {
         Err(_) => true,
     };
 
+    let force_gpu = match env::var("LIVE_COMPOSITOR_FORCE_GPU") {
+        Ok(enable) => bool_env_from_str(&enable).unwrap_or(false),
+        Err(_) => false,
+    };
+
     const DEFAULT_STREAM_FALLBACK_TIMEOUT: Duration = Duration::from_millis(2000);
     let stream_fallback_timeout = match env::var("LIVE_COMPOSITOR_STREAM_FALLBACK_TIMEOUT_MS") {
         Ok(timeout_ms) => match timeout_ms.parse::<f64>() {
@@ -115,6 +121,7 @@ fn read_config() -> Result<Config, &'static str> {
         },
         framerate,
         stream_fallback_timeout,
+        force_gpu,
         web_renderer: WebRendererInitOptions {
             enable: web_renderer_enable,
             enable_gpu: web_renderer_gpu_enable,

--- a/src/snapshot_tests/utils.rs
+++ b/src/snapshot_tests/utils.rs
@@ -61,6 +61,7 @@ pub(super) fn create_renderer(
             enable: false,
             enable_gpu: false,
         },
+        force_gpu: false,
         framerate: Framerate { num: 30, den: 1 },
         stream_fallback_timeout: Duration::from_secs(3),
     })


### PR DESCRIPTION
- Add `LIVE_COMPOSITOR_FORCE_GPU` env
- Improve logging defaults to avoid log spam
- Display useful info about available adpaters

It looks like M1 metal is detected as CPU, but given that this option is mostly useful for deployment purposes then I think it's still fine