### PR TITLE
Implement control flow for elements after queue

### DIFF
--- a/compositor_pipeline/src/pipeline/encoder/ffmpeg_h264.rs
+++ b/compositor_pipeline/src/pipeline/encoder/ffmpeg_h264.rs
@@ -97,8 +97,8 @@ impl LibavH264Encoder {
     pub fn new(
         options: Options,
     ) -> Result<(Self, Box<dyn Iterator<Item = EncodedChunk> + Send>), EncoderInitError> {
-        let (frame_sender, frame_receiver) = crossbeam_channel::unbounded();
-        let (packet_sender, packet_receiver) = crossbeam_channel::unbounded();
+        let (frame_sender, frame_receiver) = crossbeam_channel::bounded(5);
+        let (packet_sender, packet_receiver) = crossbeam_channel::bounded(5);
         let (result_sender, result_receiver) = crossbeam_channel::bounded(0);
 
         let options_clone = options.clone();
@@ -205,11 +205,6 @@ impl LibavH264Encoder {
                 Ok(Message::Stop) => break,
                 Err(_) => break,
             };
-
-            if frame_receiver.len() > 20 {
-                warn!("Dropping frame: render queue is too long.",);
-                continue;
-            }
 
             let mut av_frame = frame::Video::new(
                 Pixel::YUV420P,

--- a/compositor_pipeline/src/pipeline/output/rtp.rs
+++ b/compositor_pipeline/src/pipeline/output/rtp.rs
@@ -1,6 +1,10 @@
 use compositor_render::OutputId;
 use log::{debug, error};
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    thread,
+    time::{Duration, Instant},
+};
 
 use rand::Rng;
 use rtp::packetizer::Payloader;
@@ -10,6 +14,9 @@ use crate::{
     error::OutputInitError,
     pipeline::structs::{EncodedChunk, VideoCodec},
 };
+
+/// Hot much into the future we can send data (assume sync on first frame)
+const RTP_MAX_BUFFER_DURATION: Duration = Duration::from_secs(5);
 
 #[derive(Debug)]
 pub struct RtpSender {
@@ -23,6 +30,8 @@ pub struct RtpContext {
     next_sequence_number: u16,
     payloader: rtp::codecs::h264::H264Payloader,
     socket: std::net::UdpSocket,
+    first_packet_instant: Option<Instant>,
+    first_packet_pts: Option<Duration>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -59,6 +68,8 @@ impl RtpSender {
             next_sequence_number,
             payloader,
             socket,
+            first_packet_instant: None,
+            first_packet_pts: None,
         };
 
         let sender_thread = std::thread::Builder::new()
@@ -81,6 +92,20 @@ impl RtpSender {
     fn send_data(context: &mut RtpContext, packet: EncodedChunk) {
         // TODO: check if this is h264
         let EncodedChunk { data, pts, .. } = packet;
+
+        let first_packet_instant = context
+            .first_packet_instant
+            .get_or_insert_with(Instant::now);
+        let first_packet_pts = context.first_packet_pts.get_or_insert(pts);
+
+        let max_pts_to_send =
+            first_packet_instant.elapsed() + RTP_MAX_BUFFER_DURATION + *first_packet_pts;
+        if max_pts_to_send < pts {
+            // If current PTS is significantly higher than the value than PTS value that
+            // should represent now, then wait.
+            // This step is necessary on all outputs streams without control flow.
+            thread::sleep(pts.saturating_sub(max_pts_to_send))
+        }
 
         let payloads = match context.payloader.payload(1500, &data) {
             Ok(p) => p,

--- a/compositor_pipeline/src/pipeline/pipeline_input.rs
+++ b/compositor_pipeline/src/pipeline/pipeline_input.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use compositor_render::InputId;
+
 use crate::error::RegisterInputError;
 
 use super::{
@@ -8,14 +10,13 @@ use super::{
 };
 
 pub(super) fn new_pipeline_input(
+    input_id: &InputId,
     opts: RegisterInputOptions,
     download_dir: &Path,
 ) -> Result<(PipelineInput, DecodedDataReceiver, Option<Port>), RegisterInputError> {
     let RegisterInputOptions {
-        input_id,
         input_options,
         decoder_options,
-        ..
     } = opts;
 
     let (input, chunks_receiver, port) = input::Input::new(input_options, download_dir)

--- a/compositor_pipeline/src/pipeline/pipeline_output.rs
+++ b/compositor_pipeline/src/pipeline/pipeline_output.rs
@@ -1,0 +1,35 @@
+use compositor_render::OutputId;
+
+use crate::error::RegisterOutputError;
+
+use super::{
+    encoder::{Encoder, EncoderOptions},
+    output::Output,
+    PipelineOutput, RegisterOutputOptions,
+};
+
+pub(super) fn new_pipeline_output(
+    output_id: &OutputId,
+    opts: RegisterOutputOptions,
+) -> Result<PipelineOutput, RegisterOutputError> {
+    let RegisterOutputOptions {
+        encoder_options,
+        output_options,
+    } = opts;
+    let EncoderOptions::H264(ref h264_opts) = encoder_options;
+    if h264_opts.resolution.width % 2 != 0 || h264_opts.resolution.height % 2 != 0 {
+        return Err(RegisterOutputError::UnsupportedResolution(
+            output_id.clone(),
+        ));
+    }
+
+    let (encoder, packets) = Encoder::new(encoder_options)
+        .map_err(|e| RegisterOutputError::EncoderError(output_id.clone(), e))?;
+
+    let output = Output::new(output_options, packets)
+        .map_err(|e| RegisterOutputError::OutputError(output_id.clone(), e))?;
+
+    let output = PipelineOutput { encoder, output };
+
+    Ok(output)
+}

--- a/compositor_pipeline/src/queue/audio_queue_thread.rs
+++ b/compositor_pipeline/src/queue/audio_queue_thread.rs
@@ -6,6 +6,7 @@ use std::{
 
 use compositor_render::AudioSamplesSet;
 use crossbeam_channel::{tick, Sender};
+use log::warn;
 
 use super::Queue;
 
@@ -52,7 +53,9 @@ impl AudioQueueThread {
                 .lock()
                 .unwrap()
                 .pop_samples_set((pts, pts + self.chunk_duration), self.clock_start);
-            self.sender.send(samples).unwrap();
+            if self.sender.try_send(samples).is_err() {
+                warn!("Queue failed to push audio chunks. Channel is blocked.")
+            }
             self.chunks_counter += 1;
         }
     }

--- a/src/types/from_register_request.rs
+++ b/src/types/from_register_request.rs
@@ -1,10 +1,13 @@
-use compositor_pipeline::pipeline;
+use compositor_pipeline::pipeline::{self, encoder};
+use compositor_render::scene;
 
 use self::register_request::{AudioChannels, AudioCodec, Port, VideoCodec};
 
-use super::*;
+use super::{register_request::EncoderPreset, *};
 
-impl TryFrom<register_request::RtpInputStream> for pipeline::RegisterInputOptions {
+impl TryFrom<register_request::RtpInputStream>
+    for (compositor_render::InputId, pipeline::RegisterInputOptions)
+{
     type Error = TypeError;
 
     fn try_from(value: register_request::RtpInputStream) -> Result<Self, Self::Error> {
@@ -59,15 +62,19 @@ impl TryFrom<register_request::RtpInputStream> for pipeline::RegisterInputOption
             }),
         };
 
-        Ok(pipeline::RegisterInputOptions {
-            input_id: input_id.into(),
-            input_options,
-            decoder_options,
-        })
+        Ok((
+            input_id.into(),
+            pipeline::RegisterInputOptions {
+                input_options,
+                decoder_options,
+            },
+        ))
     }
 }
 
-impl TryFrom<register_request::Mp4> for pipeline::RegisterInputOptions {
+impl TryFrom<register_request::Mp4>
+    for (compositor_render::InputId, pipeline::RegisterInputOptions)
+{
     type Error = TypeError;
 
     fn try_from(value: register_request::Mp4) -> Result<Self, Self::Error> {
@@ -89,19 +96,23 @@ impl TryFrom<register_request::Mp4> for pipeline::RegisterInputOptions {
             (None, Some(path)) => pipeline::input::mp4::Source::File(path.into()),
         };
 
-        Ok(pipeline::RegisterInputOptions {
-            input_id: input_id.clone().into(),
-            input_options: pipeline::input::InputOptions::Mp4(pipeline::input::mp4::Mp4Options {
-                input_id: input_id.into(),
-                source,
-            }),
-            decoder_options: pipeline::decoder::DecoderOptions {
-                video: Some(pipeline::decoder::VideoDecoderOptions {
-                    codec: pipeline::VideoCodec::H264,
-                }),
-                audio: None,
+        Ok((
+            input_id.clone().into(),
+            pipeline::RegisterInputOptions {
+                input_options: pipeline::input::InputOptions::Mp4(
+                    pipeline::input::mp4::Mp4Options {
+                        input_id: input_id.into(),
+                        source,
+                    },
+                ),
+                decoder_options: pipeline::decoder::DecoderOptions {
+                    video: Some(pipeline::decoder::VideoDecoderOptions {
+                        codec: pipeline::VideoCodec::H264,
+                    }),
+                    audio: None,
+                },
             },
-        })
+        ))
     }
 }
 
@@ -164,13 +175,49 @@ impl From<AudioChannels> for pipeline::AudioChannels {
     }
 }
 
-impl From<RegisterOutputRequest> for pipeline::output::OutputOptions {
-    fn from(value: RegisterOutputRequest) -> Self {
-        pipeline::output::OutputOptions::Rtp(pipeline::output::rtp::RtpSenderOptions {
-            codec: compositor_pipeline::pipeline::VideoCodec::H264,
-            ip: value.ip,
-            port: value.port,
-            output_id: value.output_id.into(),
-        })
+impl TryFrom<RegisterOutputRequest>
+    for (
+        compositor_render::OutputId,
+        pipeline::RegisterOutputOptions,
+        scene::Component,
+    )
+{
+    type Error = TypeError;
+
+    fn try_from(request: RegisterOutputRequest) -> Result<Self, Self::Error> {
+        let output_options =
+            pipeline::output::OutputOptions::Rtp(pipeline::output::rtp::RtpSenderOptions {
+                codec: compositor_pipeline::pipeline::VideoCodec::H264,
+                ip: request.ip,
+                port: request.port,
+                output_id: request.output_id.clone().into(),
+            });
+        let preset = match request.encoder_preset.unwrap_or(EncoderPreset::Fast) {
+            EncoderPreset::Ultrafast => encoder::ffmpeg_h264::EncoderPreset::Ultrafast,
+            EncoderPreset::Superfast => encoder::ffmpeg_h264::EncoderPreset::Superfast,
+            EncoderPreset::Veryfast => encoder::ffmpeg_h264::EncoderPreset::Veryfast,
+            EncoderPreset::Faster => encoder::ffmpeg_h264::EncoderPreset::Faster,
+            EncoderPreset::Fast => encoder::ffmpeg_h264::EncoderPreset::Fast,
+            EncoderPreset::Medium => encoder::ffmpeg_h264::EncoderPreset::Medium,
+            EncoderPreset::Slow => encoder::ffmpeg_h264::EncoderPreset::Slow,
+            EncoderPreset::Slower => encoder::ffmpeg_h264::EncoderPreset::Slower,
+            EncoderPreset::Veryslow => encoder::ffmpeg_h264::EncoderPreset::Veryslow,
+            EncoderPreset::Placebo => encoder::ffmpeg_h264::EncoderPreset::Placebo,
+        };
+
+        let encoder_options = encoder::EncoderOptions::H264(encoder::ffmpeg_h264::Options {
+            preset,
+            resolution: request.resolution.into(),
+            output_id: request.output_id.clone().into(),
+        });
+
+        Ok((
+            request.output_id.into(),
+            pipeline::RegisterOutputOptions {
+                encoder_options,
+                output_options,
+            },
+            request.initial_scene.try_into()?,
+        ))
     }
 }

--- a/src/types/register_request.rs
+++ b/src/types/register_request.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use compositor_pipeline::pipeline::encoder;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -137,26 +136,4 @@ pub enum EncoderPreset {
     Slower,
     Veryslow,
     Placebo,
-}
-
-impl From<RegisterOutputRequest> for encoder::EncoderOptions {
-    fn from(request: RegisterOutputRequest) -> Self {
-        let preset = match request.encoder_preset.unwrap_or(EncoderPreset::Fast) {
-            EncoderPreset::Ultrafast => encoder::ffmpeg_h264::EncoderPreset::Ultrafast,
-            EncoderPreset::Superfast => encoder::ffmpeg_h264::EncoderPreset::Superfast,
-            EncoderPreset::Veryfast => encoder::ffmpeg_h264::EncoderPreset::Veryfast,
-            EncoderPreset::Faster => encoder::ffmpeg_h264::EncoderPreset::Faster,
-            EncoderPreset::Fast => encoder::ffmpeg_h264::EncoderPreset::Fast,
-            EncoderPreset::Medium => encoder::ffmpeg_h264::EncoderPreset::Medium,
-            EncoderPreset::Slow => encoder::ffmpeg_h264::EncoderPreset::Slow,
-            EncoderPreset::Slower => encoder::ffmpeg_h264::EncoderPreset::Slower,
-            EncoderPreset::Veryslow => encoder::ffmpeg_h264::EncoderPreset::Veryslow,
-            EncoderPreset::Placebo => encoder::ffmpeg_h264::EncoderPreset::Placebo,
-        };
-        Self::H264(encoder::ffmpeg_h264::Options {
-            preset,
-            resolution: request.resolution.into(),
-            output_id: request.output_id.into(),
-        })
-    }
 }


### PR DESCRIPTION
The main change here is changing `send` in queue to `try_send`/`send_deadline`. Other changes in this PR are only partially related to control flow:

- remove code that drops output frames from the pipeline and encoder
- change all unbound queues to bound(5)
- refactor output registration code (just moving stuff around, no changes in behavior)
- for audio there is large buffer, so just try_send is fine
- for video, we have very small buffers, so `send_deadline` needs to be used to check against buffer size how long we can wait.