### PR TITLE
Add AAC decoding for MP4 files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -408,6 +409,7 @@ dependencies = [
  "chrono",
  "compositor_render",
  "crossbeam-channel",
+ "fdk-aac-sys",
  "ffmpeg-next",
  "log",
  "mp4",
@@ -417,6 +419,7 @@ dependencies = [
  "rtcp",
  "rtp",
  "socket2",
+ "symphonia",
  "thiserror",
  "webrtc-util",
 ]
@@ -642,6 +645,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209098dd6dfc4445aa6111f0e98653ac323eaa4dfd212c9ca3931bf9955c31bd"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fdk-aac-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24516d2611506d5cb1833555adc75f6baf9fe2706b9c13e6fc33a6b22c51ca83"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1188,6 +1200,15 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "jpeg-decoder"
@@ -2458,6 +2479,78 @@ checksum = "3b7c73c813353c347272919aa1af2885068b05e625e5532b43049e4f641ae77f"
 dependencies = [
  "yazi",
  "zeno",
+]
+
+[[package]]
+name = "symphonia"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e48dba70095f265fdb269b99619b95d04c89e619538138383e63310b14d941"
+dependencies = [
+ "lazy_static",
+ "symphonia-codec-aac",
+ "symphonia-core",
+ "symphonia-format-isomp4",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68bdd75b25ce4b84b12a4bd20bfea2460c2dbd7fc1d227ef5533504d3168109d"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c73eb88fee79705268cc7b742c7bc93a7b76e092ab751d0833866970754142"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf14bae5cf352032416bc64151e5d6242d29d33cbf3238513b44d4427a1efb"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c3e1937e31d0e068bbe829f66b2f2bfaa28d056365279e0ef897172c3320c0"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a450ca645b80d69aff8b35576cbfdc7f20940b29998202aab910045714c951f8"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]

--- a/compositor_pipeline/Cargo.toml
+++ b/compositor_pipeline/Cargo.toml
@@ -21,4 +21,5 @@ rand = { workspace = true }
 mp4 = "0.14.0"
 reqwest = { workspace = true }
 chrono = { workspace = true }
-
+symphonia = { version = "0.5.3", default-features = false, features = ["isomp4", "aac"] }
+fdk-aac-sys = "0.5.0"

--- a/compositor_pipeline/src/error.rs
+++ b/compositor_pipeline/src/error.rs
@@ -6,7 +6,7 @@ use compositor_render::{
     InputId, OutputId,
 };
 
-use crate::pipeline::VideoCodec;
+use crate::pipeline::{decoder::fdk_aac, VideoCodec};
 
 #[derive(Debug, thiserror::Error)]
 pub enum RegisterInputError {
@@ -84,6 +84,8 @@ pub enum DecoderInitError {
     FfmpegError(#[from] ffmpeg_next::Error),
     #[error(transparent)]
     OpusError(#[from] opus::Error),
+    #[error(transparent)]
+    AacError(#[from] fdk_aac::AacDecoderError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -23,7 +23,6 @@ use crate::error::{
 };
 use crate::queue::Queue;
 
-use self::decoder::DecoderOptions;
 use self::encoder::EncoderOptions;
 use self::input::InputOptions;
 use self::output::OutputOptions;
@@ -51,7 +50,6 @@ pub enum RequestedPort {
 
 pub struct RegisterInputOptions {
     pub input_options: InputOptions,
-    pub decoder_options: DecoderOptions,
 }
 
 pub struct RegisterOutputOptions {

--- a/compositor_pipeline/src/pipeline/decoder/fdk_aac.rs
+++ b/compositor_pipeline/src/pipeline/decoder/fdk_aac.rs
@@ -1,0 +1,202 @@
+use compositor_render::{AudioSamples, AudioSamplesBatch, InputId};
+use crossbeam_channel::{Receiver, Sender};
+use fdk_aac_sys as fdk;
+
+use crate::pipeline::structs::{EncodedChunk, EncodedChunkKind};
+
+use super::AacDecoderOptions;
+
+struct Decoder(*mut fdk::AAC_DECODER_INSTANCE);
+
+#[derive(Debug, thiserror::Error)]
+pub enum AacDecoderError {
+    #[error("The internal fdk decoder returned an error: {0:?}.")]
+    FdkDecoderError(fdk::AAC_DECODER_ERROR),
+
+    #[error("The channel config in the aac audio is unsupported.")]
+    UnsupportedChannelConfig,
+
+    #[error("The aac decoder cannot decode chunks with kind {0:?}.")]
+    UnsupportedChunkKind(EncodedChunkKind),
+}
+
+impl Decoder {
+    fn new(options: AacDecoderOptions) -> Result<Self, AacDecoderError> {
+        // MP4_RAW should cover a huge majority of MP4 AAC streams (95+%), and detecting which transport
+        // is used in the mp4 seems to be very hard
+        let dec = unsafe { fdk::aacDecoder_Open(fdk::TRANSPORT_TYPE_TT_MP4_RAW, 1) };
+        let dec = Decoder(dec);
+
+        if let Some(config) = options.asc {
+            let result = unsafe {
+                fdk::aacDecoder_ConfigRaw(
+                    dec.0,
+                    &mut config.to_vec().as_mut_ptr(),
+                    &(config.len() as u32),
+                )
+            };
+
+            if result != fdk::AAC_DECODER_ERROR_AAC_DEC_OK {
+                return Err(AacDecoderError::FdkDecoderError(result));
+            }
+        }
+
+        let info = unsafe { *fdk::aacDecoder_GetStreamInfo(dec.0) };
+        if info.channelConfig != 1 && info.channelConfig != 2 {
+            return Err(AacDecoderError::UnsupportedChannelConfig);
+        }
+
+        Ok(dec)
+    }
+
+    fn decode_chunk(&self, chunk: EncodedChunk) -> Result<Vec<AudioSamplesBatch>, AacDecoderError> {
+        if chunk.kind != EncodedChunkKind::Audio(crate::pipeline::AudioCodec::Aac) {
+            return Err(AacDecoderError::UnsupportedChunkKind(chunk.kind));
+        }
+
+        let buffer_size = chunk.data.len() as u32;
+        let mut bytes_valid = buffer_size;
+        let mut buffer = chunk.data.to_vec();
+        let mut output_buffer = Vec::new();
+
+        while bytes_valid > 0 {
+            // This fills the decoder with data.
+            // It will adjust `bytes_valid` on its own based on how many bytes are left in the
+            // buffer.
+            let result = unsafe {
+                fdk::aacDecoder_Fill(
+                    self.0,
+                    &mut buffer.as_mut_ptr(),
+                    &buffer_size,
+                    &mut bytes_valid,
+                )
+            };
+
+            if result != fdk::AAC_DECODER_ERROR_AAC_DEC_OK {
+                return Err(AacDecoderError::FdkDecoderError(result));
+            }
+
+            let info = unsafe { *fdk::aacDecoder_GetStreamInfo(self.0) };
+
+            // The decoder should output `info.aacSamplesPerFrame` for each channel
+            let mut decoded_samples: Vec<fdk::INT_PCM> =
+                vec![0; (info.aacSamplesPerFrame * info.channelConfig) as usize];
+
+            let result = unsafe {
+                fdk::aacDecoder_DecodeFrame(
+                    self.0,
+                    decoded_samples.as_mut_ptr(),
+                    decoded_samples.len() as i32,
+                    0,
+                )
+            };
+
+            if result == fdk::AAC_DECODER_ERROR_AAC_DEC_NOT_ENOUGH_BITS {
+                // Need to put more data in
+                continue;
+            }
+
+            if result != fdk::AAC_DECODER_ERROR_AAC_DEC_OK {
+                return Err(AacDecoderError::FdkDecoderError(result));
+            }
+
+            let samples = match info.channelConfig {
+                1 => AudioSamples::Mono(decoded_samples),
+                2 => AudioSamples::Stereo(
+                    decoded_samples
+                        .chunks_exact(2)
+                        .map(|c| (c[0], c[1]))
+                        .collect(),
+                ),
+
+                _ => return Err(AacDecoderError::UnsupportedChannelConfig),
+            };
+
+            // We need the info before the decode call to get the channel info, but the sample rate
+            // can change during `aacDecoder_DecodeFrame`
+            let info = unsafe { *fdk::aacDecoder_GetStreamInfo(self.0) };
+
+            output_buffer.push(AudioSamplesBatch {
+                samples: samples.into(),
+                start_pts: chunk.pts,
+                sample_rate: info.sampleRate as u32,
+            });
+        }
+
+        Ok(output_buffer)
+    }
+}
+
+impl Drop for Decoder {
+    fn drop(&mut self) {
+        unsafe {
+            fdk::aacDecoder_Close(self.0);
+        }
+    }
+}
+
+pub struct FdkAacDecoder;
+
+impl FdkAacDecoder {
+    pub(super) fn new(
+        options: AacDecoderOptions,
+        chunks_receiver: Receiver<EncodedChunk>,
+        samples_sender: Sender<AudioSamplesBatch>,
+        input_id: InputId,
+    ) -> Result<Self, AacDecoderError> {
+        let (result_sender, result_receiver) = crossbeam_channel::bounded(1);
+
+        std::thread::Builder::new()
+            .name(format!("fdk aac decoder {}", input_id.0))
+            .spawn(move || {
+                start_decoding(
+                    options,
+                    samples_sender,
+                    chunks_receiver,
+                    input_id,
+                    result_sender,
+                )
+            })
+            .unwrap();
+
+        result_receiver.recv().unwrap()?;
+
+        Ok(Self)
+    }
+}
+
+fn start_decoding(
+    options: AacDecoderOptions,
+    samples_sender: Sender<AudioSamplesBatch>,
+    chunks_receiver: Receiver<EncodedChunk>,
+    input_id: InputId,
+    result_sender: Sender<Result<(), AacDecoderError>>,
+) {
+    let decoder = match Decoder::new(options) {
+        Ok(decoder) => {
+            result_sender.send(Ok(())).unwrap();
+            decoder
+        }
+
+        Err(e) => {
+            result_sender.send(Err(e)).unwrap();
+            return;
+        }
+    };
+
+    for chunk in chunks_receiver {
+        let decoded_samples = match decoder.decode_chunk(chunk) {
+            Ok(samples) => samples,
+            Err(e) => {
+                log::error!("Failed to decode AAC packet: {e}");
+                continue;
+            }
+        };
+
+        for batch in decoded_samples {
+            if let Err(err) = samples_sender.send(batch) {
+                log::error!("Error enqueueing audio samples for input {input_id}: {err}",);
+            }
+        }
+    }
+}

--- a/compositor_pipeline/src/pipeline/input.rs
+++ b/compositor_pipeline/src/pipeline/input.rs
@@ -7,7 +7,7 @@ use rtp::{RtpReceiver, RtpReceiverOptions};
 
 use self::mp4::{Mp4, Mp4Options};
 
-use super::{structs::EncodedChunk, Port};
+use super::{decoder::DecoderOptions, structs::EncodedChunk, Port};
 
 pub mod mp4;
 pub mod rtp;
@@ -21,16 +21,24 @@ impl Input {
     pub fn new(
         options: InputOptions,
         download_dir: &Path,
-    ) -> Result<(Self, ChunksReceiver, Option<Port>), InputInitError> {
+    ) -> Result<(Self, ChunksReceiver, DecoderOptions, Option<Port>), InputInitError> {
         match options {
             InputOptions::Rtp(opts) => Ok(RtpReceiver::new(opts).map(
-                |(receiver, chunks_receiver, port)| {
-                    (Self::Rtp(receiver), chunks_receiver, Some(port))
+                |(receiver, chunks_receiver, decoder_options, port)| {
+                    (
+                        Self::Rtp(receiver),
+                        chunks_receiver,
+                        decoder_options,
+                        Some(port),
+                    )
                 },
             )?),
 
-            InputOptions::Mp4(opts) => Ok(Mp4::new(opts, download_dir)
-                .map(|(mp4, chunks_receiver)| (Self::Mp4(mp4), chunks_receiver, None))?),
+            InputOptions::Mp4(opts) => Ok(Mp4::new(opts, download_dir).map(
+                |(mp4, chunks_receiver, decoder_options)| {
+                    (Self::Mp4(mp4), chunks_receiver, decoder_options, None)
+                },
+            )?),
         }
     }
 }

--- a/compositor_pipeline/src/pipeline/pipeline_input.rs
+++ b/compositor_pipeline/src/pipeline/pipeline_input.rs
@@ -14,13 +14,11 @@ pub(super) fn new_pipeline_input(
     opts: RegisterInputOptions,
     download_dir: &Path,
 ) -> Result<(PipelineInput, DecodedDataReceiver, Option<Port>), RegisterInputError> {
-    let RegisterInputOptions {
-        input_options,
-        decoder_options,
-    } = opts;
+    let RegisterInputOptions { input_options } = opts;
 
-    let (input, chunks_receiver, port) = input::Input::new(input_options, download_dir)
-        .map_err(|e| RegisterInputError::InputError(input_id.clone(), e))?;
+    let (input, chunks_receiver, decoder_options, port) =
+        input::Input::new(input_options, download_dir)
+            .map_err(|e| RegisterInputError::InputError(input_id.clone(), e))?;
 
     let (decoder, decoded_data_receiver) =
         decoder::Decoder::new(input_id.clone(), chunks_receiver, decoder_options)

--- a/compositor_pipeline/src/pipeline/structs.rs
+++ b/compositor_pipeline/src/pipeline/structs.rs
@@ -59,6 +59,7 @@ pub enum VideoCodec {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AudioCodec {
+    Aac,
     Opus,
 }
 


### PR DESCRIPTION
This PR uses the FDK deocder for decoding and Symphonia for demuxing. Most MP4s should work in this configuration. The remaining work is:

- allow OPUS decoding for MP4s
- allow AAC decoding for RTP

Closes #374 