### PR TITLE
Switch to macos-14 image for release build

### DIFF
--- a/.github/workflows/package_for_release.yml
+++ b/.github/workflows/package_for_release.yml
@@ -56,7 +56,7 @@ jobs:
                 path: video_compositor_with_web_renderer_darwin_x86_64.tar.gz
 
     macos-aarch64:
-        runs-on: macos-latest-xlarge
+        runs-on: macos-14
         steps:
             - name: 🛠 Install system dependencies
               run: brew install ffmpeg


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/