### PR TITLE
Implement control flow for elements before queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +405,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "chrono",
  "compositor_render",
  "crossbeam-channel",
  "ffmpeg-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ anyhow = "1.0.71"
 image = { version = "0.24.7", features = ["jpeg", "png"] }
 rtp = "0.9.0"
 rand = "0.8.5"
+chrono = { version = "0.4.33", default-features = false, features = [ "std", "alloc"] }
 
 [dependencies]
 compositor_render = { path = "compositor_render" }

--- a/compositor_pipeline/Cargo.toml
+++ b/compositor_pipeline/Cargo.toml
@@ -20,4 +20,5 @@ opus = "0.3.0"
 rand = { workspace = true }
 mp4 = "0.14.0"
 reqwest = { workspace = true }
+chrono = { workspace = true }
 

--- a/compositor_pipeline/src/pipeline/decoder/ffmpeg_h264.rs
+++ b/compositor_pipeline/src/pipeline/decoder/ffmpeg_h264.rs
@@ -105,7 +105,7 @@ impl H264FfmpegDecoder {
                             }
                         };
 
-                        if let Err(_err) = frame_sender.send(frame) {
+                        if frame_sender.send(frame).is_err() {
                             return;
                         }
                     }

--- a/compositor_pipeline/src/pipeline/decoder/ffmpeg_h264.rs
+++ b/compositor_pipeline/src/pipeline/decoder/ffmpeg_h264.rs
@@ -1,13 +1,12 @@
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use crate::{
     error::DecoderInitError,
     pipeline::structs::{EncodedChunk, EncodedChunkKind, VideoCodec},
-    queue::Queue,
 };
 
-use compositor_render::{error::ErrorStack, Frame, InputId, Resolution, YuvData};
-use crossbeam_channel::Receiver;
+use compositor_render::{Frame, InputId, Resolution, YuvData};
+use crossbeam_channel::{Receiver, Sender};
 use ffmpeg_next::{
     codec::{Context, Id},
     ffi::AV_CODEC_FLAG2_CHUNKS,
@@ -22,7 +21,7 @@ pub struct H264FfmpegDecoder;
 impl H264FfmpegDecoder {
     pub fn new(
         chunks_receiver: Receiver<EncodedChunk>,
-        queue: Arc<Queue>,
+        frame_sender: Sender<Frame>,
         input_id: InputId,
     ) -> Result<Self, DecoderInitError> {
         let (init_result_sender, init_result_receiver) = crossbeam_channel::bounded(0);
@@ -106,11 +105,8 @@ impl H264FfmpegDecoder {
                             }
                         };
 
-                        if let Err(err) = queue.enqueue_video_frame(input_id.clone(), frame) {
-                            error!(
-                                "Failed to push frame: {}",
-                                ErrorStack::new(&err).into_string()
-                            );
+                        if let Err(_err) = frame_sender.send(frame) {
+                            return;
                         }
                     }
                 }

--- a/compositor_pipeline/src/pipeline/decoder/opus_decoder.rs
+++ b/compositor_pipeline/src/pipeline/decoder/opus_decoder.rs
@@ -1,13 +1,12 @@
 use std::sync::Arc;
 
 use compositor_render::{AudioSamples, AudioSamplesBatch, InputId};
-use crossbeam_channel::Receiver;
+use crossbeam_channel::{Receiver, Sender};
 use log::error;
 
 use crate::{
     error::DecoderInitError,
     pipeline::structs::{AudioChannels, EncodedChunk},
-    queue::Queue,
 };
 
 use super::OpusDecoderOptions;
@@ -18,14 +17,14 @@ impl OpusDecoder {
     pub fn new(
         opts: OpusDecoderOptions,
         chunks_receiver: Receiver<EncodedChunk>,
-        queue: Arc<Queue>,
+        sample_sender: Sender<AudioSamplesBatch>,
         input_id: InputId,
     ) -> Result<Self, DecoderInitError> {
         let decoder = opus::Decoder::new(opts.sample_rate, opts.channels.into())?;
 
         std::thread::Builder::new()
             .name(format!("opus decoder {}", input_id.0))
-            .spawn(move || Self::start_decoding(decoder, opts, queue, chunks_receiver, input_id))
+            .spawn(move || Self::start_decoding(decoder, opts, chunks_receiver, sample_sender))
             .unwrap();
 
         Ok(Self)
@@ -34,9 +33,8 @@ impl OpusDecoder {
     fn start_decoding(
         mut decoder: opus::Decoder,
         opts: OpusDecoderOptions,
-        queue: Arc<Queue>,
         chunks_receiver: Receiver<EncodedChunk>,
-        input_id: InputId,
+        sample_sender: Sender<AudioSamplesBatch>,
     ) {
         // Max sample rate for opus is 48kHz.
         // Usually packets contain 20ms audio chunks, but for safety we use buffer
@@ -67,15 +65,12 @@ impl OpusDecoder {
 
             let samples = AudioSamplesBatch {
                 samples: Arc::new(samples),
-                pts: chunk.pts,
+                start_pts: chunk.pts,
                 sample_rate: opts.sample_rate,
             };
 
-            if let Err(err) = queue.enqueue_audio_samples(input_id.clone(), samples) {
-                error!(
-                    "Error enqueueing audio samples for input {}: {}",
-                    input_id, err
-                );
+            if sample_sender.send(samples).is_err() {
+                return;
             };
         }
     }

--- a/compositor_pipeline/src/pipeline/pipeline_input.rs
+++ b/compositor_pipeline/src/pipeline/pipeline_input.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+
+use crate::error::RegisterInputError;
+
+use super::{
+    decoder::{self, DecodedDataReceiver},
+    input, PipelineInput, Port, RegisterInputOptions,
+};
+
+pub(super) fn new_pipeline_input(
+    opts: RegisterInputOptions,
+    download_dir: &Path,
+) -> Result<(PipelineInput, DecodedDataReceiver, Option<Port>), RegisterInputError> {
+    let RegisterInputOptions {
+        input_id,
+        input_options,
+        decoder_options,
+        ..
+    } = opts;
+
+    let (input, chunks_receiver, port) = input::Input::new(input_options, download_dir)
+        .map_err(|e| RegisterInputError::InputError(input_id.clone(), e))?;
+
+    let (decoder, decoded_data_receiver) =
+        decoder::Decoder::new(input_id.clone(), chunks_receiver, decoder_options)
+            .map_err(|e| RegisterInputError::DecoderError(input_id.clone(), e))?;
+
+    let pipeline_input = PipelineInput { input, decoder };
+    Ok((pipeline_input, decoded_data_receiver, port))
+}

--- a/compositor_pipeline/src/queue.rs
+++ b/compositor_pipeline/src/queue.rs
@@ -9,46 +9,15 @@ use std::{
     time::{Duration, Instant},
 };
 
-use compositor_render::{
-    AudioSamples, AudioSamplesBatch, AudioSamplesSet, Frame, FrameSet, Framerate, InputId,
-};
+use compositor_render::{AudioSamplesSet, FrameSet, Framerate, InputId};
 use crossbeam_channel::{unbounded, Receiver, Sender};
-use log::error;
-use thiserror::Error;
 
-use crate::pipeline::{decoder::DecodedDataReceiver, AudioChannels};
+use crate::pipeline::decoder::DecodedDataReceiver;
 
 use self::{
     audio_queue::AudioQueue, audio_queue_thread::AudioQueueThread, video_queue::VideoQueue,
     video_queue_thread::VideoQueueThread,
 };
-
-#[derive(Debug, Clone)]
-pub struct InputOptions {
-    pub video: Option<Receiver<Frame>>,
-    pub audio: Option<Receiver<AudioSamplesBatch>>,
-}
-
-#[derive(Error, Debug)]
-pub enum QueueError {
-    #[error("the input id `{:#?}` is unknown", 0)]
-    UnknownInputId(InputId),
-    #[error(
-        "expected samples in {:#?} channel format, but received samples {:#?}",
-        expected,
-        received
-    )]
-    MismatchedSamplesChannels {
-        expected: AudioChannels,
-        received: AudioSamples,
-    },
-    #[error(
-        "expected samples with {} sample rate, but received samples of rate {}",
-        expected,
-        received
-    )]
-    MismatchedSampleRate { expected: u32, received: u32 },
-}
 
 const DEFAULT_BUFFER_DURATION: Duration = Duration::from_millis(16 * 5); // about 5 frames at 60 fps
 const DEFAULT_AUDIO_CHUNK_DURATION: Duration = Duration::from_millis(20); // typical audio packet size

--- a/compositor_pipeline/src/queue.rs
+++ b/compositor_pipeline/src/queue.rs
@@ -1,38 +1,32 @@
 mod audio_queue;
 mod audio_queue_thread;
+mod utils;
 mod video_queue;
 mod video_queue_thread;
 
 use std::{
     sync::{Arc, Mutex},
-    thread,
     time::{Duration, Instant},
 };
 
 use compositor_render::{
-    error::ErrorStack, AudioSamples, AudioSamplesBatch, AudioSamplesSet, Frame, FrameSet,
-    Framerate, InputId,
+    AudioSamples, AudioSamplesBatch, AudioSamplesSet, Frame, FrameSet, Framerate, InputId,
 };
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use log::error;
 use thiserror::Error;
 
-use crate::pipeline::AudioChannels;
+use crate::pipeline::{decoder::DecodedDataReceiver, AudioChannels};
 
 use self::{
     audio_queue::AudioQueue, audio_queue_thread::AudioQueueThread, video_queue::VideoQueue,
     video_queue_thread::VideoQueueThread,
 };
 
-pub struct InputType {
-    pub input_id: InputId,
-    pub video: Option<()>,
-    pub audio: Option<AudioOptions>,
-}
-
-pub struct AudioOptions {
-    pub sample_rate: u32,
-    pub channels: AudioChannels,
+#[derive(Debug, Clone)]
+pub struct InputOptions {
+    pub video: Option<Receiver<Frame>>,
+    pub audio: Option<Receiver<AudioSamplesBatch>>,
 }
 
 #[derive(Error, Debug)]
@@ -105,15 +99,18 @@ impl Queue {
         }
     }
 
-    pub fn add_input(&self, options: InputType) {
-        if let Some(_video_options) = options.video {
+    pub fn add_input(&self, input_id: &InputId, receiver: DecodedDataReceiver) {
+        if let Some(receiver) = receiver.video {
             self.video_queue
                 .lock()
                 .unwrap()
-                .add_input(options.input_id.clone());
+                .add_input(input_id, receiver);
         };
-        if let Some(_audio_options) = options.audio {
-            self.audio_queue.lock().unwrap().add_input(options.input_id);
+        if let Some(receiver) = receiver.audio {
+            self.audio_queue
+                .lock()
+                .unwrap()
+                .add_input(input_id, receiver);
         }
     }
 
@@ -154,63 +151,7 @@ impl Queue {
         .spawn();
     }
 
-    pub fn enqueue_audio_samples(
-        &self,
-        input_id: InputId,
-        samples: AudioSamplesBatch,
-    ) -> Result<(), QueueError> {
-        let is_first_batch_for_input = !self
-            .audio_queue
-            .lock()
-            .unwrap()
-            .did_receive_samples(&input_id);
-        if is_first_batch_for_input {
-            thread::sleep(self.buffer_duration)
-        }
-        self.audio_queue
-            .lock()
-            .unwrap()
-            .enqueue_samples(input_id, samples, self.clock_start)
-    }
-
-    pub fn enqueue_video_frame(&self, input_id: InputId, frame: Frame) -> Result<(), QueueError> {
-        let is_first_frame_for_input = !self
-            .video_queue
-            .lock()
-            .unwrap()
-            .did_receive_frame(&input_id);
-        if is_first_frame_for_input {
-            // Sleep here ensures that we will buffer `self.buffer_duration` on each input.
-            // It also makes calculation easier because PTS of frames will be already offset
-            // by a correct value.
-            thread::sleep(self.buffer_duration);
-        }
-
-        let mut internal_queue = self.video_queue.lock().unwrap();
-
-        internal_queue.enqueue_frame(input_id.clone(), frame, self.clock_start)?;
-
-        // We don't know when pipeline is started, so we can't resolve real_next_pts,
-        // but we can remove frames based on estimated PTS. This only works if queue
-        // is able to push frames in real time and is never behind more than one frame.
-        let framerate_tick = Duration::from_secs_f64(
-            self.output_framerate.den as f64 / self.output_framerate.num as f64,
-        );
-        let estimated_pts = self.clock_start.elapsed() - framerate_tick;
-        if let Err(err) = internal_queue.drop_old_frames_by_input_id(&input_id, estimated_pts) {
-            error!(
-                "Failed to drop frames on input {}:\n{}",
-                input_id,
-                ErrorStack::new(&err).into_string()
-            )
-        }
-
-        self.check_video_queue_channel.0.send(()).unwrap();
-
-        Ok(())
-    }
-
-    pub fn subscribe_input_listener(&self, input_id: InputId, callback: Box<dyn FnOnce() + Send>) {
+    pub fn subscribe_input_listener(&self, input_id: &InputId, callback: Box<dyn FnOnce() + Send>) {
         self.video_queue
             .lock()
             .unwrap()

--- a/compositor_pipeline/src/queue/audio_queue.rs
+++ b/compositor_pipeline/src/queue/audio_queue.rs
@@ -91,7 +91,7 @@ impl AudioQueueInput {
             }
         }
 
-        let poped_samples = self
+        let popped_samples = self
             .queue
             .iter()
             .filter(|batch| batch.start_pts < end_pts && batch.end_pts() > start_pts)
@@ -99,7 +99,7 @@ impl AudioQueueInput {
             .collect::<Vec<AudioSamplesBatch>>();
         self.drop_old_samples(end_pts);
 
-        poped_samples
+        popped_samples
     }
 
     fn try_enqueue_samples(&mut self, clock_start: Instant) -> Result<(), TryRecvError> {

--- a/compositor_pipeline/src/queue/audio_queue_thread.rs
+++ b/compositor_pipeline/src/queue/audio_queue_thread.rs
@@ -21,6 +21,7 @@ pub struct AudioQueueThread {
     buffer_duration: Duration,
     chunk_duration: Duration,
     chunks_counter: u32,
+    clock_start: Instant,
 }
 
 impl AudioQueueThread {
@@ -30,6 +31,7 @@ impl AudioQueueThread {
             sender,
             buffer_duration: opts.buffer_duration,
             chunk_duration: opts.pushed_chunk_length,
+            clock_start: opts.clock_start,
             chunks_counter: 0,
         }
     }
@@ -49,7 +51,7 @@ impl AudioQueueThread {
                 .audio_queue
                 .lock()
                 .unwrap()
-                .pop_samples_set(pts, self.chunk_duration);
+                .pop_samples_set((pts, pts + self.chunk_duration), self.clock_start);
             self.sender.send(samples).unwrap();
             self.chunks_counter += 1;
         }

--- a/compositor_pipeline/src/queue/utils.rs
+++ b/compositor_pipeline/src/queue/utils.rs
@@ -1,0 +1,11 @@
+use std::time::Duration;
+
+pub(super) trait DurationExt {
+    fn chrono(self) -> chrono::Duration;
+}
+
+impl DurationExt for Duration {
+    fn chrono(self) -> chrono::Duration {
+        chrono::Duration::from_std(self).unwrap_or(chrono::Duration::max_value())
+    }
+}

--- a/compositor_pipeline/src/queue/utils.rs
+++ b/compositor_pipeline/src/queue/utils.rs
@@ -8,6 +8,20 @@ use compositor_render::{AudioSamplesBatch, Frame};
 
 use super::DEFAULT_BUFFER_DURATION;
 
+/// InputState handles initial processing for frames/samples that are being
+/// queued. For each received frame/sample batch, the `process_new_chunk`
+/// method should be called and only elements returned should be used
+/// in a queue.
+///
+/// 1. New input start in `InputState::WaitingForStart`.
+/// 2. When `process_new_chunk` is called for the first time it transitions to
+///    the Buffering state.
+/// 3. Each new call to the `process_new_chunk` is adding frames to the buffer
+///    until it reaches a specific size/duration.
+/// 4. After buffer reaches a certain size, calculate the offset and switch
+///    to the `Ready` state.
+/// 5. In `Ready` state `process_new_chunk` is immediately returning frame or sample
+///    batch passed with arguments with modified pts.
 #[derive(Debug)]
 pub(super) enum InputState<Payload: ApplyOffsetExt> {
     WaitingForStart,

--- a/compositor_pipeline/src/queue/utils.rs
+++ b/compositor_pipeline/src/queue/utils.rs
@@ -1,6 +1,85 @@
-use std::time::Duration;
+use std::{
+    collections::VecDeque,
+    mem,
+    time::{Duration, Instant},
+};
 
-pub(super) trait DurationExt {
+use compositor_render::{AudioSamplesBatch, Frame};
+
+use super::DEFAULT_BUFFER_DURATION;
+
+#[derive(Debug)]
+pub(super) enum InputState<Payload: ApplyOffsetExt> {
+    WaitingForStart,
+    Buffering { buffer: Vec<(Payload, Duration)> },
+    Ready { offset: chrono::Duration },
+}
+
+impl<Payload: ApplyOffsetExt> InputState<Payload> {
+    pub(super) fn process_new_chunk(
+        &mut self,
+        mut payload: Payload,
+        pts: Duration,
+        clock_start: Instant,
+    ) -> VecDeque<Payload> {
+        match self {
+            InputState::WaitingForStart => {
+                *self = InputState::Buffering {
+                    buffer: vec![(payload, pts)],
+                };
+                VecDeque::new()
+            }
+            InputState::Buffering { ref mut buffer } => {
+                buffer.push((payload, pts));
+                let first_pts = buffer.first().map(|(_, p)| *p).unwrap_or(Duration::ZERO);
+                let last_pts = buffer.last().map(|(_, p)| *p).unwrap_or(Duration::ZERO);
+                let buffer_duration = last_pts.saturating_sub(first_pts);
+
+                if buffer_duration < DEFAULT_BUFFER_DURATION {
+                    VecDeque::new()
+                } else {
+                    let offset = clock_start.elapsed().chrono() - first_pts.chrono();
+
+                    let chunks = mem::take(buffer)
+                        .into_iter()
+                        .map(|(mut buffer, _)| {
+                            buffer.apply_offset(offset);
+                            buffer
+                        })
+                        .collect();
+                    *self = InputState::Ready { offset };
+                    chunks
+                }
+            }
+            InputState::Ready { offset } => {
+                payload.apply_offset(*offset);
+                VecDeque::from([payload])
+            }
+        }
+    }
+}
+
+pub(super) trait ApplyOffsetExt {
+    fn apply_offset(&mut self, offset: chrono::Duration);
+}
+
+impl ApplyOffsetExt for Frame {
+    fn apply_offset(&mut self, offset: chrono::Duration) {
+        self.pts = (self.pts.chrono() + offset)
+            .to_std()
+            .unwrap_or(Duration::ZERO);
+    }
+}
+
+impl ApplyOffsetExt for AudioSamplesBatch {
+    fn apply_offset(&mut self, offset: chrono::Duration) {
+        self.start_pts = (self.start_pts.chrono() + offset)
+            .to_std()
+            .unwrap_or(Duration::ZERO);
+    }
+}
+
+trait DurationExt {
     fn chrono(self) -> chrono::Duration;
 }
 

--- a/compositor_pipeline/src/queue/video_queue_thread.rs
+++ b/compositor_pipeline/src/queue/video_queue_thread.rs
@@ -60,7 +60,8 @@ impl VideoQueueThread {
         let mut internal_queue = self.queue.video_queue.lock().unwrap();
         let next_buffer_pts = self.get_next_output_buffer_pts();
 
-        let ready_to_push = internal_queue.check_all_inputs_ready(next_buffer_pts)
+        let ready_to_push = internal_queue
+            .check_all_inputs_ready(next_buffer_pts, self.opts.clock_start)
             || self.should_push_pts(next_buffer_pts);
         if !ready_to_push {
             return;

--- a/compositor_render/src/types.rs
+++ b/compositor_render/src/types.rs
@@ -3,20 +3,21 @@ use std::{collections::HashMap, fmt::Display, sync::Arc, time::Duration};
 #[derive(Debug)]
 pub struct AudioSamplesSet {
     pub samples: HashMap<InputId, Vec<AudioSamplesBatch>>,
-    pub pts: Duration,
+    pub start_pts: Duration,
     pub length: Duration,
 }
 
 #[derive(Debug, Clone)]
 pub struct AudioSamplesBatch {
     pub samples: Arc<AudioSamples>,
-    pub pts: Duration,
+    pub start_pts: Duration,
     pub sample_rate: u32,
 }
 
 impl AudioSamplesBatch {
-    pub fn end(&self) -> Duration {
-        self.pts + Duration::from_secs_f64(self.samples.len() as f64 / self.sample_rate as f64)
+    pub fn end_pts(&self) -> Duration {
+        self.start_pts
+            + Duration::from_secs_f64(self.samples.len() as f64 / self.sample_rate as f64)
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -127,7 +127,7 @@ impl Api {
             QueryRequest::WaitForNextFrame { input_id } => {
                 let (sender, receiver) = bounded(1);
                 self.pipeline.queue().subscribe_input_listener(
-                    input_id.into(),
+                    &input_id.into(),
                     Box::new(move || {
                         sender.send(Ok(Response::Ok {})).unwrap();
                     }),

--- a/src/types/from_register_request.rs
+++ b/src/types/from_register_request.rs
@@ -21,14 +21,6 @@ impl TryFrom<register_request::RtpInputStream> for pipeline::RegisterInputOption
         if video.is_none() && audio.is_none() {
             return Err(TypeError::new(NO_VIDEO_AUDIO_SPEC));
         }
-        let input_type = pipeline::InputType {
-            input_id: input_id.clone().into(),
-            video: video.as_ref().map(|_video| ()),
-            audio: audio.as_ref().map(|audio| pipeline::AudioOptions {
-                sample_rate: audio.sample_rate,
-                channels: audio.channels.clone().into(),
-            }),
-        };
 
         let rtp_stream = pipeline::input::rtp::RtpStream {
             video: video
@@ -71,7 +63,6 @@ impl TryFrom<register_request::RtpInputStream> for pipeline::RegisterInputOption
             input_id: input_id.into(),
             input_options,
             decoder_options,
-            input_type,
         })
     }
 }
@@ -98,12 +89,6 @@ impl TryFrom<register_request::Mp4> for pipeline::RegisterInputOptions {
             (None, Some(path)) => pipeline::input::mp4::Source::File(path.into()),
         };
 
-        let input_type = pipeline::InputType {
-            input_id: input_id.clone().into(),
-            video: Some(()),
-            audio: None,
-        };
-
         Ok(pipeline::RegisterInputOptions {
             input_id: input_id.clone().into(),
             input_options: pipeline::input::InputOptions::Mp4(pipeline::input::mp4::Mp4Options {
@@ -116,7 +101,6 @@ impl TryFrom<register_request::Mp4> for pipeline::RegisterInputOptions {
                 }),
                 audio: None,
             },
-            input_type,
         })
     }
 }


### PR DESCRIPTION
- Refactor queues to store just one HashMap
- use chrono::Duration for offset calculations (supports negative values)
- remove code from mp4 code that simulates real-time
- add queue between decoder and queue
  - decoder <-> queue - bounded channel 10
  - mp4 <-> decoder - bounded channel 10
  - rtp - for now  unbounded
- ~~[REGRESSION] I removed sleep which ensured buffer was filled. (I'm working on that, but I'm not sure if this will be part of this PR or a follow up)~~
  - resolved in https://github.com/membraneframework/video_compositor/pull/383/commits/9c85719dc90b778e256d782b85729ff3144ade27

For now, I just did minimal testing + ~~I'm still looking into replacement for sleep~~, but I think this PR is complete enough for review.