### PR TITLE
Implement RTP over TCP on input

### DIFF
--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -41,8 +41,10 @@ pub use self::structs::AudioChannels;
 pub use self::structs::AudioCodec;
 pub use self::structs::VideoCodec;
 
+#[derive(Debug)]
 pub struct Port(pub u16);
 
+#[derive(Debug, Clone, Copy)]
 pub enum RequestedPort {
     Exact(u16),
     Range((u16, u16)),

--- a/compositor_pipeline/src/pipeline/input/rtp.rs
+++ b/compositor_pipeline/src/pipeline/input/rtp.rs
@@ -9,17 +9,22 @@ use crate::pipeline::{
     structs::EncodedChunkKind,
     Port, RequestedPort,
 };
-use bytes::BytesMut;
 use compositor_render::InputId;
-use crossbeam_channel::{unbounded, Receiver, Sender};
-use log::{error, warn};
+use crossbeam_channel::{unbounded, Receiver};
+use log::{error, info, warn};
 use webrtc_util::Unmarshal;
 
-use self::depayloader::{Depayloader, DepayloaderNewError};
+use self::{
+    depayloader::{Depayloader, DepayloaderNewError},
+    tcp_server::run_tcp_server_receiver,
+    udp::run_udp_receiver,
+};
 
 use super::ChunksReceiver;
 
 mod depayloader;
+mod tcp_server;
+mod udp;
 
 #[derive(Debug, thiserror::Error)]
 pub enum RtpReceiverError {
@@ -41,6 +46,7 @@ pub enum RtpReceiverError {
 
 pub struct RtpReceiverOptions {
     pub port: RequestedPort,
+    pub transport_protocol: TransportProtocol,
     pub input_id: compositor_render::InputId,
     pub stream: RtpStream,
 }
@@ -49,6 +55,12 @@ pub struct RtpReceiverOptions {
 pub struct VideoStream {
     pub options: decoder::VideoDecoderOptions,
     pub payload_type: u8,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum TransportProtocol {
+    Udp,
+    TcpServer,
 }
 
 #[derive(Debug, Clone)]
@@ -76,6 +88,67 @@ impl RtpReceiver {
         opts: RtpReceiverOptions,
     ) -> Result<(Self, ChunksReceiver, DecoderOptions, Port), RtpReceiverError> {
         let should_close = Arc::new(AtomicBool::new(false));
+
+        let (port, receiver_thread, packets_rx) = match opts.transport_protocol {
+            TransportProtocol::Udp => Self::start_udp_reader(&opts, should_close.clone())?,
+            TransportProtocol::TcpServer => {
+                Self::start_tcp_server_reader(&opts, should_close.clone())?
+            }
+        };
+
+        let depayloader = Depayloader::new(&opts.stream)?;
+
+        let (depayloader_thread, chunks_receiver) =
+            DepayloaderThread::new(&opts.input_id, packets_rx, depayloader);
+
+        Ok((
+            Self {
+                port: port.0,
+                receiver_thread: Some(receiver_thread),
+                should_close,
+                _depayloader_thread: Some(depayloader_thread),
+            },
+            chunks_receiver,
+            DecoderOptions {
+                video: opts.stream.video.map(|v| v.options),
+                audio: opts.stream.audio.map(|a| a.options),
+            },
+            port,
+        ))
+    }
+
+    fn start_tcp_server_reader(
+        opts: &RtpReceiverOptions,
+        should_close: Arc<AtomicBool>,
+    ) -> Result<(Port, thread::JoinHandle<()>, Receiver<bytes::Bytes>), RtpReceiverError> {
+        let (packets_tx, packets_rx) = unbounded();
+        info!("Starting tcp socket");
+
+        let socket = socket2::Socket::new(
+            socket2::Domain::IPV4,
+            socket2::Type::STREAM,
+            Some(socket2::Protocol::TCP),
+        )
+        .map_err(RtpReceiverError::SocketOptions)?;
+
+        let port = Self::bind_to_port(opts.port, &socket)?;
+
+        socket.listen(1).map_err(RtpReceiverError::SocketBind)?;
+
+        let socket = std::net::TcpListener::from(socket);
+
+        let receiver_thread = thread::Builder::new()
+            .name(format!("RTP TCP server receiver {}", opts.input_id))
+            .spawn(move || run_tcp_server_receiver(socket, packets_tx, should_close))
+            .unwrap();
+
+        Ok((port, receiver_thread, packets_rx))
+    }
+
+    fn start_udp_reader(
+        opts: &RtpReceiverOptions,
+        should_close: Arc<AtomicBool>,
+    ) -> Result<(Port, thread::JoinHandle<()>, Receiver<bytes::Bytes>), RtpReceiverError> {
         let (packets_tx, packets_rx) = unbounded();
 
         let socket = socket2::Socket::new(
@@ -95,7 +168,27 @@ impl RtpReceiver {
             }
         }
 
-        let port = match opts.port {
+        let port = Self::bind_to_port(opts.port, &socket)?;
+
+        socket
+            .set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .map_err(RtpReceiverError::SocketOptions)?;
+
+        let socket = std::net::UdpSocket::from(socket);
+
+        let receiver_thread = thread::Builder::new()
+            .name(format!("RTP UDP receiver {}", opts.input_id))
+            .spawn(move || run_udp_receiver(socket, packets_tx, should_close))
+            .unwrap();
+
+        Ok((port, receiver_thread, packets_rx))
+    }
+
+    fn bind_to_port(
+        requested_port: RequestedPort,
+        socket: &socket2::Socket,
+    ) -> Result<Port, RtpReceiverError> {
+        let port = match requested_port {
             RequestedPort::Exact(port) => {
                 socket
                     .bind(
@@ -135,68 +228,7 @@ impl RtpReceiver {
                 }
             }
         };
-
-        socket
-            .set_read_timeout(Some(std::time::Duration::from_millis(50)))
-            .map_err(RtpReceiverError::SocketOptions)?;
-
-        let socket = std::net::UdpSocket::from(socket);
-
-        let should_close2 = should_close.clone();
-
-        let receiver_thread = thread::Builder::new()
-            .name(format!("RTP receiver {}", opts.input_id))
-            .spawn(move || RtpReceiver::rtp_receiver(socket, packets_tx, should_close2))
-            .unwrap();
-
-        let depayloader = Depayloader::new(&opts.stream)?;
-
-        let (depayloader_thread, chunks_receiver) =
-            DepayloaderThread::new(&opts.input_id, packets_rx, depayloader);
-
-        Ok((
-            Self {
-                port,
-                receiver_thread: Some(receiver_thread),
-                should_close,
-                _depayloader_thread: Some(depayloader_thread),
-            },
-            chunks_receiver,
-            DecoderOptions {
-                video: opts.stream.video.map(|v| v.options),
-                audio: opts.stream.audio.map(|a| a.options),
-            },
-            Port(port),
-        ))
-    }
-
-    fn rtp_receiver(
-        socket: std::net::UdpSocket,
-        packets_tx: Sender<bytes::Bytes>,
-        should_close: Arc<AtomicBool>,
-    ) {
-        let mut buffer = BytesMut::zeroed(65536);
-
-        loop {
-            if should_close.load(std::sync::atomic::Ordering::Relaxed) {
-                return;
-            }
-
-            // This can be faster if we batched sending the packets through the channel
-            let (received_bytes, _) = match socket.recv_from(&mut buffer) {
-                Ok(n) => n,
-                Err(e) => match e.kind() {
-                    std::io::ErrorKind::WouldBlock => continue,
-                    _ => {
-                        error!("Error while receiving UDP packet: {}", e);
-                        continue;
-                    }
-                },
-            };
-
-            let packet: bytes::Bytes = buffer[..received_bytes].to_vec().into();
-            packets_tx.send(packet).unwrap();
-        }
+        Ok(Port(port))
     }
 }
 

--- a/compositor_pipeline/src/pipeline/input/rtp/tcp_server.rs
+++ b/compositor_pipeline/src/pipeline/input/rtp/tcp_server.rs
@@ -1,0 +1,101 @@
+use std::{
+    io::{self, Read},
+    net::TcpStream,
+    sync::{atomic::AtomicBool, Arc},
+    thread,
+    time::Duration,
+};
+
+use bytes::BytesMut;
+use compositor_render::error::ErrorStack;
+use crossbeam_channel::Sender;
+use log::info;
+
+pub(super) fn run_tcp_server_receiver(
+    socket: std::net::TcpListener,
+    packets_tx: Sender<bytes::Bytes>,
+    should_close: Arc<AtomicBool>,
+) {
+    let mut buffer = BytesMut::zeroed(65536);
+    // make accept non blocking so we have a chance to handle should_close value
+    socket
+        .set_nonblocking(true)
+        .expect("Cannot set non-blocking");
+
+    loop {
+        if should_close.load(std::sync::atomic::Ordering::Relaxed) {
+            return;
+        }
+
+        // accept only one connection at the time
+        let accept_result = socket.accept();
+        let Ok((socket, _)) = accept_result else {
+            thread::sleep(Duration::from_millis(50));
+            continue;
+        };
+        info!("Connection accepted");
+
+        socket
+            .set_read_timeout(Some(Duration::from_millis(50)))
+            .expect("Cannot set read timeout");
+
+        loop {
+            let mut len_bytes = [0u8; 2];
+            if let Err(err) = (&socket).read_exact_with_should_close(&mut len_bytes, &should_close)
+            {
+                maybe_log_err(err);
+                break;
+            };
+            let len = u16::from_be_bytes(len_bytes) as usize;
+
+            if let Err(err) =
+                (&socket).read_exact_with_should_close(&mut buffer[..len], &should_close)
+            {
+                maybe_log_err(err);
+                break;
+            };
+            packets_tx
+                .send(bytes::Bytes::copy_from_slice(&buffer[..len]))
+                .unwrap();
+        }
+    }
+}
+
+fn maybe_log_err(err: io::Error) {
+    if err.kind() != io::ErrorKind::WouldBlock {
+        log::error!(
+            "Unknown error when reading from TCP socket. {}",
+            ErrorStack::new(&err).into_string()
+        );
+    }
+}
+
+trait TcpStreamExt {
+    fn read_exact_with_should_close(
+        &mut self,
+        buf: &mut [u8],
+        should_close: &Arc<AtomicBool>,
+    ) -> io::Result<()>;
+}
+
+impl TcpStreamExt for &TcpStream {
+    fn read_exact_with_should_close(
+        &mut self,
+        buf: &mut [u8],
+        should_close: &Arc<AtomicBool>,
+    ) -> io::Result<()> {
+        loop {
+            match self.read_exact(buf) {
+                Ok(val) => return Ok(val),
+                Err(err) => match err.kind() {
+                    std::io::ErrorKind::WouldBlock
+                        if should_close.load(std::sync::atomic::Ordering::Relaxed) =>
+                    {
+                        continue;
+                    }
+                    _ => return io::Result::Err(err),
+                },
+            };
+        }
+    }
+}

--- a/compositor_pipeline/src/pipeline/input/rtp/udp.rs
+++ b/compositor_pipeline/src/pipeline/input/rtp/udp.rs
@@ -1,0 +1,34 @@
+use std::sync::{atomic::AtomicBool, Arc};
+
+use bytes::BytesMut;
+use crossbeam_channel::Sender;
+
+pub(super) fn run_udp_receiver(
+    socket: std::net::UdpSocket,
+    packets_tx: Sender<bytes::Bytes>,
+    should_close: Arc<AtomicBool>,
+) {
+    let mut buffer = BytesMut::zeroed(65536);
+
+    loop {
+        if should_close.load(std::sync::atomic::Ordering::Relaxed) {
+            return;
+        }
+
+        // This can be faster if we batched sending the packets through the channel
+        let (received_bytes, _) = match socket.recv_from(&mut buffer) {
+            Ok(n) => n,
+            Err(e) => match e.kind() {
+                std::io::ErrorKind::WouldBlock => continue,
+                _ => {
+                    log::error!("Error while receiving UDP packet: {}", e);
+                    continue;
+                }
+            },
+        };
+
+        packets_tx
+            .send(bytes::Bytes::copy_from_slice(&buffer[..received_bytes]))
+            .unwrap();
+    }
+}

--- a/examples/rtp_tcp.rs
+++ b/examples/rtp_tcp.rs
@@ -1,0 +1,113 @@
+use anyhow::Result;
+use log::{error, info};
+use serde_json::json;
+use std::{
+    env, fs,
+    process::{Command, Stdio},
+    thread,
+    time::Duration,
+};
+use video_compositor::{config::config, http, logger, types::Resolution};
+
+use crate::common::write_example_sdp_file;
+
+#[path = "./common/common.rs"]
+mod common;
+
+const SAMPLE_FILE_URL: &str = "https://filesamples.com/samples/video/mp4/sample_1280x720.mp4";
+const SAMPLE_FILE_PATH: &str = "examples/assets/sample_1280_720.mp4";
+const VIDEO_RESOLUTION: Resolution = Resolution {
+    width: 1280,
+    height: 720,
+};
+
+fn main() {
+    env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
+    ffmpeg_next::format::network::init();
+    logger::init_logger();
+
+    thread::spawn(|| {
+        if let Err(err) = start_example_client_code() {
+            error!("{err}")
+        }
+    });
+
+    http::Server::new(config().api_port).run();
+}
+
+fn start_example_client_code() -> Result<()> {
+    info!("[example] Start listening on output port.");
+    let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
+    Command::new("ffplay")
+        .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    thread::sleep(Duration::from_secs(2));
+
+    info!("[example] Download sample.");
+    let sample_path = env::current_dir()?.join(SAMPLE_FILE_PATH);
+    fs::create_dir_all(sample_path.parent().unwrap())?;
+    common::ensure_downloaded(SAMPLE_FILE_URL, &sample_path)?;
+
+    info!("[example] Send register input request.");
+    common::post(&json!({
+        "type": "register",
+        "entity_type": "rtp_input_stream",
+        "transport_protocol": "tcp_server",
+        "input_id": "input_1",
+        "port": 8004,
+        "video": {
+            "codec": "h264"
+        }
+    }))?;
+
+    let shader_source = include_str!("./silly.wgsl");
+    info!("[example] Register shader transform");
+    common::post(&json!({
+        "type": "register",
+        "entity_type": "shader",
+        "shader_id": "shader_example_1",
+        "source": shader_source,
+    }))?;
+
+    info!("[example] Send register output request.");
+    common::post(&json!({
+        "type": "register",
+        "entity_type": "output_stream",
+        "output_id": "output_1",
+        "port": 8002,
+        "ip": "127.0.0.1",
+        "resolution": {
+            "width": VIDEO_RESOLUTION.width,
+            "height": VIDEO_RESOLUTION.height,
+        },
+        "encoder_preset": "medium",
+        "initial_scene": {
+            "type": "shader",
+            "id": "shader_node_1",
+            "shader_id": "shader_example_1",
+            "children": [
+                {
+                    "id": "input_1",
+                    "type": "input_stream",
+                    "input_id": "input_1",
+                }
+            ],
+            "resolution": { "width": VIDEO_RESOLUTION.width, "height": VIDEO_RESOLUTION.height },
+        }
+    }))?;
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    info!("[example] Start pipeline");
+    common::post(&json!({
+        "type": "start",
+    }))?;
+
+    let sample_path_str = sample_path.to_string_lossy().to_string();
+    let gst_command = format!("gst-launch-1.0 -v funnel name=fn filesrc location={sample_path_str} ! qtdemux ! h264parse ! rtph264pay config-interval=1 pt=96  ! .send_rtp_sink rtpsession name=session .send_rtp_src ! fn. session.send_rtcp_src ! fn. fn. ! rtpstreampay ! tcpclientsink host=127.0.0.1 port=8004");
+    Command::new("bash").arg("-c").arg(gst_command).spawn()?;
+
+    Ok(())
+}

--- a/schemas/register.schema.json
+++ b/schemas/register.schema.json
@@ -33,6 +33,17 @@
             }
           ]
         },
+        "transport_protocol": {
+          "description": "Transport protocol.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TransportProtocol"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "video": {
           "description": "Parameters of a video source included in the RTP stream.",
           "anyOf": [
@@ -407,6 +418,24 @@
           "type": "integer",
           "format": "uint16",
           "minimum": 0.0
+        }
+      ]
+    },
+    "TransportProtocol": {
+      "oneOf": [
+        {
+          "description": "UDP protocol.",
+          "type": "string",
+          "enum": [
+            "udp"
+          ]
+        },
+        {
+          "description": "TCP protocol where LiveCompositor is a server side of the connection.",
+          "type": "string",
+          "enum": [
+            "tcp_server"
+          ]
         }
       ]
     },

--- a/src/types/register_request.rs
+++ b/src/types/register_request.rs
@@ -28,6 +28,8 @@ pub struct RtpInputStream {
     pub input_id: InputId,
     /// UDP port or port range on which the compositor should listen for the stream.
     pub port: Port,
+    /// Transport protocol.
+    pub transport_protocol: Option<TransportProtocol>,
     /// Parameters of a video source included in the RTP stream.
     pub video: Option<Video>,
     /// Parameters of an audio source included in the RTP stream.
@@ -103,7 +105,16 @@ pub struct Audio {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum TransportProtocol {
+    /// UDP protocol.
+    Udp,
+    /// TCP protocol where LiveCompositor is a server side of the connection.
+    TcpServer,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum AudioChannels {
     /// Mono audio (single channel).
     Mono,


### PR DESCRIPTION
Add `transport_protocol` field to request that registers rtp input stream.  Option for tcp is called `tcp_server` to indicate the direction, but I don't plan to ever implement `tcp_client` variant.