### PR TITLE
Remove `register_inputs` from web renderer

### DIFF
--- a/compositor_render/src/scene.rs
+++ b/compositor_render/src/scene.rs
@@ -91,7 +91,7 @@ pub(crate) struct Node {
 pub(crate) enum NodeParams {
     InputStream(InputId),
     Shader(ShaderComponentParams, Arc<Shader>),
-    Web(Arc<WebRenderer>),
+    Web(Vec<ComponentId>, Arc<WebRenderer>),
     Image(Image),
     Text(TextRenderParams),
     Layout(LayoutNode),
@@ -174,7 +174,7 @@ impl Component {
         match self {
             Component::InputStream(input) => input.stateful_component(ctx),
             Component::Shader(shader) => shader.stateful_component(ctx),
-            Component::WebView(shader) => shader.stateful_component(ctx),
+            Component::WebView(web_view) => web_view.stateful_component(ctx),
             Component::Image(image) => image.stateful_component(ctx),
             Component::Text(text) => text.stateful_component(ctx),
             Component::View(view) => view.stateful_component(ctx),
@@ -205,6 +205,9 @@ pub enum SceneError {
         "Instance of web renderer \"{0}\" was used more than once. Only one component can use specific web renderer at the time."
     )]
     WebRendererUsageNotExclusive(RendererId),
+
+    #[error("WebView using \"{0}\" web renderer has children without \"id\" property")]
+    WebViewChildWithoutId(RendererId),
 
     #[error("Invalid parameter passed to \"{1}\" shader.")]
     ShaderNodeParametersValidationError(#[source] ParametersValidationError, RendererId),

--- a/compositor_render/src/scene/components.rs
+++ b/compositor_render/src/scene/components.rs
@@ -70,7 +70,7 @@ pub struct TextComponent {
     /// in pixels, default: same as font_size
     pub line_height: f32,
     pub color: RGBAColor,
-    /// https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#family-name-value   
+    /// https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#family-name-value
     /// use font family name, not generic family name
     pub font_family: Arc<str>,
     pub style: TextStyle,

--- a/compositor_render/src/scene/scene_state.rs
+++ b/compositor_render/src/scene/scene_state.rs
@@ -169,7 +169,7 @@ impl IntermediateNode {
                     .collect::<Result<_, _>>()?,
             }),
             IntermediateNode::WebView { web, children } => Ok(Node {
-                params: NodeParams::Web(web.instance), // TODO: enforce resolution
+                params: NodeParams::Web(web.children_ids, web.instance), // TODO: enforce resolution
                 children: children
                     .into_iter()
                     .map(|node| node.build_tree(None, pts))

--- a/compositor_render/src/scene/web_view_component.rs
+++ b/compositor_render/src/scene/web_view_component.rs
@@ -11,6 +11,7 @@ use super::{
 pub(super) struct StatefulWebViewComponent {
     pub(super) id: Option<ComponentId>,
     pub(super) children: Vec<StatefulComponent>,
+    pub(super) children_ids: Vec<ComponentId>,
     pub(super) instance: Arc<WebRenderer>,
 }
 
@@ -52,11 +53,20 @@ impl WebViewComponent {
             .children
             .into_iter()
             .map(|c| Component::stateful_component(c, ctx))
+            .collect::<Result<Vec<_>, _>>()?;
+        let children_ids = children
+            .iter()
+            .map(|c| {
+                c.component_id()
+                    .cloned()
+                    .ok_or(SceneError::WebViewChildWithoutId(self.instance_id.clone()))
+            })
             .collect::<Result<_, _>>()?;
         Ok(StatefulComponent::WebView(StatefulWebViewComponent {
             id: self.id,
             instance,
             children,
+            children_ids,
         }))
     }
 }

--- a/compositor_render/src/state/node.rs
+++ b/compositor_render/src/state/node.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::vec;
 
-use crate::scene::{self, ShaderComponentParams};
+use crate::scene::{self, ComponentId, ShaderComponentParams};
 use crate::transformations::image_renderer::Image;
 use crate::transformations::layout::LayoutNode;
 use crate::transformations::shader::node::ShaderNode;
@@ -75,8 +75,8 @@ impl RenderNode {
             scene::NodeParams::Shader(shader_params, shader) => {
                 Self::new_shader_node(ctx, children, shader_params, shader)
             }
-            scene::NodeParams::Web(web_renderer) => {
-                Self::new_web_renderer_node(ctx, children, web_renderer)
+            scene::NodeParams::Web(children_ids, web_renderer) => {
+                Self::new_web_renderer_node(ctx, children, children_ids, web_renderer)
             }
             scene::NodeParams::Image(image) => Self::new_image_node(image),
             scene::NodeParams::Text(text_params) => Self::new_text_node(text_params),
@@ -127,10 +127,11 @@ impl RenderNode {
     pub(super) fn new_web_renderer_node(
         ctx: &RenderCtx,
         children: Vec<RenderNode>,
+        children_ids: Vec<ComponentId>,
         web_renderer: Arc<WebRenderer>,
     ) -> Self {
         let resolution = web_renderer.resolution();
-        let node = InnerRenderNode::Web(WebRendererNode::new(web_renderer));
+        let node = InnerRenderNode::Web(WebRendererNode::new(children_ids, web_renderer));
         let mut output = NodeTexture::new();
         output.ensure_size(ctx.wgpu_ctx, resolution);
 

--- a/compositor_render/src/transformations/web_renderer/disabled_renderer.rs
+++ b/compositor_render/src/transformations/web_renderer/disabled_renderer.rs
@@ -6,7 +6,7 @@ use crate::{
     Resolution,
 };
 
-use super::WebRendererSpec;
+use super::{node::EmbeddingData, WebRendererSpec};
 
 #[derive(Debug)]
 pub struct WebRenderer {
@@ -22,7 +22,7 @@ impl WebRenderer {
         &self,
         _ctx: &RenderCtx,
         _sources: &[&NodeTexture],
-        _buffers: &[Arc<wgpu::Buffer>],
+        _embedding_data: &EmbeddingData,
         _target: &mut NodeTexture,
     ) -> Result<(), RenderWebsiteError> {
         Ok(())

--- a/compositor_render/src/transformations/web_renderer/node.rs
+++ b/compositor_render/src/transformations/web_renderer/node.rs
@@ -4,6 +4,7 @@ use log::error;
 
 use crate::{
     error::ErrorStack,
+    scene::ComponentId,
     state::RenderCtx,
     wgpu::{
         texture::{utils::pad_to_256, NodeTexture, RGBATexture},
@@ -15,14 +16,17 @@ use super::WebRenderer;
 
 pub struct WebRendererNode {
     renderer: Arc<WebRenderer>,
-    buffers: Vec<Arc<wgpu::Buffer>>,
+    embedding_data: EmbeddingData,
 }
 
 impl WebRendererNode {
-    pub fn new(renderer: Arc<WebRenderer>) -> Self {
+    pub fn new(children_ids: Vec<ComponentId>, renderer: Arc<WebRenderer>) -> Self {
         Self {
             renderer,
-            buffers: Vec::new(),
+            embedding_data: EmbeddingData {
+                buffers: Vec::new(),
+                children_ids,
+            },
         }
     }
 
@@ -33,8 +37,10 @@ impl WebRendererNode {
         target: &mut NodeTexture,
     ) {
         self.ensure_buffers(ctx.wgpu_ctx, sources);
-
-        if let Err(err) = self.renderer.render(ctx, sources, &self.buffers, target) {
+        if let Err(err) = self
+            .renderer
+            .render(ctx, sources, &self.embedding_data, target)
+        {
             error!(
                 "Failed to run web render: {}",
                 ErrorStack::new(&err).into_string()
@@ -43,7 +49,7 @@ impl WebRendererNode {
     }
 
     fn ensure_buffers(&mut self, wgpu_ctx: &WgpuCtx, sources: &[&NodeTexture]) {
-        self.buffers.resize_with(sources.len(), || {
+        self.embedding_data.buffers.resize_with(sources.len(), || {
             let buffer = wgpu_ctx.device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some("Temporary texture buffer"),
                 size: 0,
@@ -54,7 +60,7 @@ impl WebRendererNode {
             Arc::new(buffer)
         });
 
-        for (texture, buffer) in sources.iter().zip(&mut self.buffers) {
+        for (texture, buffer) in sources.iter().zip(&mut self.embedding_data.buffers) {
             let Some(texture_state) = texture.state() else {
                 continue;
             };
@@ -71,4 +77,9 @@ impl WebRendererNode {
             *buffer = Arc::new(texture.new_download_buffer(ctx));
         }
     }
+}
+
+pub struct EmbeddingData {
+    pub buffers: Vec<Arc<wgpu::Buffer>>,
+    pub children_ids: Vec<ComponentId>,
 }

--- a/compositor_render/src/transformations/web_renderer/renderer.rs
+++ b/compositor_render/src/transformations/web_renderer/renderer.rs
@@ -21,6 +21,7 @@ use crate::{
 
 use super::{
     embedder::{EmbedError, EmbeddingHelper, RenderInfo},
+    node::EmbeddingData,
     shader::WebRendererShader,
     FrameData, SourceTransforms, WebEmbeddingMethod, WebRendererSpec,
 };
@@ -71,11 +72,11 @@ impl WebRenderer {
         &self,
         ctx: &RenderCtx,
         sources: &[&NodeTexture],
-        buffers: &[Arc<wgpu::Buffer>],
+        embedding_data: &EmbeddingData,
         target: &mut NodeTexture,
     ) -> Result<(), RenderWebsiteError> {
         self.embedding_helper
-            .prepare_embedding(sources, buffers)
+            .prepare_embedding(sources, embedding_data)
             .map_err(|err| RenderWebsiteError::EmbeddingFailed(self.spec.url.clone(), err))?;
 
         if let Some(frame) = self.retrieve_frame() {

--- a/examples/web_view.html
+++ b/examples/web_view.html
@@ -1,50 +1,41 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Web Renderer Example</title>
+    </head>
 
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Web Renderer Example</title>
-</head>
-
-<style>
-    html,
-    body {
-        color: white;
-        background-color: transparent;
-    }
-
-    canvas {
-        border: 2px solid red;
-        animation: anim infinite ease-in-out;
-        animation-duration: 3s;
-        width: 800px;
-        height: 600px;
-    }
-
-    @keyframes anim {
-
-        0%,
-        100% {
-            margin-left: 0;
+    <style>
+        html,
+        body {
+            color: white;
+            background-color: transparent;
         }
 
-        50% {
-            margin-left: 250px;
+        canvas {
+            border: 2px solid red;
+            animation: anim infinite ease-in-out;
+            animation-duration: 3s;
+            width: 800px;
+            height: 600px;
         }
-    }
-</style>
 
-<body>
-    <h2>Frame embedding:</h2>
-    <canvas id="input_1"></canvas>
-</body>
+        @keyframes anim {
+            0%,
+            100% {
+                margin-left: 0;
+            }
 
-<script>
-    register_inputs(
-        "input_1"
-    );
-</script>
+            50% {
+                margin-left: 250px;
+            }
+        }
+    </style>
 
+    <body>
+        <h2>Frame embedding:</h2>
+        <canvas id="big_bunny_video"></canvas>
+    </body>
 </html>

--- a/examples/web_view.rs
+++ b/examples/web_view.rs
@@ -111,6 +111,7 @@ fn start_example_client_code() -> Result<()> {
             "instance_id": "example_website",
             "children": [
                 {
+                    "id": "big_bunny_video",
                     "type": "input_stream",
                     "input_id": "input_1",
                 }

--- a/src/bin/process_helper/handler.rs
+++ b/src/bin/process_helper/handler.rs
@@ -21,13 +21,7 @@ impl cef::RenderProcessHandler for RenderProcessHandler {
         _frame: &cef::Frame,
         context: &cef::V8Context,
     ) {
-        let mut global = context.global().unwrap();
-        let ctx_entered = context.enter().unwrap();
-
         context.eval(include_str!("render_frame.js")).unwrap();
-        if let Err(err) = self.register_native_funcs(&mut global, &ctx_entered) {
-            error!("Failed to register native functions for V8Context: {err}");
-        }
     }
 
     fn on_process_message_received(
@@ -65,8 +59,8 @@ impl RenderProcessHandler {
         let ctx_entered = ctx.enter()?;
         let mut global = ctx.global()?;
 
-        const MSG_SIZE: usize = 3;
-        for i in (0..msg.size()).step_by(3) {
+        const MSG_SIZE: usize = 4;
+        for i in (0..msg.size()).step_by(MSG_SIZE) {
             let source_idx = i / MSG_SIZE;
 
             let Some(shmem_path) = msg.read_string(i) else {
@@ -74,19 +68,27 @@ impl RenderProcessHandler {
             };
             let shmem_path = PathBuf::from(shmem_path);
 
-            let Some(width) = msg.read_int(i + 1) else {
+            let Some(id_attribute) = msg.read_string(i + 1) else {
                 return Err(anyhow!(
-                    "Failed to read width of input {} at {}",
+                    "Failed to read HTML id attribute of input {} at {}",
                     source_idx,
                     i + 1
                 ));
             };
 
-            let Some(height) = msg.read_int(i + 2) else {
+            let Some(width) = msg.read_int(i + 2) else {
+                return Err(anyhow!(
+                    "Failed to read width of input {} at {}",
+                    source_idx,
+                    i + 2
+                ));
+            };
+
+            let Some(height) = msg.read_int(i + 3) else {
                 return Err(anyhow!(
                     "Failed to read height of input {} at {}",
                     source_idx,
-                    i + 2
+                    i + 3
                 ));
             };
 
@@ -99,6 +101,7 @@ impl RenderProcessHandler {
                 width: width as u32,
                 height: height as u32,
                 shmem_path,
+                id_attribute,
             };
 
             self.render_frame(frame_info, &mut global, &ctx_entered)?;
@@ -116,13 +119,15 @@ impl RenderProcessHandler {
         let mut state = self.state.lock().unwrap();
         let source = match state.source(&frame_info.shmem_path) {
             Some(source) => source,
-            None => state.create_source(frame_info, ctx_entered)?,
+            None => state.create_source(&frame_info, ctx_entered)?,
         };
 
+        source.ensure(&frame_info);
+
         global.call_method(
-            "renderFrame",
+            "live_compositor_renderFrame",
             &[
-                &source.source_id,
+                &source.id_attribute_value,
                 &source.array_buffer,
                 &source.width,
                 &source.height,
@@ -147,9 +152,8 @@ impl RenderProcessHandler {
         let ctx = surface.v8_context()?;
         let ctx_entered = ctx.enter()?;
 
-        let source_id = state.input_name(source.source_index)?;
         let mut global = ctx.global()?;
-        global.delete(&source_id, &ctx_entered)?;
+        global.delete(&source.id_attribute, &ctx_entered)?;
         state.remove_source(&shmem_path);
 
         Ok(())
@@ -161,70 +165,31 @@ impl RenderProcessHandler {
         let global = ctx.global()?;
         let document = global.document()?;
 
-        let Some(source_count) = msg.read_int(0) else {
-            return Err(anyhow!("Expected source count"));
-        };
-
-        let state = self.state.lock().unwrap();
         let mut response = cef::ProcessMessage::new(GET_FRAME_POSITIONS_MESSAGE);
-        let mut index = 0;
-        for source_idx in 0..(source_count as usize) {
-            let source_id = state.input_name(source_idx)?;
-            let element = match document.element_by_id(&source_id, &ctx_entered) {
+        let mut write_idx = 0;
+        for read_idx in 0..msg.size() {
+            let Some(id_attribute) = msg.read_string(read_idx) else {
+                return Err(anyhow!("Failed to read id attribute at {read_idx}"));
+            };
+            let element = match document.element_by_id(&id_attribute, &ctx_entered) {
                 Ok(element) => element,
                 Err(err) => {
-                    return Err(anyhow!("Failed to retrieve element \"{source_id}\": {err}"));
+                    return Err(anyhow!(
+                        "Failed to retrieve element \"{id_attribute}\": {err}"
+                    ));
                 }
             };
+
             let rect = element.bounding_rect(&ctx_entered)?;
+            response.write_double(write_idx, rect.x);
+            response.write_double(write_idx + 1, rect.y);
+            response.write_double(write_idx + 2, rect.width);
+            response.write_double(write_idx + 3, rect.height);
 
-            response.write_double(index, rect.x);
-            response.write_double(index + 1, rect.y);
-            response.write_double(index + 2, rect.width);
-            response.write_double(index + 3, rect.height);
-
-            index += 4;
+            write_idx += 4;
         }
 
         surface.send_process_message(cef::ProcessId::Browser, response)?;
-
-        Ok(())
-    }
-
-    pub fn register_native_funcs(
-        &self,
-        global: &mut cef::V8Global,
-        ctx_entered: &cef::V8ContextEntered,
-    ) -> Result<()> {
-        let state = self.state.clone();
-        let func = cef::V8Function::new("register_inputs", move |args| {
-            let mut input_mappings = Vec::new();
-            for arg in args {
-                let cef::V8Value::String(element_id) = arg else {
-                    return Err("Expected string value".into());
-                };
-                let element_id = element_id.get().unwrap().into();
-                if input_mappings.contains(&element_id) {
-                    return Err(format!(
-                        "\"{element_id}\" already exists in the provided input mappings"
-                    )
-                    .into());
-                }
-
-                input_mappings.push(element_id);
-            }
-
-            let mut state = state.lock().unwrap();
-            state.set_input_mappings(input_mappings);
-            Ok(cef::V8Undefined::new().into())
-        });
-
-        global.set(
-            "register_inputs",
-            &cef::V8Value::from(func),
-            cef::V8PropertyAttribute::None,
-            ctx_entered,
-        )?;
 
         Ok(())
     }

--- a/src/bin/process_helper/render_frame.js
+++ b/src/bin/process_helper/render_frame.js
@@ -1,4 +1,4 @@
-function renderFrame(sourceId, buffer, width, height) {
+function live_compositor_renderFrame(sourceId, buffer, width, height) {
     const canvas = document.getElementById(sourceId);
     const ctx = canvas.getContext("2d");
     const imageData = new ImageData(new Uint8ClampedArray(buffer), width, height);

--- a/src/bin/process_helper/state.rs
+++ b/src/bin/process_helper/state.rs
@@ -1,38 +1,34 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use compositor_chromium::cef;
 use shared_memory::{Shmem, ShmemConf};
 
 pub struct State {
-    input_mappings: Vec<Arc<str>>,
-    sources: HashMap<PathBuf, Arc<Source>>,
+    sources: HashMap<PathBuf, Source>,
 }
 
 impl State {
     pub fn new() -> Self {
         Self {
-            input_mappings: Vec::new(),
             sources: HashMap::new(),
         }
     }
 
-    pub fn source(&self, key: &Path) -> Option<Arc<Source>> {
-        self.sources.get(key).cloned()
+    pub fn source(&mut self, key: &Path) -> Option<&mut Source> {
+        self.sources.get_mut(key)
     }
 
     pub fn create_source(
         &mut self,
-        frame_info: FrameInfo,
+        frame_info: &FrameInfo,
         ctx_entered: &cef::V8ContextEntered,
-    ) -> Result<Arc<Source>> {
-        let source_id = self.input_name(frame_info.source_idx)?;
+    ) -> Result<&mut Source> {
         let shmem = ShmemConf::new().flink(&frame_info.shmem_path).open()?;
         let data_ptr = shmem.as_ptr();
 
-        let source_id = cef::V8String::new(&source_id).into();
+        let id_attribute_value = cef::V8String::new(&frame_info.id_attribute).into();
         let array_buffer: cef::V8Value = unsafe {
             cef::V8ArrayBuffer::from_ptr(
                 data_ptr,
@@ -44,44 +40,40 @@ impl State {
         let width = cef::V8Uint::new(frame_info.width).into();
         let height = cef::V8Uint::new(frame_info.height).into();
 
-        // `Arc` is used instead of `Rc` because we can't make any guarantees that Chromium will run this code on a single thread.
-        #[allow(clippy::arc_with_non_send_sync)]
-        let source = Arc::new(Source {
+        let source = Source {
             _shmem: shmem,
-            source_index: frame_info.source_idx,
-            source_id,
+            id_attribute: frame_info.id_attribute.clone(),
+            id_attribute_value,
             array_buffer,
             width,
             height,
-        });
+        };
 
-        self.sources.insert(frame_info.shmem_path, source.clone());
-        Ok(source)
+        self.sources.insert(frame_info.shmem_path.clone(), source);
+        Ok(self.sources.get_mut(&frame_info.shmem_path).unwrap())
     }
 
     pub fn remove_source(&mut self, key: &Path) {
         self.sources.remove(key);
     }
-
-    pub fn set_input_mappings(&mut self, new_input_mappings: Vec<Arc<str>>) {
-        self.sources.clear();
-        self.input_mappings = new_input_mappings;
-    }
-
-    pub fn input_name(&self, source_idx: usize) -> Result<Arc<str>> {
-        self.input_mappings.get(source_idx).cloned().with_context(|| {
-            format!("Could not retrieve input name. Expected registered input for index {source_idx}. Use register_inputs(\"input_name1\", ...)")
-        })
-    }
 }
 
 pub struct Source {
     pub _shmem: Shmem,
-    pub source_index: usize,
-    pub source_id: cef::V8Value,
+    pub id_attribute: String,
+    pub id_attribute_value: cef::V8Value,
     pub array_buffer: cef::V8Value,
     pub width: cef::V8Value,
     pub height: cef::V8Value,
+}
+
+impl Source {
+    pub fn ensure(&mut self, frame_info: &FrameInfo) {
+        if self.id_attribute != frame_info.id_attribute {
+            let id_attribute_value = cef::V8String::new(&frame_info.id_attribute).into();
+            self.id_attribute_value = id_attribute_value;
+        }
+    }
 }
 
 pub struct FrameInfo {
@@ -89,4 +81,5 @@ pub struct FrameInfo {
     pub width: u32,
     pub height: u32,
     pub shmem_path: PathBuf,
+    pub id_attribute: String,
 }


### PR DESCRIPTION
Currently, users have to specify HTML elements that display frames in the `register_inputs` JS function.
For example:
```html
<body>
  <canvas id="my_video"></canvas>
</body>

<script>
  register_inputs("my_video")
</script>
```

The problems with this approach:
- Code editors don't know about `register_inputs` so they show an error
- You can't test the website in a normal browser because the browser would also show an error 
- The embedding config isn't in one place
- It could cause problems for react or similar libraries


The new approach uses component IDs for specifying IDs of HTML elements.
```ts
{
    "output_id": "output_1",
    "root": {
        "id": "embed_input_on_website",
        "type": "web_view",
        "instance_id": "example_website",
        "children": [
            {
                "id": "my_video", // <-- here
                "type": "input_stream",
                "input_id": "input_1",
            }
        ]
    }
}
```
  
I don't know if using component ID is the correct way to solve this problem. I considered adding a new field to each child but I'm not sure if that's any better.

Issue #352 