### PR TITLE
Add an option to create the `WgpuCtx` once and reuse it.

### DIFF
--- a/compositor_render/src/lib.rs
+++ b/compositor_render/src/lib.rs
@@ -18,6 +18,8 @@ pub use state::Renderer;
 pub use state::RendererOptions;
 pub use state::RendererSpec;
 
+pub use wgpu::use_global_wgpu_ctx;
+
 pub mod image {
     pub use crate::transformations::image_renderer::{ImageSource, ImageSpec, ImageType};
 }

--- a/compositor_render/src/state.rs
+++ b/compositor_render/src/state.rs
@@ -151,7 +151,7 @@ impl Renderer {
 
 impl InnerRenderer {
     pub fn new(opts: RendererOptions) -> Result<Self, InitRendererEngineError> {
-        let wgpu_ctx = Arc::new(WgpuCtx::new(opts.force_gpu)?);
+        let wgpu_ctx = WgpuCtx::new(opts.force_gpu)?;
 
         Ok(Self {
             wgpu_ctx: wgpu_ctx.clone(),

--- a/compositor_render/src/wgpu.rs
+++ b/compositor_render/src/wgpu.rs
@@ -6,6 +6,7 @@ pub(crate) mod format;
 pub(crate) mod texture;
 pub(crate) mod utils;
 
+pub use ctx::use_global_wgpu_ctx;
 pub(crate) use ctx::WgpuCtx;
 
 #[must_use]
@@ -30,7 +31,7 @@ impl WgpuErrorScope {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Clone)]
 pub enum CreateWgpuCtxError {
     #[error("Failed to get a wgpu adapter.")]
     NoAdapter,
@@ -42,7 +43,7 @@ pub enum CreateWgpuCtxError {
     WgpuError(#[from] WgpuError),
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Clone)]
 pub enum WgpuError {
     #[error("Wgpu validation error:\n{0}")]
     Validation(String),

--- a/src/bin/update_snapshots/main.rs
+++ b/src/bin/update_snapshots/main.rs
@@ -19,6 +19,7 @@ use crate::{
 
 fn main() {
     println!("Updating snapshots:");
+    compositor_render::use_global_wgpu_ctx();
 
     let tests: Vec<_> = snapshot_tests();
     let has_only_flag = tests.iter().any(|t| t.only);

--- a/src/snapshot_tests.rs
+++ b/src/snapshot_tests.rs
@@ -12,6 +12,8 @@ mod utils;
 
 #[test]
 fn test_snapshots() {
+    compositor_render::use_global_wgpu_ctx();
+
     let failed_snapshot_path = failed_snapshot_path();
     if failed_snapshot_path.exists() {
         fs::remove_dir_all(failed_snapshot_path).unwrap();


### PR DESCRIPTION
This allows us to create many hundreds of renderers in snapshot tests. It used to fail on NVIDIA drivers, and it works now.

closes #332 