### PR TITLE
Support per-output scene updates in renderer

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -58,6 +58,11 @@ jobs:
             - name: 📖 Check formatting
               run: cargo fmt --all --check
 
+            - name: 🛠 Cargo build
+              run: |
+                cargo build
+                cargo build --no-default-features
+
             - name: 📎 Run clippy
               run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 

--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -149,7 +149,8 @@ impl Pipeline {
 
         self.inputs.insert(input_id.clone(), pipeline_input.into());
 
-        self.queue.add_input(input_id);
+        self.queue.add_input(input_id.clone());
+        self.renderer.register_input(input_id);
         Ok(port)
     }
 
@@ -160,6 +161,7 @@ impl Pipeline {
 
         self.inputs.remove(input_id);
         self.queue.remove_input(input_id);
+        self.renderer.unregister_input(input_id);
         Ok(())
     }
 

--- a/compositor_render/src/state/node.rs
+++ b/compositor_render/src/state/node.rs
@@ -1,45 +1,41 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
+use std::vec;
 
 use crate::scene::{self, ShaderComponentParams};
 use crate::transformations::image_renderer::Image;
 use crate::transformations::layout::LayoutNode;
 use crate::transformations::shader::node::ShaderNode;
 use crate::transformations::shader::Shader;
-use crate::FallbackStrategy;
+use crate::InputId;
 
 use crate::transformations::text_renderer::TextRenderParams;
 use crate::transformations::web_renderer::WebRenderer;
 use crate::transformations::{
     image_renderer::ImageNode, text_renderer::TextRendererNode, web_renderer::node::WebRendererNode,
 };
-use crate::wgpu::texture::NodeTexture;
+use crate::wgpu::texture::{InputTexture, NodeTexture};
 
-use super::render_graph::NodeId;
 use super::RenderCtx;
 
-pub(crate) enum InnerRenderNode {
+pub(super) enum InnerRenderNode {
     Shader(ShaderNode),
     Web(WebRendererNode),
     Text(TextRendererNode),
     Image(ImageNode),
     Layout(LayoutNode),
-    InputStream,
+    InputStreamRef(InputId),
 }
 
 impl InnerRenderNode {
     pub fn render(
         &mut self,
         ctx: &mut RenderCtx,
-        sources: &[(&NodeId, &NodeTexture)],
+        sources: &[&NodeTexture],
         target: &mut NodeTexture,
         pts: Duration,
     ) {
-        if self.should_fallback(sources) {
-            target.clear();
-            return;
-        }
-
         match self {
             InnerRenderNode::Shader(ref shader) => {
                 shader.render(ctx.wgpu_ctx, sources, target, pts);
@@ -49,54 +45,66 @@ impl InnerRenderNode {
                 renderer.render(ctx, target);
             }
             InnerRenderNode::Image(ref node) => node.render(ctx, target, pts),
-            InnerRenderNode::InputStream => {
+            InnerRenderNode::InputStreamRef(_) => {
                 // Nothing to do, textures on input nodes should be populated
                 // at the start of render loop
             }
             InnerRenderNode::Layout(node) => node.render(ctx, sources, target, pts),
         }
     }
-
-    // TODO: move to FallbackStrategyExt
-    fn should_fallback(&self, sources: &[(&NodeId, &NodeTexture)]) -> bool {
-        if sources.is_empty() {
-            return false;
-        }
-
-        match self.fallback_strategy() {
-            FallbackStrategy::NeverFallback => false,
-            FallbackStrategy::FallbackIfAllInputsMissing => sources
-                .iter()
-                .all(|(_, node_texture)| node_texture.is_empty()),
-            FallbackStrategy::FallbackIfAnyInputMissing => sources
-                .iter()
-                .any(|(_, node_texture)| node_texture.is_empty()),
-        }
-    }
-
-    fn fallback_strategy(&self) -> FallbackStrategy {
-        match self {
-            InnerRenderNode::Shader(shader_node) => shader_node.fallback_strategy(),
-            InnerRenderNode::Web(web_renderer_node) => web_renderer_node.fallback_strategy(),
-            InnerRenderNode::Text(_) => FallbackStrategy::NeverFallback,
-            InnerRenderNode::Image(_) => FallbackStrategy::NeverFallback,
-            InnerRenderNode::InputStream => FallbackStrategy::NeverFallback,
-            InnerRenderNode::Layout(_) => FallbackStrategy::NeverFallback,
-        }
-    }
 }
 
-pub struct RenderNode {
-    pub(crate) output: NodeTexture,
-    pub(crate) inputs: Vec<NodeId>,
-    pub(crate) fallback: Option<NodeId>,
-    pub(crate) renderer: InnerRenderNode,
+pub(super) struct RenderNode {
+    pub(super) output: NodeTexture,
+    pub(super) renderer: InnerRenderNode,
+    pub(super) children: Vec<RenderNode>,
 }
 
 impl RenderNode {
-    pub(super) fn new_shader_node(
+    pub(super) fn new(
         ctx: &RenderCtx,
-        inputs: Vec<NodeId>,
+        params: scene::NodeParams,
+        children: Vec<RenderNode>,
+    ) -> Self {
+        match params {
+            scene::NodeParams::InputStream(id) => Self {
+                output: NodeTexture::new(),
+                renderer: InnerRenderNode::InputStreamRef(id),
+                children,
+            },
+            scene::NodeParams::Shader(shader_params, shader) => {
+                Self::new_shader_node(ctx, children, shader_params, shader)
+            }
+            scene::NodeParams::Web(web_renderer) => {
+                Self::new_web_renderer_node(ctx, children, web_renderer)
+            }
+            scene::NodeParams::Image(image) => Self::new_image_node(image),
+            scene::NodeParams::Text(text_params) => Self::new_text_node(text_params),
+            scene::NodeParams::Layout(layout_provider) => {
+                Self::new_layout_node(ctx, children, layout_provider)
+            }
+        }
+    }
+
+    /// Helper to access real texture backing up specific node. For all nodes this is
+    /// equivalent of accessing output field, but in case of InputStreamRef `output` field
+    /// is just a stub that does not do anything.
+    pub(super) fn output_texture<'a>(
+        &'a self,
+        inputs: &'a HashMap<InputId, (NodeTexture, InputTexture)>,
+    ) -> &'a NodeTexture {
+        match &self.renderer {
+            InnerRenderNode::InputStreamRef(id) => inputs
+                .get(id)
+                .map(|(node_texture, _)| node_texture)
+                .unwrap_or(&self.output),
+            _non_input_stream => &self.output,
+        }
+    }
+
+    fn new_shader_node(
+        ctx: &RenderCtx,
+        children: Vec<RenderNode>,
         shader_params: ShaderComponentParams,
         shader: Arc<Shader>,
     ) -> Self {
@@ -111,15 +119,14 @@ impl RenderNode {
 
         Self {
             renderer: node,
-            inputs,
-            fallback: None,
             output,
+            children,
         }
     }
 
     pub(super) fn new_web_renderer_node(
         ctx: &RenderCtx,
-        inputs: Vec<NodeId>,
+        children: Vec<RenderNode>,
         web_renderer: Arc<WebRenderer>,
     ) -> Self {
         let resolution = web_renderer.resolution();
@@ -129,9 +136,8 @@ impl RenderNode {
 
         Self {
             renderer: node,
-            inputs,
-            fallback: None,
             output,
+            children,
         }
     }
 
@@ -141,9 +147,8 @@ impl RenderNode {
 
         Self {
             renderer: node,
-            inputs: vec![],
-            fallback: None,
             output,
+            children: vec![],
         }
     }
 
@@ -153,15 +158,14 @@ impl RenderNode {
 
         Self {
             renderer: node,
-            inputs: vec![],
-            fallback: None,
             output,
+            children: vec![],
         }
     }
 
     pub(super) fn new_layout_node(
         ctx: &RenderCtx,
-        inputs: Vec<NodeId>,
+        children: Vec<RenderNode>,
         provider: scene::LayoutNode,
     ) -> Self {
         let node = InnerRenderNode::Layout(LayoutNode::new(ctx, Box::new(provider)));
@@ -169,20 +173,8 @@ impl RenderNode {
 
         Self {
             renderer: node,
-            inputs,
-            fallback: None,
             output,
-        }
-    }
-
-    pub(crate) fn new_input() -> Self {
-        let output = NodeTexture::new();
-
-        Self {
-            renderer: InnerRenderNode::InputStream,
-            inputs: vec![],
-            fallback: None,
-            output,
+            children,
         }
     }
 }

--- a/compositor_render/src/state/render_graph.rs
+++ b/compositor_render/src/state/render_graph.rs
@@ -1,230 +1,71 @@
 use std::collections::HashMap;
-use std::fmt::Display;
-
-use log::error;
 
 use crate::scene::{self, OutputNode};
-use crate::wgpu::texture::{InputTexture, OutputTexture};
+use crate::wgpu::texture::{InputTexture, NodeTexture, OutputTexture};
 use crate::{error::UpdateSceneError, wgpu::WgpuErrorScope};
 use crate::{InputId, OutputId};
 
-use super::NodeRenderPass;
 use super::{node::RenderNode, RenderCtx};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct NodeId(pub usize);
-
-impl Display for NodeId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
+pub(super) struct RenderGraph {
+    pub(super) outputs: HashMap<OutputId, OutputRenderTree>,
+    pub(super) inputs: HashMap<InputId, (NodeTexture, InputTexture)>,
 }
 
-pub struct RenderGraph {
-    pub nodes: RenderNodesSet,
-    pub outputs: HashMap<OutputId, (NodeId, OutputTexture)>,
-    pub inputs: HashMap<InputId, (NodeId, InputTexture)>,
-}
-
-#[derive(Debug)]
-struct NodeIdProvider(NodeId);
-
-impl NodeIdProvider {
-    fn new() -> Self {
-        Self(NodeId(0))
-    }
-
-    fn next(&mut self) -> NodeId {
-        self.0 = NodeId(self.0 .0 + 1);
-        self.0
-    }
+pub(super) struct OutputRenderTree {
+    pub(super) root: RenderNode,
+    pub(super) output_texture: OutputTexture,
 }
 
 impl RenderGraph {
     pub fn empty() -> Self {
         Self {
-            nodes: RenderNodesSet::new(),
             outputs: HashMap::new(),
             inputs: HashMap::new(),
         }
     }
 
-    pub(crate) fn update(
+    pub(super) fn register_input(&mut self, input_id: InputId) {
+        self.inputs
+            .insert(input_id, (NodeTexture::new(), InputTexture::new()));
+    }
+
+    pub(super) fn unregister_input(&mut self, input_id: &InputId) {
+        self.inputs.remove(input_id);
+    }
+
+    pub(super) fn unregister_output(&mut self, output_id: &OutputId) {
+        self.outputs.remove(output_id);
+    }
+
+    pub(super) fn update(
         &mut self,
         ctx: &RenderCtx,
-        output_nodes: Vec<OutputNode>,
+        output: OutputNode,
     ) -> Result<(), UpdateSceneError> {
         // TODO: If we want nodes to be stateful we could try reusing nodes instead
         //       of recreating them on every scene update
         let scope = WgpuErrorScope::push(&ctx.wgpu_ctx.device);
 
-        let mut new_nodes = HashMap::new();
-        let mut inputs = HashMap::new();
-        let mut id_provider = NodeIdProvider::new();
-        let outputs = output_nodes
-            .into_iter()
-            .map(|output| {
-                let node_id = Self::ensure_node(
-                    ctx,
-                    output.node,
-                    &mut inputs,
-                    &mut new_nodes,
-                    &mut id_provider,
-                )?;
-                let output_texture = OutputTexture::new(ctx.wgpu_ctx, output.resolution);
-                Ok((output.output_id.clone(), (node_id, output_texture)))
-            })
-            .collect::<Result<_, UpdateSceneError>>()?;
+        let output_tree = OutputRenderTree {
+            root: Self::create_node(ctx, output.node)?,
+            output_texture: OutputTexture::new(ctx.wgpu_ctx, output.resolution),
+        };
 
         scope.pop(&ctx.wgpu_ctx.device)?;
 
-        self.inputs = inputs;
-        self.outputs = outputs;
-        self.nodes = RenderNodesSet { nodes: new_nodes };
+        self.outputs.insert(output.output_id, output_tree);
 
         Ok(())
     }
 
-    fn ensure_node(
-        ctx: &RenderCtx,
-        node: scene::Node,
-        inputs: &mut HashMap<InputId, (NodeId, InputTexture)>,
-        new_nodes: &mut HashMap<NodeId, RenderNode>,
-        id_provider: &mut NodeIdProvider,
-    ) -> Result<NodeId, UpdateSceneError> {
-        // check if input stream already registered
-        if let scene::NodeParams::InputStream(input_id) = &node.params {
-            if let Some((node_id, _)) = inputs.get(input_id) {
-                return Ok(*node_id);
-            }
-        }
-
-        let node_id = id_provider.next();
-        let input_pads: Vec<NodeId> = node
+    fn create_node(ctx: &RenderCtx, node: scene::Node) -> Result<RenderNode, UpdateSceneError> {
+        let children: Vec<RenderNode> = node
             .children
             .into_iter()
-            .map(|node| Self::ensure_node(ctx, node, inputs, new_nodes, id_provider))
+            .map(|node| Self::create_node(ctx, node))
             .collect::<Result<Vec<_>, _>>()?;
 
-        match node.params {
-            scene::NodeParams::InputStream(input_id) => {
-                let node = RenderNode::new_input();
-                new_nodes.insert(node_id, node);
-                inputs.insert(input_id.clone(), (node_id, InputTexture::new()));
-            }
-            scene::NodeParams::Shader(shader_params, shader) => {
-                let node = RenderNode::new_shader_node(ctx, input_pads, shader_params, shader);
-                new_nodes.insert(node_id, node);
-            }
-            scene::NodeParams::Web(web_renderer) => {
-                let node = RenderNode::new_web_renderer_node(ctx, input_pads, web_renderer);
-                new_nodes.insert(node_id, node);
-            }
-            scene::NodeParams::Image(image) => {
-                let node = RenderNode::new_image_node(image);
-                new_nodes.insert(node_id, node);
-            }
-            scene::NodeParams::Text(text) => {
-                let node = RenderNode::new_text_node(text);
-                new_nodes.insert(node_id, node);
-            }
-            scene::NodeParams::Layout(layout) => {
-                let node = RenderNode::new_layout_node(ctx, input_pads, layout);
-                new_nodes.insert(node_id, node);
-            }
-        }
-        Ok(node_id)
+        Ok(RenderNode::new(ctx, node.params, children))
     }
-}
-
-#[derive(Default)]
-pub struct RenderNodesSet {
-    nodes: HashMap<NodeId, RenderNode>,
-}
-
-impl RenderNodesSet {
-    pub fn new() -> Self {
-        Self {
-            nodes: HashMap::new(),
-        }
-    }
-
-    pub fn node(&self, node_id: &NodeId) -> Result<&RenderNode, InternalSceneError> {
-        self.nodes
-            .get(node_id)
-            .ok_or(InternalSceneError::MissingNode(node_id.0))
-    }
-
-    pub fn node_mut(&mut self, node_id: &NodeId) -> Result<&mut RenderNode, InternalSceneError> {
-        self.nodes
-            .get_mut(node_id)
-            .ok_or(InternalSceneError::MissingNode(node_id.0))
-    }
-
-    pub fn node_or_fallback<'a>(
-        &'a self,
-        node_id: &NodeId,
-    ) -> Result<&'a RenderNode, InternalSceneError> {
-        let nodes: HashMap<&NodeId, &RenderNode> = self.nodes.iter().collect();
-        Self::find_fallback_node(&nodes, node_id)
-    }
-
-    /// Borrow all nodes that are needed to render node node_id.
-    pub(crate) fn node_render_pass<'a>(
-        &'a mut self,
-        node_id: &NodeId,
-    ) -> Result<NodeRenderPass<'a>, InternalSceneError> {
-        let input_ids: Vec<NodeId> = self.node(node_id)?.inputs.to_vec();
-
-        // Borrow all the references, Fallback technically can be applied on every
-        // level, so the easiest approach is to just borrow everything
-        let mut nodes_mut: HashMap<&NodeId, &mut RenderNode> = self.nodes.iter_mut().collect();
-
-        // Extract mutable borrow for the node we will render.
-        let node = nodes_mut
-            .remove(&node_id)
-            .ok_or(InternalSceneError::MissingNode(node_id.0))?;
-
-        // Convert mutable borrows on rest of the nodes into immutable.
-        // One input might be used multiple times, so we might need to
-        // borrow it more than once, so it needs to be immutable.
-        let nodes: HashMap<&NodeId, &RenderNode> = nodes_mut
-            .into_iter()
-            .map(|(id, node)| (id, &*node))
-            .collect();
-
-        // Get immutable borrows for inputs. For each input if node texture
-        // is empty go through the fallback chain
-        let inputs: Vec<(NodeId, &RenderNode)> = input_ids
-            .into_iter()
-            .map(|input_id| {
-                let node = Self::find_fallback_node(&nodes, &input_id)?;
-                // input_id and node.node_id are different if fallback is triggered
-                Ok((input_id, node))
-            })
-            .collect::<Result<Vec<_>, InternalSceneError>>()?;
-        Ok(NodeRenderPass { node, inputs })
-    }
-
-    fn find_fallback_node<'a>(
-        nodes: &HashMap<&NodeId, &'a RenderNode>,
-        node_id: &NodeId,
-    ) -> Result<&'a RenderNode, InternalSceneError> {
-        let mut node: &RenderNode = nodes
-            .get(node_id)
-            .ok_or(InternalSceneError::MissingNode(node_id.0))?;
-        while node.output.is_empty() && node.fallback.is_some() {
-            let fallback_id = node.fallback.unwrap();
-            node = nodes
-                .get(&fallback_id)
-                .ok_or(InternalSceneError::MissingNode(fallback_id.0))?
-        }
-        Ok(node)
-    }
-}
-
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
-pub enum InternalSceneError {
-    #[error("Missing node \"{0}\"")]
-    MissingNode(usize),
 }

--- a/compositor_render/src/state/render_loop.rs
+++ b/compositor_render/src/state/render_loop.rs
@@ -1,28 +1,20 @@
-use std::{
-    collections::{HashMap, HashSet},
-    time::Duration,
-};
+use std::{collections::HashMap, time::Duration};
 
 use log::error;
 
 use crate::{
     scene::RGBColor,
-    state::{
-        node::RenderNode,
-        render_graph::{InternalSceneError, RenderGraph, RenderNodesSet},
-        RenderCtx,
-    },
+    state::{node::RenderNode, render_graph::RenderGraph, RenderCtx},
+    wgpu::texture::{InputTexture, NodeTexture},
     Frame, FrameSet, InputId, OutputId,
 };
-
-use super::render_graph::NodeId;
 
 pub(super) fn populate_inputs(
     ctx: &RenderCtx,
     scene: &mut RenderGraph,
-    frame_set: &mut FrameSet<InputId>,
-) -> Result<(), InternalSceneError> {
-    for (input_id, (_node_id, input_textures)) in &mut scene.inputs {
+    mut frame_set: FrameSet<InputId>,
+) {
+    for (input_id, (_node_texture, input_textures)) in &mut scene.inputs {
         let Some(frame) = frame_set.frames.remove(input_id) else {
             input_textures.clear();
             continue;
@@ -37,64 +29,60 @@ pub(super) fn populate_inputs(
 
     ctx.wgpu_ctx.queue.submit([]);
 
-    for (node_id, input_textures) in scene.inputs.values_mut() {
-        let node = scene.nodes.node_mut(node_id)?;
+    for (node_texture, input_textures) in scene.inputs.values_mut() {
         if let Some(input_textures) = input_textures.state() {
-            let node_texture = node
-                .output
-                .ensure_size(ctx.wgpu_ctx, input_textures.resolution());
+            let node_texture_state =
+                node_texture.ensure_size(ctx.wgpu_ctx, input_textures.resolution());
             ctx.wgpu_ctx.format.convert_yuv_to_rgba(
                 ctx.wgpu_ctx,
                 (input_textures.yuv_textures(), input_textures.bind_group()),
-                node_texture.rgba_texture(),
+                node_texture_state.rgba_texture(),
             );
         } else {
-            node.output.clear()
+            node_texture.clear()
         }
     }
-    Ok(())
 }
 
 pub(super) fn read_outputs(
     ctx: &RenderCtx,
     scene: &mut RenderGraph,
     pts: Duration,
-) -> Result<HashMap<OutputId, Frame>, InternalSceneError> {
+) -> HashMap<OutputId, Frame> {
     let mut pending_downloads = Vec::with_capacity(scene.outputs.len());
-    for (output_id, (node_id, output_texture)) in &scene.outputs {
-        let node = scene.nodes.node_or_fallback(node_id)?;
-        match node.output.state() {
+    for (output_id, output) in &scene.outputs {
+        match output.root.output_texture(&scene.inputs).state() {
             Some(node) => {
                 ctx.wgpu_ctx.format.convert_rgba_to_yuv(
                     ctx.wgpu_ctx,
-                    ((node.rgba_texture()), (node.bind_group())),
-                    output_texture.yuv_textures(),
+                    (node.rgba_texture(), node.bind_group()),
+                    output.output_texture.yuv_textures(),
                 );
             }
             None => {
                 let (y, u, v) = RGBColor::BLACK.to_yuv();
                 ctx.wgpu_ctx.utils.fill_r8_with_value(
                     ctx.wgpu_ctx,
-                    output_texture.yuv_textures().plane(0),
+                    output.output_texture.yuv_textures().plane(0),
                     y,
                 );
                 ctx.wgpu_ctx.utils.fill_r8_with_value(
                     ctx.wgpu_ctx,
-                    output_texture.yuv_textures().plane(1),
+                    output.output_texture.yuv_textures().plane(1),
                     u,
                 );
                 ctx.wgpu_ctx.utils.fill_r8_with_value(
                     ctx.wgpu_ctx,
-                    output_texture.yuv_textures().plane(2),
+                    output.output_texture.yuv_textures().plane(2),
                     v,
                 );
             }
         };
-        let yuv_pending = output_texture.start_download(ctx.wgpu_ctx);
+        let yuv_pending = output.output_texture.start_download(ctx.wgpu_ctx);
         pending_downloads.push((
             output_id,
             yuv_pending,
-            output_texture.resolution().to_owned(),
+            output.output_texture.resolution().to_owned(),
         ));
     }
     ctx.wgpu_ctx.device.poll(wgpu::MaintainBase::Wait);
@@ -117,70 +105,30 @@ pub(super) fn read_outputs(
             },
         );
     }
-    Ok(result)
+    result
 }
 
-pub(super) fn run_transforms(
-    ctx: &mut RenderCtx,
-    scene: &mut RenderGraph,
-    pts: Duration,
-) -> Result<(), InternalSceneError> {
-    let mut already_rendered = HashSet::new();
-    for (node_id, _) in scene.outputs.values() {
-        render_node(ctx, &mut scene.nodes, pts, node_id, &mut already_rendered)?;
+pub(super) fn run_transforms(ctx: &mut RenderCtx, scene: &mut RenderGraph, pts: Duration) {
+    for output in scene.outputs.values_mut() {
+        render_node(ctx, &scene.inputs, pts, &mut output.root);
     }
-    Ok(())
 }
 
 pub(super) fn render_node(
     ctx: &mut RenderCtx,
-    nodes: &mut RenderNodesSet,
+    inputs: &HashMap<InputId, (NodeTexture, InputTexture)>,
     pts: Duration,
-    node_id: &NodeId,
-    already_rendered: &mut HashSet<NodeId>,
-) -> Result<(), InternalSceneError> {
-    if already_rendered.contains(node_id) {
-        return Ok(());
-    }
-    // Make sure all input are rendered
-    {
-        let input_ids: Vec<_> = nodes.node(node_id)?.inputs.to_vec();
-        for input_id in input_ids {
-            render_node(ctx, nodes, pts, &input_id, already_rendered)?;
-        }
-    }
-    // Try to render node
-    //
-    // - If node texture is empty after the render and fallback_id was
-    // defined return that Some(fallback_id) from this block.
-    // - If node texture is not empty return None, even if fallback_id
-    // was defined
-    let fallback_id = {
-        let NodeRenderPass { node, inputs } = nodes.node_render_pass(node_id)?;
-        let input_textures: Vec<_> = inputs
-            .iter()
-            .map(|(node_id, node)| (node_id, &node.output))
-            .collect();
-        node.renderer
-            .render(ctx, &input_textures, &mut node.output, pts);
-
-        match node.output.is_empty() {
-            true => node.fallback,
-            false => None,
-        }
-    };
-
-    // Try to render a fallback
-    if let Some(fallback_id) = fallback_id {
-        render_node(ctx, nodes, pts, &fallback_id, already_rendered)?;
+    node: &mut RenderNode,
+) {
+    for child_node in node.children.iter_mut() {
+        render_node(ctx, inputs, pts, child_node);
     }
 
-    Ok(())
-}
-
-pub(crate) struct NodeRenderPass<'a> {
-    pub node: &'a mut RenderNode,
-    /// NodeId identifies input pad, but Node might refer
-    /// to a node with different id if fallback are in use
-    pub inputs: Vec<(NodeId, &'a RenderNode)>,
+    let input_textures: Vec<_> = node
+        .children
+        .iter()
+        .map(|node| node.output_texture(inputs))
+        .collect();
+    node.renderer
+        .render(ctx, &input_textures, &mut node.output, pts);
 }

--- a/compositor_render/src/transformations/layout.rs
+++ b/compositor_render/src/transformations/layout.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use crate::{
     scene::{RGBAColor, Size},
-    state::{render_graph::NodeId, RenderCtx},
+    state::RenderCtx,
     wgpu::texture::NodeTexture,
     Resolution,
 };
@@ -104,13 +104,13 @@ impl LayoutNode {
     pub fn render(
         &mut self,
         ctx: &RenderCtx,
-        sources: &[(&NodeId, &NodeTexture)],
+        sources: &[&NodeTexture],
         target: &mut NodeTexture,
         pts: Duration,
     ) {
         let input_resolutions: Vec<Option<Resolution>> = sources
             .iter()
-            .map(|(_, node_texture)| node_texture.resolution())
+            .map(|node_texture| node_texture.resolution())
             .collect();
         let output_resolution = self.layout_provider.resolution(pts);
         let layouts = self
@@ -147,7 +147,7 @@ impl LayoutNode {
             .map(|layout| match layout.content {
                 RenderLayoutContent::Color(_) => None,
                 RenderLayoutContent::ChildNode { index, .. } => match sources.get(index) {
-                    Some((_node_id, node_texture)) => Some(*node_texture),
+                    Some(node_texture) => Some(*node_texture),
                     None => {
                         error!("Invalid source index in layout");
                         None

--- a/compositor_render/src/transformations/shader.rs
+++ b/compositor_render/src/transformations/shader.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::{
     scene::ShaderParam,
     wgpu::{common_pipeline::CreateShaderError, WgpuCtx},
-    FallbackStrategy, RendererId,
+    RendererId,
 };
 
 use self::{pipeline::ShaderPipeline, validation::error::ParametersValidationError};
@@ -18,7 +18,6 @@ const SHADER_INPUT_TEXTURES_AMOUNT: u32 = 16;
 #[derive(Debug)]
 pub struct Shader {
     pipeline: ShaderPipeline,
-    fallback_strategy: FallbackStrategy,
     clear_color: Option<wgpu::Color>,
 }
 
@@ -26,18 +25,15 @@ pub struct Shader {
 pub struct ShaderSpec {
     pub shader_id: RendererId,
     pub source: Arc<str>,
-    pub fallback_strategy: FallbackStrategy,
 }
 
 impl Shader {
     pub fn new(wgpu_ctx: &Arc<WgpuCtx>, spec: ShaderSpec) -> Result<Self, CreateShaderError> {
-        let fallback_strategy = spec.fallback_strategy;
         let clear_color = None;
         let pipeline = ShaderPipeline::new(wgpu_ctx, spec.source)?;
 
         Ok(Self {
             pipeline,
-            fallback_strategy,
             clear_color,
         })
     }

--- a/compositor_render/src/transformations/shader/node.rs
+++ b/compositor_render/src/transformations/shader/node.rs
@@ -4,9 +4,9 @@ use wgpu::util::DeviceExt;
 
 use crate::{
     scene::ShaderParam,
-    state::{render_graph::NodeId, RenderCtx},
+    state::RenderCtx,
     wgpu::{texture::NodeTexture, WgpuCtx},
-    FallbackStrategy, Resolution,
+    Resolution,
 };
 
 use super::Shader;
@@ -68,14 +68,10 @@ impl ShaderNode {
         })
     }
 
-    pub fn fallback_strategy(&self) -> FallbackStrategy {
-        self.shader.fallback_strategy
-    }
-
     pub fn render(
         &self,
         wgpu_ctx: &Arc<WgpuCtx>,
-        sources: &[(&NodeId, &NodeTexture)],
+        sources: &[&NodeTexture],
         target: &mut NodeTexture,
         pts: Duration,
     ) {

--- a/compositor_render/src/transformations/shader/pipeline.rs
+++ b/compositor_render/src/transformations/shader/pipeline.rs
@@ -4,7 +4,6 @@ use wgpu::ShaderStages;
 
 use crate::{
     scene::ShaderParam,
-    state::render_graph::NodeId,
     wgpu::{
         common_pipeline::{self, CreateShaderError, Sampler},
         texture::{NodeTexture, NodeTextureState, RGBATexture},
@@ -99,7 +98,7 @@ impl ShaderPipeline {
         &self,
         wgpu_ctx: &Arc<WgpuCtx>,
         params: &wgpu::BindGroup,
-        sources: &[(&NodeId, &NodeTexture)],
+        sources: &[&NodeTexture],
         target: &NodeTextureState,
         pts: Duration,
         clear_color: Option<wgpu::Color>,
@@ -176,11 +175,11 @@ impl ShaderPipeline {
     fn input_textures_bg(
         &self,
         wgpu_ctx: &Arc<WgpuCtx>,
-        sources: &[(&NodeId, &NodeTexture)],
+        sources: &[&NodeTexture],
     ) -> wgpu::BindGroup {
         let mut texture_views: Vec<&wgpu::TextureView> = sources
             .iter()
-            .map(|(_, texture)| {
+            .map(|texture| {
                 texture
                     .state()
                     .map(NodeTextureState::rgba_texture)

--- a/compositor_render/src/transformations/web_renderer.rs
+++ b/compositor_render/src/transformations/web_renderer.rs
@@ -1,4 +1,4 @@
-use crate::{FallbackStrategy, RendererId, Resolution};
+use crate::{RendererId, Resolution};
 use bytes::Bytes;
 use nalgebra_glm::Mat4;
 use std::sync::{Arc, Mutex};
@@ -47,7 +47,6 @@ pub struct WebRendererSpec {
     pub url: String,
     pub resolution: Resolution,
     pub embedding_method: WebEmbeddingMethod,
-    pub fallback_strategy: FallbackStrategy,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/compositor_render/src/transformations/web_renderer/chromium_sender.rs
+++ b/compositor_render/src/transformations/web_renderer/chromium_sender.rs
@@ -1,9 +1,6 @@
 use std::sync::Arc;
 
-use crate::{
-    state::{render_graph::NodeId, RegisterCtx},
-    Resolution,
-};
+use crate::{state::RegisterCtx, Resolution};
 use crossbeam_channel::{Receiver, Sender};
 use log::error;
 
@@ -48,14 +45,8 @@ impl ChromiumSender {
         }
     }
 
-    pub fn embed_sources(
-        &self,
-        sources: &[(&NodeId, &NodeTexture)],
-    ) -> Result<(), ChromiumSenderError> {
-        let resolutions = sources
-            .iter()
-            .map(|(_, texture)| texture.resolution())
-            .collect();
+    pub fn embed_sources(&self, sources: &[&NodeTexture]) -> Result<(), ChromiumSenderError> {
+        let resolutions = sources.iter().map(|texture| texture.resolution()).collect();
         self.message_sender
             .send(ChromiumSenderMessage::EmbedSources { resolutions })
             .map_err(|_| ChromiumSenderError::MessageChannelDisconnected)
@@ -63,12 +54,9 @@ impl ChromiumSender {
 
     pub fn ensure_shared_memory(
         &self,
-        sources: &[(&NodeId, &NodeTexture)],
+        sources: &[&NodeTexture],
     ) -> Result<(), ChromiumSenderError> {
-        let resolutions = sources
-            .iter()
-            .map(|(_, texture)| texture.resolution())
-            .collect();
+        let resolutions = sources.iter().map(|texture| texture.resolution()).collect();
         self.message_sender
             .send(ChromiumSenderMessage::EnsureSharedMemory { resolutions })
             .map_err(|_| ChromiumSenderError::MessageChannelDisconnected)
@@ -98,7 +86,7 @@ impl ChromiumSender {
 
     pub fn request_frame_positions(
         &self,
-        sources: &[(&NodeId, &NodeTexture)],
+        sources: &[&NodeTexture],
     ) -> Result<(), ChromiumSenderError> {
         self.message_sender
             .send(ChromiumSenderMessage::GetFramePositions {

--- a/compositor_render/src/transformations/web_renderer/disabled_renderer.rs
+++ b/compositor_render/src/transformations/web_renderer/disabled_renderer.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use crate::{
-    state::{render_graph::NodeId, RegisterCtx, RenderCtx},
+    state::{RegisterCtx, RenderCtx},
     wgpu::texture::NodeTexture,
-    FallbackStrategy, Resolution,
+    Resolution,
 };
 
 use super::WebRendererSpec;
@@ -21,8 +21,7 @@ impl WebRenderer {
     pub fn render(
         &self,
         _ctx: &RenderCtx,
-        _node_id: &NodeId,
-        _sources: &[(&NodeId, &NodeTexture)],
+        _sources: &[&NodeTexture],
         _buffers: &[Arc<wgpu::Buffer>],
         _target: &mut NodeTexture,
     ) -> Result<(), RenderWebsiteError> {
@@ -31,10 +30,6 @@ impl WebRenderer {
 
     pub fn resolution(&self) -> Resolution {
         self.spec.resolution
-    }
-
-    pub fn fallback_strategy(&self) -> FallbackStrategy {
-        self.spec.fallback_strategy
     }
 }
 

--- a/compositor_render/src/transformations/web_renderer/embedder.rs
+++ b/compositor_render/src/transformations/web_renderer/embedder.rs
@@ -1,4 +1,4 @@
-use crate::state::{render_graph::NodeId, RegisterCtx};
+use crate::state::RegisterCtx;
 use crate::transformations::web_renderer::chromium_sender::ChromiumSender;
 use crate::wgpu::texture::NodeTexture;
 use crate::wgpu::WgpuCtx;
@@ -33,7 +33,7 @@ impl EmbeddingHelper {
 
     pub fn prepare_embedding(
         &self,
-        sources: &[(&NodeId, &NodeTexture)],
+        sources: &[&NodeTexture],
         buffers: &[Arc<wgpu::Buffer>],
     ) -> Result<(), EmbedError> {
         match self.embedding_method {
@@ -50,14 +50,14 @@ impl EmbeddingHelper {
     /// Send sources to chromium and render them on canvases via JS API
     fn chromium_embedding(
         &self,
-        sources: &[(&NodeId, &NodeTexture)],
+        sources: &[&NodeTexture],
         buffers: &[Arc<wgpu::Buffer>],
     ) -> Result<(), EmbedError> {
         self.chromium_sender.ensure_shared_memory(sources)?;
         self.copy_sources_to_buffers(sources, buffers)?;
 
         let mut pending_downloads = Vec::new();
-        for (source_idx, ((_, texture), buffer)) in sources.iter().zip(buffers).enumerate() {
+        for (source_idx, (texture, buffer)) in sources.iter().zip(buffers).enumerate() {
             let Some(texture_state) = texture.state() else {
                 continue;
             };
@@ -78,7 +78,7 @@ impl EmbeddingHelper {
 
     fn copy_sources_to_buffers(
         &self,
-        sources: &[(&NodeId, &NodeTexture)],
+        sources: &[&NodeTexture],
         buffers: &[Arc<wgpu::Buffer>],
     ) -> Result<(), EmbedError> {
         let mut encoder = self
@@ -86,7 +86,7 @@ impl EmbeddingHelper {
             .device
             .create_command_encoder(&Default::default());
 
-        for ((_, texture), buffer) in sources.iter().zip(buffers) {
+        for (texture, buffer) in sources.iter().zip(buffers) {
             let Some(texture_state) = texture.state() else {
                 continue;
             };

--- a/compositor_render/src/transformations/web_renderer/node.rs
+++ b/compositor_render/src/transformations/web_renderer/node.rs
@@ -4,12 +4,11 @@ use log::error;
 
 use crate::{
     error::ErrorStack,
-    state::{render_graph::NodeId, RenderCtx},
+    state::RenderCtx,
     wgpu::{
         texture::{utils::pad_to_256, NodeTexture, RGBATexture},
         WgpuCtx,
     },
-    FallbackStrategy,
 };
 
 use super::WebRenderer;
@@ -30,7 +29,7 @@ impl WebRendererNode {
     pub fn render(
         &mut self,
         ctx: &mut RenderCtx,
-        sources: &[(&NodeId, &NodeTexture)],
+        sources: &[&NodeTexture],
         target: &mut NodeTexture,
     ) {
         self.ensure_buffers(ctx.wgpu_ctx, sources);
@@ -43,11 +42,7 @@ impl WebRendererNode {
         }
     }
 
-    pub fn fallback_strategy(&self) -> FallbackStrategy {
-        self.renderer.fallback_strategy()
-    }
-
-    fn ensure_buffers(&mut self, wgpu_ctx: &WgpuCtx, sources: &[(&NodeId, &NodeTexture)]) {
+    fn ensure_buffers(&mut self, wgpu_ctx: &WgpuCtx, sources: &[&NodeTexture]) {
         self.buffers.resize_with(sources.len(), || {
             let buffer = wgpu_ctx.device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some("Temporary texture buffer"),
@@ -59,7 +54,7 @@ impl WebRendererNode {
             Arc::new(buffer)
         });
 
-        for ((_, texture), buffer) in sources.iter().zip(&mut self.buffers) {
+        for (texture, buffer) in sources.iter().zip(&mut self.buffers) {
             let Some(texture_state) = texture.state() else {
                 continue;
             };

--- a/compositor_render/src/transformations/web_renderer/renderer.rs
+++ b/compositor_render/src/transformations/web_renderer/renderer.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use log::info;
 
 use crate::{
-    state::{render_graph::NodeId, RegisterCtx, RenderCtx},
+    state::{RegisterCtx, RenderCtx},
     transformations::web_renderer::{
         browser_client::BrowserClient, chromium_sender::ChromiumSender,
     },
@@ -16,7 +16,7 @@ use crate::{
         common_pipeline::CreateShaderError,
         texture::{BGRATexture, NodeTexture, Texture},
     },
-    FallbackStrategy, Resolution,
+    Resolution,
 };
 
 use super::{
@@ -70,7 +70,7 @@ impl WebRenderer {
     pub fn render(
         &self,
         ctx: &RenderCtx,
-        sources: &[(&NodeId, &NodeTexture)],
+        sources: &[&NodeTexture],
         buffers: &[Arc<wgpu::Buffer>],
         target: &mut NodeTexture,
     ) -> Result<(), RenderWebsiteError> {
@@ -93,12 +93,12 @@ impl WebRenderer {
 
     fn prepare_textures<'a>(
         &'a self,
-        sources: &'a [(&NodeId, &NodeTexture)],
+        sources: &'a [&NodeTexture],
     ) -> Vec<(Option<&Texture>, RenderInfo)> {
         let mut source_info = sources
             .iter()
             .zip(self.source_transforms.lock().unwrap().iter())
-            .map(|((_node_id, node_texture), transform)| {
+            .map(|(node_texture, transform)| {
                 (
                     node_texture.texture(),
                     RenderInfo::source_transform(transform),
@@ -143,10 +143,6 @@ impl WebRenderer {
             .join("video_compositor")
             .join(format!("instance_{compositor_instance_id}"))
             .join(web_renderer_id)
-    }
-
-    pub fn fallback_strategy(&self) -> FallbackStrategy {
-        self.spec.fallback_strategy
     }
 }
 

--- a/compositor_render/src/types.rs
+++ b/compositor_render/src/types.rs
@@ -99,13 +99,6 @@ impl From<Arc<str>> for OutputId {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum FallbackStrategy {
-    NeverFallback,
-    FallbackIfAllInputsMissing,
-    FallbackIfAnyInputMissing,
-}
-
 pub const MAX_NODE_RESOLUTION: Resolution = Resolution {
     width: 7682,
     height: 4320,

--- a/compositor_render/src/wgpu/texture.rs
+++ b/compositor_render/src/wgpu/texture.rs
@@ -165,10 +165,6 @@ impl NodeTexture {
         self.0.state()
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.0.state().is_none()
-    }
-
     pub fn resolution(&self) -> Option<Resolution> {
         self.0.state().map(NodeTextureState::resolution)
     }

--- a/examples/pass_through.rs
+++ b/examples/pass_through.rs
@@ -1,0 +1,113 @@
+use anyhow::Result;
+use log::{error, info};
+use serde_json::json;
+use std::{
+    env, fs,
+    process::{Command, Stdio},
+    thread,
+    time::Duration,
+};
+use video_compositor::{config::config, http, logger, types::Resolution};
+
+use crate::common::write_example_sdp_file;
+
+#[path = "./common/common.rs"]
+mod common;
+
+const SAMPLE_FILE_URL: &str = "https://filesamples.com/samples/video/mp4/sample_1280x720.mp4";
+const SAMPLE_FILE_PATH: &str = "examples/assets/sample_1280_720.mp4";
+const VIDEO_RESOLUTION: Resolution = Resolution {
+    width: 1280,
+    height: 720,
+};
+
+fn main() {
+    env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
+    ffmpeg_next::format::network::init();
+    logger::init_logger();
+
+    thread::spawn(|| {
+        if let Err(err) = start_example_client_code() {
+            error!("{err}")
+        }
+    });
+
+    http::Server::new(config().api_port).run();
+}
+
+fn start_example_client_code() -> Result<()> {
+    info!("[example] Start listening on output port.");
+    let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
+    Command::new("ffplay")
+        .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    thread::sleep(Duration::from_secs(2));
+
+    info!("[example] Download sample.");
+    let sample_path = env::current_dir()?.join(SAMPLE_FILE_PATH);
+    fs::create_dir_all(sample_path.parent().unwrap())?;
+    common::ensure_downloaded(SAMPLE_FILE_URL, &sample_path)?;
+
+    info!("[example] Send register output request.");
+    common::post(&json!({
+        "type": "register",
+        "entity_type": "output_stream",
+        "output_id": "output_1",
+        "port": 8002,
+        "ip": "127.0.0.1",
+        "resolution": {
+            "width": VIDEO_RESOLUTION.width,
+            "height": VIDEO_RESOLUTION.height,
+        },
+        "encoder_preset": "medium"
+    }))?;
+
+    info!("[example] Send register input request.");
+    common::post(&json!({
+        "type": "register",
+        "entity_type": "rtp_input_stream",
+        "input_id": "input_1",
+        "port": 8004,
+        "video": {
+            "codec": "h264"
+        }
+    }))?;
+
+    info!("[example] Update scene");
+    common::post(&json!({
+        "type": "update_scene",
+        "outputs": [{
+            "output_id": "output_1",
+            "root": {
+                "id": "input_1",
+                "type": "input_stream",
+                "input_id": "input_1",
+            }
+        }]
+    }))?;
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    info!("[example] Start pipeline");
+    common::post(&json!({
+        "type": "start",
+    }))?;
+
+    Command::new("ffmpeg")
+        .args(["-stream_loop", "-1", "-re", "-i"])
+        .arg(sample_path)
+        .args([
+            "-an",
+            "-c:v",
+            "copy",
+            "-f",
+            "rtp",
+            "-bsf:v",
+            "h264_mp4toannexb",
+            "rtp://127.0.0.1:8004?rtcpport=8004",
+        ])
+        .spawn()?;
+    Ok(())
+}

--- a/src/snapshot_tests/utils.rs
+++ b/src/snapshot_tests/utils.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashSet, fs, path::PathBuf, time::Duration};
 
 use compositor_render::{
-    scene::OutputScene, web_renderer, Frame, Framerate, OutputId, Renderer, RendererOptions,
-    RendererSpec, YuvData,
+    scene::OutputScene, web_renderer, Frame, Framerate, InputId, OutputId, Renderer,
+    RendererOptions, RendererSpec, YuvData,
 };
 
 pub const SNAPSHOTS_DIR_NAME: &str = "snapshot_tests/snapshots/render_snapshots";
@@ -72,6 +72,9 @@ pub(super) fn create_renderer(
             panic!("Tests with web renderer are not supported");
         }
         renderer.register_renderer(spec).unwrap();
+    }
+    for id in 0..16 {
+        renderer.register_input(InputId(format!("input_{id}").into()))
     }
     for scene_update in scene_updates {
         renderer.update_scene(scene_update.clone()).unwrap();

--- a/src/types/from_renderer.rs
+++ b/src/types/from_renderer.rs
@@ -12,7 +12,6 @@ impl TryFrom<ShaderSpec> for compositor_render::RendererSpec {
         let spec = shader::ShaderSpec {
             shader_id: spec.shader_id.into(),
             source: spec.source.into(),
-            fallback_strategy: compositor_render::FallbackStrategy::FallbackIfAllInputsMissing,
         };
         Ok(Self::Shader(spec))
     }
@@ -39,7 +38,6 @@ impl TryFrom<WebRendererSpec> for compositor_render::RendererSpec {
             instance_id: spec.instance_id.into(),
             url: spec.url,
             resolution: spec.resolution.into(),
-            fallback_strategy: compositor_render::FallbackStrategy::FallbackIfAllInputsMissing,
             embedding_method,
         };
         Ok(Self::WebRenderer(spec))


### PR DESCRIPTION
- ensure variant without chrome builds on CI
- pass information about register/unregistering inputs and unregistering output is passed to renderer (register output is not necessary now, but it will be added in follow up)
- removed fallback code. Until now fallback code was left there because we want to address that issue, but don't know how yet, plus it didn't cost us any maintenance overhead, but now it makes it harder so I removed it.
- internals
  - nodes do not have an ids right now (they were only needed to establish edges of the graph)
  - render graph is now a tree