### PR TITLE
Audio output - encoding and RTP sending

### DIFF
--- a/compositor_pipeline/src/error.rs
+++ b/compositor_pipeline/src/error.rs
@@ -85,6 +85,9 @@ pub enum EncoderInitError {
 
     #[error(transparent)]
     FfmpegError(#[from] ffmpeg_next::Error),
+
+    #[error(transparent)]
+    OpusError(#[from] opus::Error),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -291,9 +291,10 @@ impl Pipeline {
                     .get(&output_id)
                     .ok_or_else(|| UpdateSceneError::OutputNotRegistered(output_id.clone()))?
                     .encoder
-            .video
-            .as_ref()
-            .map(|v| v.resolution()) else {
+                    .video
+                    .as_ref()
+                    .map(|v| v.resolution())
+            else {
                 return Err(UpdateSceneError::AudioVideoNotMatching(output_id));
             };
 

--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -25,7 +25,7 @@ use crate::error::{
 };
 use crate::queue::{self, Queue, QueueOptions};
 
-use self::encoder::VideoEncoderOptions;
+use self::encoder::{AudioEncoderPreset, VideoEncoderOptions};
 use self::input::InputOptions;
 use self::output::OutputOptions;
 
@@ -62,6 +62,7 @@ pub struct OutputAudioOptions {
     pub initial: AudioMixingParams,
     pub channels: AudioChannels,
     pub forward_error_correction: bool,
+    pub encoder_preset: AudioEncoderPreset,
 }
 
 #[derive(Debug, Clone)]

--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -323,15 +323,15 @@ impl Pipeline {
         let (frames_sender, frames_receiver) = bounded(1);
         // for 20ms chunks this will be 60 seconds of audio
         let (audio_sender, audio_receiver) = bounded(300);
-        let renderer = self.renderer.clone();
-        let audio_mixer = self.audio_mixer.clone();
-        let outputs = self.outputs.clone();
-        let outputs2 = self.outputs.clone();
-
         self.queue.start(frames_sender, audio_sender);
 
+        let renderer = self.renderer.clone();
+        let outputs = self.outputs.clone();
         thread::spawn(move || Self::run_renderer_thread(frames_receiver, renderer, outputs));
-        thread::spawn(move || Self::run_audio_mixer_thread(audio_mixer, audio_receiver, outputs2));
+
+        let audio_mixer = self.audio_mixer.clone();
+        let outputs = self.outputs.clone();
+        thread::spawn(move || Self::run_audio_mixer_thread(audio_mixer, audio_receiver, outputs));
     }
 
     fn run_renderer_thread(

--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -287,17 +287,17 @@ impl Pipeline {
         scene_root: Component,
     ) -> Result<(), UpdateSceneError> {
         let Some(resolution) = self
-                    .outputs
-                    .lock()
-                    .get(&output_id)
-                    .ok_or_else(|| UpdateSceneError::OutputNotRegistered(output_id.clone()))?
-                    .encoder
-                    .video
-                    .as_ref()
-                    .map(|v| v.resolution())
-            else {
-                return Err(UpdateSceneError::AudioVideoNotMatching(output_id));
-            };
+            .outputs
+            .lock()
+            .get(&output_id)
+            .ok_or_else(|| UpdateSceneError::OutputNotRegistered(output_id.clone()))?
+            .encoder
+            .video
+            .as_ref()
+            .map(|v| v.resolution())
+        else {
+            return Err(UpdateSceneError::AudioVideoNotMatching(output_id));
+        };
 
         info!("Update scene {:#?}", scene_root);
 

--- a/compositor_pipeline/src/pipeline/encoder.rs
+++ b/compositor_pipeline/src/pipeline/encoder.rs
@@ -1,16 +1,19 @@
 use compositor_render::{Frame, Resolution};
+use crossbeam_channel::{unbounded, Sender};
+use log::error;
 
-use crate::error::EncoderInitError;
+use crate::{audio_mixer::types::AudioSamplesBatch, error::EncoderInitError};
 
-use self::ffmpeg_h264::LibavH264Encoder;
+use self::{ffmpeg_h264::LibavH264Encoder, opus_encoder::OpusEncoder};
 
 use super::structs::EncodedChunk;
 
 pub mod ffmpeg_h264;
 pub mod opus_encoder;
 
-pub enum VideoEncoder {
-    H264(LibavH264Encoder),
+pub struct EncoderOptions {
+    pub video: Option<VideoEncoderOptions>,
+    pub audio: Option<AudioEncoderOptions>,
 }
 
 #[derive(Debug, Clone)]
@@ -23,19 +26,80 @@ pub enum AudioEncoderOptions {
     Opus(opus_encoder::Options),
 }
 
-pub struct EncoderOptions {
-    pub video: Option<VideoEncoderOptions>,
-    pub audio: Option<AudioEncoderOptions>,
+#[derive(Debug, Clone)]
+pub enum AudioEncoderPreset {
+    Quality,
+    Voip,
+    LowestLatency,
+}
+
+pub struct Encoder {
+    pub video: Option<VideoEncoder>,
+    audio: Option<AudioEncoder>,
+}
+
+pub enum VideoEncoder {
+    H264(LibavH264Encoder),
+}
+
+pub enum AudioEncoder {
+    Opus(OpusEncoder),
+}
+
+impl Encoder {
+    pub fn new(
+        options: EncoderOptions,
+    ) -> Result<(Self, Box<dyn Iterator<Item = EncodedChunk> + Send>), EncoderInitError> {
+        let (encoded_chunks_sender, encoded_chunks_receiver) = unbounded();
+
+        let video_encoder = match options.video {
+            Some(video_encoder_options) => Some(VideoEncoder::new(
+                video_encoder_options,
+                encoded_chunks_sender.clone(),
+            )?),
+            None => None,
+        };
+
+        let audio_encoder = match options.audio {
+            Some(audio_encoder_options) => Some(AudioEncoder::new(
+                audio_encoder_options,
+                encoded_chunks_sender,
+            )?),
+            None => None,
+        };
+
+        Ok((
+            Self {
+                video: video_encoder,
+                audio: audio_encoder,
+            },
+            Box::new(encoded_chunks_receiver.into_iter()),
+        ))
+    }
+
+    pub fn send_frame(&self, frame: Frame) {
+        match &self.video {
+            Some(video_encoder) => video_encoder.send_frame(frame),
+            None => error!("Non video encoder received frame to send."),
+        }
+    }
+
+    pub fn send_samples_batch(&self, batch: AudioSamplesBatch) {
+        match &self.audio {
+            Some(audio_encoder) => audio_encoder.send_samples_batch(batch),
+            None => error!("Non audio encoder received samples to send."),
+        }
+    }
 }
 
 impl VideoEncoder {
     pub fn new(
         options: VideoEncoderOptions,
-    ) -> Result<(Self, Box<dyn Iterator<Item = EncodedChunk> + Send>), EncoderInitError> {
+        sender: Sender<EncodedChunk>,
+    ) -> Result<Self, EncoderInitError> {
         match options {
             VideoEncoderOptions::H264(options) => {
-                let (encoder, iter) = LibavH264Encoder::new(options)?;
-                Ok((Self::H264(encoder), iter))
+                Ok(Self::H264(LibavH264Encoder::new(options, sender)?))
             }
         }
     }
@@ -49,6 +113,25 @@ impl VideoEncoder {
     pub fn send_frame(&self, frame: Frame) {
         match self {
             Self::H264(encoder) => encoder.send_frame(frame),
+        }
+    }
+}
+
+impl AudioEncoder {
+    fn new(
+        options: AudioEncoderOptions,
+        sender: Sender<EncodedChunk>,
+    ) -> Result<Self, EncoderInitError> {
+        match options {
+            AudioEncoderOptions::Opus(opus_encoder_options) => {
+                OpusEncoder::new(opus_encoder_options, sender).map(AudioEncoder::Opus)
+            }
+        }
+    }
+
+    pub fn send_samples_batch(&self, batch: AudioSamplesBatch) {
+        match self {
+            AudioEncoder::Opus(opus_encoder) => opus_encoder.send_samples_batch(batch),
         }
     }
 }

--- a/compositor_pipeline/src/pipeline/encoder.rs
+++ b/compositor_pipeline/src/pipeline/encoder.rs
@@ -49,6 +49,7 @@ pub enum AudioEncoder {
 impl Encoder {
     pub fn new(
         options: EncoderOptions,
+        sample_rate: u32,
     ) -> Result<(Self, Box<dyn Iterator<Item = EncodedChunk> + Send>), EncoderInitError> {
         let (encoded_chunks_sender, encoded_chunks_receiver) = unbounded();
 
@@ -63,6 +64,7 @@ impl Encoder {
         let audio_encoder = match options.audio {
             Some(audio_encoder_options) => Some(AudioEncoder::new(
                 audio_encoder_options,
+                sample_rate,
                 encoded_chunks_sender,
             )?),
             None => None,
@@ -120,11 +122,12 @@ impl VideoEncoder {
 impl AudioEncoder {
     fn new(
         options: AudioEncoderOptions,
+        sample_rate: u32,
         sender: Sender<EncodedChunk>,
     ) -> Result<Self, EncoderInitError> {
         match options {
             AudioEncoderOptions::Opus(opus_encoder_options) => {
-                OpusEncoder::new(opus_encoder_options, sender).map(AudioEncoder::Opus)
+                OpusEncoder::new(opus_encoder_options, sample_rate, sender).map(AudioEncoder::Opus)
             }
         }
     }

--- a/compositor_pipeline/src/pipeline/encoder/opus_encoder.rs
+++ b/compositor_pipeline/src/pipeline/encoder/opus_encoder.rs
@@ -1,7 +1,156 @@
-use crate::audio_mixer::types::AudioChannels;
+use std::thread::JoinHandle;
+
+use crossbeam_channel::{bounded, Receiver, Sender};
+use log::error;
+
+use crate::{
+    audio_mixer::types::{AudioChannels, AudioSamples, AudioSamplesBatch},
+    error::EncoderInitError,
+    pipeline::{
+        structs::{EncodedChunk, EncodedChunkKind},
+        AudioCodec,
+    },
+};
+
+use super::AudioEncoderPreset;
 
 #[derive(Debug, Clone)]
 pub struct Options {
     pub sample_rate: u32,
     pub channels: AudioChannels,
+    pub preset: AudioEncoderPreset,
+}
+
+pub struct OpusEncoder {
+    samples_batch_sender: Sender<Message>,
+    encoder_handle: Option<JoinHandle<()>>,
+}
+
+impl OpusEncoder {
+    pub fn new(
+        options: Options,
+        packets_sender: Sender<EncodedChunk>,
+    ) -> Result<Self, EncoderInitError> {
+        let (init_result_sender, init_result_receiver) = bounded(0);
+        let (samples_batch_sender, samples_batch_receiver) = bounded(50);
+
+        let encoder_handle = Some(
+            std::thread::Builder::new()
+                .name("Opus encoder thread".to_string())
+                .spawn(move || {
+                    Self::encoder_thread(
+                        options,
+                        samples_batch_receiver,
+                        packets_sender,
+                        init_result_sender,
+                    )
+                })
+                .unwrap(),
+        );
+
+        init_result_receiver.recv().unwrap()?;
+
+        Ok(Self {
+            samples_batch_sender,
+            encoder_handle,
+        })
+    }
+
+    pub fn send_samples_batch(&self, batch: AudioSamplesBatch) {
+        self.samples_batch_sender
+            .send(Message::Batch(batch))
+            .unwrap();
+    }
+
+    fn encoder_thread(
+        options: Options,
+        samples_batch_receiver: Receiver<Message>,
+        packets_sender: Sender<EncodedChunk>,
+        init_result_sender: Sender<Result<(), EncoderInitError>>,
+    ) {
+        let mut encoder = match opus::Encoder::new(
+            options.sample_rate,
+            options.channels.into(),
+            options.preset.into(),
+        ) {
+            Ok(encoder) => {
+                init_result_sender.send(Ok(())).unwrap();
+                encoder
+            }
+            Err(err) => {
+                init_result_sender
+                    .send(Err(EncoderInitError::OpusError(err)))
+                    .unwrap();
+                return;
+            }
+        };
+
+        let mut output_buffer = [0u8; 1024 * 1024];
+
+        let mut encode = |samples: &[i16]| match encoder.encode(samples, &mut output_buffer) {
+            Ok(len) => Some(bytes::Bytes::copy_from_slice(&output_buffer[..len])),
+            Err(err) => {
+                error!("Opus encoding error: {}", err);
+                None
+            }
+        };
+
+        let mut send_batch = |batch: AudioSamplesBatch| {
+            let data = match batch.samples.as_ref() {
+                AudioSamples::Mono(mono_samples) => {
+                    let Some(data) = encode(mono_samples) else {
+                        return;
+                    };
+                    data
+                }
+                AudioSamples::Stereo(stereo_samples) => {
+                    let flatten_samples: Vec<i16> =
+                        stereo_samples.iter().flat_map(|(l, r)| [*l, *r]).collect();
+                    let Some(data) = encode(&flatten_samples) else {
+                        return;
+                    };
+                    data
+                }
+            };
+            let chunk = EncodedChunk {
+                data,
+                pts: batch.start_pts,
+                dts: None,
+                kind: EncodedChunkKind::Audio(AudioCodec::Opus),
+            };
+            packets_sender.send(chunk).unwrap();
+        };
+
+        for msg in samples_batch_receiver {
+            match msg {
+                Message::Batch(batch) => send_batch(batch),
+                Message::Stop => break,
+            }
+        }
+    }
+}
+
+impl Drop for OpusEncoder {
+    fn drop(&mut self) {
+        self.samples_batch_sender.send(Message::Stop).unwrap();
+        match self.encoder_handle.take() {
+            Some(handle) => handle.join().unwrap(),
+            None => error!("Opus encoder thread was already joined. This should not happen.",),
+        };
+    }
+}
+
+enum Message {
+    Batch(AudioSamplesBatch),
+    Stop,
+}
+
+impl From<AudioEncoderPreset> for opus::Application {
+    fn from(value: AudioEncoderPreset) -> Self {
+        match value {
+            AudioEncoderPreset::Quality => opus::Application::Audio,
+            AudioEncoderPreset::Voip => opus::Application::Voip,
+            AudioEncoderPreset::LowestLatency => opus::Application::LowDelay,
+        }
+    }
 }

--- a/compositor_pipeline/src/pipeline/input/rtp.rs
+++ b/compositor_pipeline/src/pipeline/input/rtp.rs
@@ -198,7 +198,7 @@ impl Drop for RtpReceiver {
 }
 
 #[derive(Debug)]
-pub struct DepayloaderThread {
+pub(crate) struct DepayloaderThread {
     should_close: Arc<AtomicBool>,
     depayloader_thread: Option<thread::JoinHandle<()>>,
 }

--- a/compositor_pipeline/src/pipeline/input/rtp/depayloader.rs
+++ b/compositor_pipeline/src/pipeline/input/rtp/depayloader.rs
@@ -7,12 +7,11 @@ use rtp::{
 
 use crate::pipeline::{
     decoder,
+    rtp::PayloadType,
     structs::{AudioCodec, EncodedChunk, EncodedChunkKind, VideoCodec},
 };
 
 use super::{DepayloadingError, RtpStream};
-
-pub struct PayloadType(u8);
 
 #[derive(Debug, thiserror::Error)]
 pub enum DepayloaderNewError {
@@ -20,7 +19,7 @@ pub enum DepayloaderNewError {
     Audio(#[from] AudioDepayloaderNewError),
 }
 
-pub struct Depayloader {
+pub(crate) struct Depayloader {
     /// (Depayloader, payload type)
     pub video: Option<(VideoDepayloader, PayloadType)>,
     pub audio: Option<(AudioDepayloader, PayloadType)>,

--- a/compositor_pipeline/src/pipeline/output/rtp/payloader.rs
+++ b/compositor_pipeline/src/pipeline/output/rtp/payloader.rs
@@ -1,0 +1,231 @@
+use std::fmt::Debug;
+
+use log::error;
+use rand::Rng;
+use rtp::{
+    codecs::{h264::H264Payloader, opus::OpusPayloader},
+    packetizer::{self},
+};
+
+use crate::pipeline::{
+    rtp::PayloadType,
+    structs::{EncodedChunk, EncodedChunkKind},
+    AudioCodec, VideoCodec,
+};
+
+struct RtpStreamContext {
+    ssrc: u32,
+    next_sequence_number: u16,
+}
+
+impl RtpStreamContext {
+    pub fn new() -> Self {
+        let mut rng = rand::thread_rng();
+        let ssrc = rng.gen::<u32>();
+        let next_sequence_number = rng.gen::<u16>();
+
+        RtpStreamContext {
+            ssrc,
+            next_sequence_number,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PayloadingError {
+    #[error("Tried to payload video with non video payloader.")]
+    NoVideoPayloader,
+
+    #[error("Tried to payload audio with non audio payloader.")]
+    NoAudioPayloader,
+
+    #[error(
+        "Tried to payload video with codec {:#?} with payloader for codec {:#?}",
+        chunk_codec,
+        payloader_codec
+    )]
+    NonMatchingVideoCodecs {
+        chunk_codec: VideoCodec,
+        payloader_codec: VideoCodec,
+    },
+
+    #[error(
+        "Tried to payload audio with codec {:#?} with payloader for codec {:#?}",
+        chunk_codec,
+        payloader_codec
+    )]
+    NonMatchingAudioCodecs {
+        chunk_codec: AudioCodec,
+        payloader_codec: AudioCodec,
+    },
+
+    #[error(transparent)]
+    RtpLibError(#[from] rtp::Error),
+}
+
+pub struct Payloader {
+    video: Option<VideoPayloader>,
+    audio: Option<AudioPayloader>,
+}
+
+enum VideoPayloader {
+    H264 {
+        payloader: H264Payloader,
+        payload_type: PayloadType,
+        context: RtpStreamContext,
+    },
+}
+
+enum AudioPayloader {
+    Opus {
+        payloader: OpusPayloader,
+        payload_type: PayloadType,
+        context: RtpStreamContext,
+    },
+}
+
+impl Payloader {
+    pub fn new(
+        video: Option<(VideoCodec, PayloadType)>,
+        audio: Option<(AudioCodec, PayloadType)>,
+    ) -> Self {
+        Self {
+            video: video.map(|(codec, payload_type)| VideoPayloader::new(codec, payload_type)),
+            audio: audio.map(|(codec, payload_type)| AudioPayloader::new(codec, payload_type)),
+        }
+    }
+
+    pub fn payload(
+        &mut self,
+        mtu: usize,
+        data: EncodedChunk,
+    ) -> Result<Vec<rtp::packet::Packet>, PayloadingError> {
+        match data.kind {
+            EncodedChunkKind::Video(chunk_codec) => {
+                let Some(ref mut video_payloader) = self.video else {
+                    return Err(PayloadingError::NoVideoPayloader);
+                };
+
+                if video_payloader.codec() != chunk_codec {
+                    return Err(PayloadingError::NonMatchingVideoCodecs {
+                        chunk_codec,
+                        payloader_codec: video_payloader.codec(),
+                    });
+                }
+
+                video_payloader.payload(mtu, data)
+            }
+            EncodedChunkKind::Audio(chunk_codec) => {
+                let Some(ref mut audio_payloader) = self.audio else {
+                    return Err(PayloadingError::NoAudioPayloader);
+                };
+
+                if audio_payloader.codec() != chunk_codec {
+                    return Err(PayloadingError::NonMatchingAudioCodecs {
+                        chunk_codec,
+                        payloader_codec: audio_payloader.codec(),
+                    });
+                }
+
+                audio_payloader.payload(mtu, data)
+            }
+        }
+    }
+}
+
+impl VideoPayloader {
+    pub fn new(codec: VideoCodec, payload_type: PayloadType) -> Self {
+        match codec {
+            VideoCodec::H264 => Self::H264 {
+                payloader: H264Payloader::default(),
+                payload_type,
+                context: RtpStreamContext::new(),
+            },
+        }
+    }
+
+    pub fn codec(&self) -> VideoCodec {
+        match self {
+            VideoPayloader::H264 { .. } => VideoCodec::H264,
+        }
+    }
+
+    pub fn payload(
+        &mut self,
+        mtu: usize,
+        chunk: EncodedChunk,
+    ) -> Result<Vec<rtp::packet::Packet>, PayloadingError> {
+        match self {
+            VideoPayloader::H264 {
+                ref mut payloader,
+                ref payload_type,
+                ref mut context,
+            } => payload(payloader, context, chunk, mtu, payload_type),
+        }
+    }
+}
+
+impl AudioPayloader {
+    pub fn new(codec: AudioCodec, payload_type: PayloadType) -> Self {
+        match codec {
+            AudioCodec::Opus => Self::Opus {
+                payloader: OpusPayloader,
+                payload_type,
+                context: RtpStreamContext::new(),
+            },
+            AudioCodec::Aac => panic!("Aac audio output is not supported yet"),
+        }
+    }
+
+    pub fn codec(&self) -> AudioCodec {
+        match self {
+            AudioPayloader::Opus { .. } => AudioCodec::Opus,
+        }
+    }
+
+    pub fn payload(
+        &mut self,
+        mtu: usize,
+        chunk: EncodedChunk,
+    ) -> Result<Vec<rtp::packet::Packet>, PayloadingError> {
+        match self {
+            AudioPayloader::Opus {
+                ref mut payloader,
+                ref payload_type,
+                ref mut context,
+            } => payload(payloader, context, chunk, mtu, payload_type),
+        }
+    }
+}
+
+fn payload<T: packetizer::Payloader>(
+    payloader: &mut T,
+    context: &mut RtpStreamContext,
+    chunk: EncodedChunk,
+    mtu: usize,
+    payload_type: &PayloadType,
+) -> Result<Vec<rtp::packet::Packet>, PayloadingError> {
+    let payloads = payloader.payload(mtu, &chunk.data)?;
+    let packets_amount = payloads.len();
+
+    Ok(payloads
+        .into_iter()
+        .enumerate()
+        .map(|(i, payload)| {
+            let header = rtp::header::Header {
+                version: 2,
+                padding: false,
+                extension: false,
+                marker: i == packets_amount - 1, // marker needs to be set on the last packet of each frame
+                payload_type: payload_type.0,
+                sequence_number: context.next_sequence_number,
+                timestamp: (chunk.pts.as_secs_f64() * 90000.0) as u32,
+                ssrc: context.ssrc,
+                ..Default::default()
+            };
+            context.next_sequence_number = context.next_sequence_number.wrapping_add(1);
+
+            rtp::packet::Packet { header, payload }
+        })
+        .collect())
+}

--- a/compositor_pipeline/src/pipeline/output/rtp/payloader.rs
+++ b/compositor_pipeline/src/pipeline/output/rtp/payloader.rs
@@ -2,10 +2,7 @@ use std::fmt::Debug;
 
 use log::error;
 use rand::Rng;
-use rtp::{
-    codecs::{h264::H264Payloader, opus::OpusPayloader},
-    packetizer::{self},
-};
+use rtp::codecs::{h264::H264Payloader, opus::OpusPayloader};
 
 use crate::pipeline::{
     rtp::PayloadType,
@@ -198,7 +195,7 @@ impl AudioPayloader {
     }
 }
 
-fn payload<T: packetizer::Payloader>(
+fn payload<T: rtp::packetizer::Payloader>(
     payloader: &mut T,
     context: &mut RtpStreamContext,
     chunk: EncodedChunk,

--- a/compositor_pipeline/src/pipeline/pipeline_output.rs
+++ b/compositor_pipeline/src/pipeline/pipeline_output.rs
@@ -18,7 +18,6 @@ pub(super) fn new_pipeline_output(
     } = opts;
     let (has_video, has_audio) = (video.is_some(), audio.is_some());
 
-    // TODO check resolution div 2
     let encoder_opts = EncoderOptions {
         video: video.map(|video_opts| video_opts.encoder_opts),
         audio: audio.map(|audio_opts| {

--- a/compositor_pipeline/src/pipeline/pipeline_output.rs
+++ b/compositor_pipeline/src/pipeline/pipeline_output.rs
@@ -1,7 +1,7 @@
 use crate::error::RegisterOutputError;
 
 use super::{
-    encoder::{opus_encoder, AudioEncoderOptions, AudioEncoderPreset, Encoder, EncoderOptions},
+    encoder::{opus_encoder, AudioEncoderOptions, Encoder, EncoderOptions},
     output::Output,
     PipelineOutput, Port, RegisterOutputOptions,
 };
@@ -22,14 +22,13 @@ pub(super) fn new_pipeline_output(
         video: video.map(|video_opts| video_opts.encoder_opts),
         audio: audio.map(|audio_opts| {
             AudioEncoderOptions::Opus(opus_encoder::Options {
-                sample_rate: output_sample_rate,
                 channels: audio_opts.channels,
-                preset: AudioEncoderPreset::Quality,
+                preset: audio_opts.encoder_preset,
             })
         }),
     };
 
-    let (encoder, packets) = Encoder::new(encoder_opts)
+    let (encoder, packets) = Encoder::new(encoder_opts, output_sample_rate)
         .map_err(|e| RegisterOutputError::EncoderError(output_id.clone(), e))?;
 
     let (output, port) = Output::new(output_options, packets)

--- a/compositor_pipeline/src/pipeline/rtp.rs
+++ b/compositor_pipeline/src/pipeline/rtp.rs
@@ -14,6 +14,9 @@ pub(super) enum BindToPortError {
     AllPortsAlreadyInUse { lower_bound: u16, upper_bound: u16 },
 }
 
+#[derive(Debug, Clone)]
+pub struct PayloadType(pub u8);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RequestedPort {
     Exact(u16),

--- a/examples/audio.rs
+++ b/examples/audio.rs
@@ -59,11 +59,6 @@ fn start_example_client_code() -> Result<()> {
         "port": 8004,
         "video": {
             "codec": "h264"
-        },
-        "audio": {
-            "codec": "opus",
-            "sample_rate": 48_000,
-            "channels": "stereo",
         }
     }))?;
 
@@ -80,15 +75,6 @@ fn start_example_client_code() -> Result<()> {
         }
     }))?;
 
-    let shader_source = include_str!("./silly.wgsl");
-    info!("[example] Register shader transform");
-    common::post(&json!({
-        "type": "register",
-        "entity_type": "shader",
-        "shader_id": "shader_example_1",
-        "source": shader_source,
-    }))?;
-
     info!("[example] Send register output request.");
     common::post(&json!({
         "type": "register",
@@ -103,18 +89,11 @@ fn start_example_client_code() -> Result<()> {
             },
             "encoder_preset": "medium",
             "initial": {
-                "type": "shader",
-                "id": "shader_node_1",
-                "shader_id": "shader_example_1",
-                "children": [
-                    {
-                        "id": "input_1",
-                        "type": "input_stream",
-                        "input_id": "input_1",
-                    }
-                ],
-                "resolution": { "width": VIDEO_RESOLUTION.width, "height": VIDEO_RESOLUTION.height },
-            }
+                "id": "input_1",
+                "type": "input_stream",
+                "input_id": "input_1",
+            },
+            "resolution": { "width": VIDEO_RESOLUTION.width, "height": VIDEO_RESOLUTION.height },
         }
     }))?;
 

--- a/examples/audio.rs
+++ b/examples/audio.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use video_compositor::{config::config, http, logger, types::Resolution};
 
-use crate::common::write_example_sdp_file;
+use crate::common::write_video_audio_example_sdp_file;
 
 #[path = "./common/common.rs"]
 mod common;
@@ -37,7 +37,7 @@ fn main() {
 
 fn start_example_client_code() -> Result<()> {
     info!("[example] Start listening on output port.");
-    let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
+    let output_sdp = write_video_audio_example_sdp_file("127.0.0.1", 8002, 8010)?;
     Command::new("ffplay")
         .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
         .stdout(Stdio::null())
@@ -109,7 +109,16 @@ fn start_example_client_code() -> Result<()> {
                 ],
                 "resolution": { "width": VIDEO_RESOLUTION.width, "height": VIDEO_RESOLUTION.height },
             }
-        },
+        }
+    }))?;
+
+    info!("[example] Send register output request.");
+    common::post(&json!({
+        "type": "register",
+        "entity_type": "output_stream",
+        "output_id": "output_2",
+        "port": 8010,
+        "ip": "127.0.0.1",
         "audio": {
             "initial": {
                 "inputs": [{"input_id": "input_2"}]

--- a/examples/audio.rs
+++ b/examples/audio.rs
@@ -14,8 +14,9 @@ use crate::common::write_video_audio_example_sdp_file;
 #[path = "./common/common.rs"]
 mod common;
 
-const SAMPLE_FILE_URL: &str = "https://filesamples.com/samples/video/mp4/sample_1280x720.mp4";
-const SAMPLE_FILE_PATH: &str = "examples/assets/sample_1280_720.mp4";
+const SAMPLE_FILE_URL: &str =
+    "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4";
+const SAMPLE_FILE_PATH: &str = "examples/assets/BigBuckBunny.mp4";
 const VIDEO_RESOLUTION: Resolution = Resolution {
     width: 1280,
     height: 720,
@@ -58,6 +59,11 @@ fn start_example_client_code() -> Result<()> {
         "port": 8004,
         "video": {
             "codec": "h264"
+        },
+        "audio": {
+            "codec": "opus",
+            "sample_rate": 48_000,
+            "channels": "stereo",
         }
     }))?;
 
@@ -136,7 +142,7 @@ fn start_example_client_code() -> Result<()> {
 
     Command::new("ffmpeg")
         .args(["-stream_loop", "-1", "-re", "-i"])
-        .arg(sample_path)
+        .arg(sample_path.clone())
         .args([
             "-an",
             "-c:v",
@@ -150,18 +156,15 @@ fn start_example_client_code() -> Result<()> {
         .spawn()?;
 
     Command::new("ffmpeg")
+        .args(["-re", "-i"])
+        .arg(sample_path)
         .args([
-            "-re",
-            "-f",
-            "lavfi",
-            "-i",
-            "sine=frequency=1000:duration=60", // Generates a sine wave tone
-            "-vn",                             // No Video
+            "-vn",
             "-c:a",
-            "libopus", // Specify audio codec
+            "libopus",
             "-f",
             "rtp",
-            "rtp://127.0.0.1:8006?rtcpport=8006", // Streaming endpoint
+            "rtp://127.0.0.1:8006?rtcpport=8006",
         ])
         .spawn()?;
 

--- a/examples/common/common.rs
+++ b/examples/common/common.rs
@@ -14,8 +14,8 @@ use serde::Serialize;
 
 /// The SDP file will describe an RTP session on localhost with H264 encoding.
 #[allow(dead_code)]
-pub fn write_example_sdp_file(ip: &str, port: u16) -> Result<String> {
-    let sdp_filepath = PathBuf::from(format!("/tmp/example_sdp_input_{}.sdp", port));
+pub fn write_video_example_sdp_file(ip: &str, port: u16) -> Result<String> {
+    let sdp_filepath = PathBuf::from(format!("/tmp/example_sdp_video_input_{}.sdp", port));
     let mut file = File::create(&sdp_filepath)?;
     file.write_all(
         format!(
@@ -30,6 +30,43 @@ pub fn write_example_sdp_file(ip: &str, port: u16) -> Result<String> {
                     a=rtcp-mux\n\
                 ",
             ip, ip, port
+        )
+        .as_bytes(),
+    )?;
+    Ok(String::from(
+        sdp_filepath
+            .to_str()
+            .ok_or_else(|| anyhow!("invalid utf string"))?,
+    ))
+}
+
+/// The SDP file will describe an RTP session on localhost with H264 video encoding and Opus audio encoding.
+#[allow(dead_code)]
+pub fn write_video_audio_example_sdp_file(
+    ip: &str,
+    video_port: u16,
+    audio_port: u16,
+) -> Result<String> {
+    let sdp_filepath = PathBuf::from(format!(
+        "/tmp/example_sdp_video_audio_input_{}.sdp",
+        video_port
+    ));
+    let mut file = File::create(&sdp_filepath)?;
+    file.write_all(
+        format!(
+            "\
+                    v=0\n\
+                    o=- 0 0 IN IP4 {}\n\
+                    s=No Name\n\
+                    c=IN IP4 {}\n\
+                    m=video {} RTP/AVP 96\n\
+                    a=rtpmap:96 H264/90000\n\
+                    a=fmtp:96 packetization-mode=1\n\
+                    a=rtcp-mux\n\
+                    m=audio {} RTP/AVP 97\n\
+                    a=rtpmap:97 opus/48000/2\n\
+                ",
+            ip, ip, video_port, audio_port
         )
         .as_bytes(),
     )?;

--- a/examples/docker.rs
+++ b/examples/docker.rs
@@ -10,7 +10,7 @@ use std::{
 };
 use video_compositor::{config::config, logger, types::Resolution};
 
-use crate::common::write_example_sdp_file;
+use crate::common::write_video_example_sdp_file;
 
 #[path = "./common/common.rs"]
 mod common;
@@ -102,7 +102,7 @@ fn start_example_client_code(host_ip: String) -> Result<()> {
     thread::sleep(Duration::from_secs(5));
 
     info!("[example] Start listening on output port.");
-    let output_sdp = write_example_sdp_file(&host_ip, 8002)?;
+    let output_sdp = write_video_example_sdp_file(&host_ip, 8002)?;
     Command::new("ffplay")
         .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
         .stderr(Stdio::null())

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -10,7 +10,7 @@ use std::{
 };
 use video_compositor::{config::config, http, logger, types::Resolution};
 
-use crate::common::write_example_sdp_file;
+use crate::common::write_video_example_sdp_file;
 
 #[path = "./common/common.rs"]
 mod common;
@@ -36,7 +36,7 @@ fn main() {
 
 fn start_example_client_code() -> Result<()> {
     info!("[example] Start listening on output port.");
-    let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
+    let output_sdp = write_video_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
         .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
         .stdout(Stdio::null())

--- a/examples/mp4.rs
+++ b/examples/mp4.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use video_compositor::{config::config, http, logger, types::Resolution};
 
-use crate::common::write_example_sdp_file;
+use crate::common::write_video_example_sdp_file;
 
 #[path = "./common/common.rs"]
 mod common;
@@ -37,7 +37,7 @@ fn main() {
 
 fn start_example_client_code() -> Result<()> {
     info!("[example] Start listening on output port.");
-    let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
+    let output_sdp = write_video_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
         .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
         .stdout(Stdio::null())

--- a/examples/pass_through.rs
+++ b/examples/pass_through.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use video_compositor::{config::config, http, logger, types::Resolution};
 
-use crate::common::write_example_sdp_file;
+use crate::common::write_video_example_sdp_file;
 
 #[path = "./common/common.rs"]
 mod common;
@@ -37,7 +37,7 @@ fn main() {
 
 fn start_example_client_code() -> Result<()> {
     info!("[example] Start listening on output port.");
-    let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
+    let output_sdp = write_video_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
         .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
         .stdout(Stdio::null())

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use video_compositor::{config::config, http, logger, types::Resolution};
 
-use crate::common::write_example_sdp_file;
+use crate::common::write_video_example_sdp_file;
 
 #[path = "./common/common.rs"]
 mod common;
@@ -37,7 +37,7 @@ fn main() {
 
 fn start_example_client_code() -> Result<()> {
     info!("[example] Start listening on output port.");
-    let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
+    let output_sdp = write_video_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
         .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
         .stdout(Stdio::null())

--- a/examples/test_pattern.rs
+++ b/examples/test_pattern.rs
@@ -10,7 +10,7 @@ use std::{
 };
 use video_compositor::{config::config, http, logger, types::Resolution};
 
-use crate::common::write_example_sdp_file;
+use crate::common::write_video_example_sdp_file;
 
 #[path = "./common/common.rs"]
 mod common;
@@ -41,7 +41,7 @@ struct RegisterResponse {
 
 fn start_example_client_code() -> Result<()> {
     info!("[example] Start listening on output port.");
-    let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
+    let output_sdp = write_video_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
         .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
         .stdout(Stdio::null())

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use video_compositor::{config::config, http, logger, types::Resolution};
 
-use crate::common::write_example_sdp_file;
+use crate::common::write_video_example_sdp_file;
 
 #[path = "./common/common.rs"]
 mod common;
@@ -35,7 +35,7 @@ fn main() {
 
 fn start_example_client_code() -> Result<()> {
     info!("[example] Start listening on output port.");
-    let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
+    let output_sdp = write_video_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
         .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
         .stdout(Stdio::null())

--- a/examples/tiles.rs
+++ b/examples/tiles.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use video_compositor::{config::config, http, logger, types::Resolution};
 
-use crate::common::write_example_sdp_file;
+use crate::common::write_video_example_sdp_file;
 
 #[path = "./common/common.rs"]
 mod common;
@@ -35,7 +35,7 @@ fn main() {
 
 fn start_example_client_code() -> Result<()> {
     info!("[example] Start listening on output port.");
-    let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
+    let output_sdp = write_video_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
         .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
         .stdout(Stdio::null())

--- a/examples/transition.rs
+++ b/examples/transition.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use video_compositor::{config::config, http, logger, types::Resolution};
 
-use crate::common::write_example_sdp_file;
+use crate::common::write_video_example_sdp_file;
 
 #[path = "./common/common.rs"]
 mod common;
@@ -35,7 +35,7 @@ fn main() {
 
 fn start_example_client_code() -> Result<()> {
     info!("[example] Start listening on output port.");
-    let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
+    let output_sdp = write_video_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
         .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
         .stdout(Stdio::null())

--- a/examples/web_view.rs
+++ b/examples/web_view.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use video_compositor::{config::config, http, logger, types::Resolution};
 
-use crate::common::write_example_sdp_file;
+use crate::common::write_video_example_sdp_file;
 
 #[path = "./common/common.rs"]
 mod common;
@@ -54,7 +54,7 @@ fn main() {
 
 fn start_example_client_code() -> Result<()> {
     info!("[example] Start listening on output port.");
-    let output_sdp = write_example_sdp_file("127.0.0.1", 8002)?;
+    let output_sdp = write_video_example_sdp_file("127.0.0.1", 8002)?;
     Command::new("ffplay")
         .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp])
         .stdout(Stdio::null())

--- a/schemas/register.schema.json
+++ b/schemas/register.schema.json
@@ -587,6 +587,15 @@
         },
         "initial": {
           "$ref": "#/definitions/Component"
+        },
+        "rtp_payload_type": {
+          "description": "(**default=`96`**)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false
@@ -1826,6 +1835,15 @@
             "boolean",
             "null"
           ]
+        },
+        "rtp_payload_type": {
+          "description": "(**default=`97`**)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false

--- a/src/types/from_register_request.rs
+++ b/src/types/from_register_request.rs
@@ -208,14 +208,22 @@ impl TryFrom<RegisterOutputRequest> for pipeline::RegisterOutputOptions {
         }
 
         let output_video_options = match video.clone() {
-            Some(v) => Some(pipeline::OutputVideoOptions {
-                initial: v.initial.try_into()?,
-                encoder_opts: pipeline::encoder::VideoEncoderOptions::H264(Options {
-                    preset: v.encoder_preset.into(),
-                    resolution: v.resolution.into(),
-                    output_id: output_id.clone().into(),
-                }),
-            }),
+            Some(v) => {
+                if v.resolution.width % 2 != 0 || v.resolution.height % 2 != 0 {
+                    return Err(TypeError::new(
+                        "Output video width and height has to be divisible by 2",
+                    ));
+                };
+
+                Some(pipeline::OutputVideoOptions {
+                    initial: v.initial.try_into()?,
+                    encoder_opts: pipeline::encoder::VideoEncoderOptions::H264(Options {
+                        preset: v.encoder_preset.into(),
+                        resolution: v.resolution.into(),
+                        output_id: output_id.clone().into(),
+                    }),
+                })
+            }
             None => None,
         };
 

--- a/src/types/from_register_request.rs
+++ b/src/types/from_register_request.rs
@@ -223,6 +223,7 @@ impl TryFrom<RegisterOutputRequest> for pipeline::RegisterOutputOptions {
             initial: a.initial.into(),
             channels: a.channels.into(),
             forward_error_correction: a.forward_error_correction.unwrap_or(false),
+            encoder_preset: a.encoder_preset.unwrap_or(AudioEncoderPreset::Voip).into(),
         });
 
         let connection_options = match transport_protocol.unwrap_or(TransportProtocol::Udp) {
@@ -281,19 +282,29 @@ impl TryFrom<RegisterOutputRequest> for pipeline::RegisterOutputOptions {
     }
 }
 
-impl From<EncoderPreset> for encoder::ffmpeg_h264::EncoderPreset {
-    fn from(value: EncoderPreset) -> Self {
+impl From<VideoEncoderPreset> for encoder::ffmpeg_h264::EncoderPreset {
+    fn from(value: VideoEncoderPreset) -> Self {
         match value {
-            EncoderPreset::Ultrafast => ffmpeg_h264::EncoderPreset::Ultrafast,
-            EncoderPreset::Superfast => ffmpeg_h264::EncoderPreset::Superfast,
-            EncoderPreset::Veryfast => ffmpeg_h264::EncoderPreset::Veryfast,
-            EncoderPreset::Faster => ffmpeg_h264::EncoderPreset::Faster,
-            EncoderPreset::Fast => ffmpeg_h264::EncoderPreset::Fast,
-            EncoderPreset::Medium => ffmpeg_h264::EncoderPreset::Medium,
-            EncoderPreset::Slow => ffmpeg_h264::EncoderPreset::Slow,
-            EncoderPreset::Slower => ffmpeg_h264::EncoderPreset::Slower,
-            EncoderPreset::Veryslow => ffmpeg_h264::EncoderPreset::Veryslow,
-            EncoderPreset::Placebo => ffmpeg_h264::EncoderPreset::Placebo,
+            VideoEncoderPreset::Ultrafast => ffmpeg_h264::EncoderPreset::Ultrafast,
+            VideoEncoderPreset::Superfast => ffmpeg_h264::EncoderPreset::Superfast,
+            VideoEncoderPreset::Veryfast => ffmpeg_h264::EncoderPreset::Veryfast,
+            VideoEncoderPreset::Faster => ffmpeg_h264::EncoderPreset::Faster,
+            VideoEncoderPreset::Fast => ffmpeg_h264::EncoderPreset::Fast,
+            VideoEncoderPreset::Medium => ffmpeg_h264::EncoderPreset::Medium,
+            VideoEncoderPreset::Slow => ffmpeg_h264::EncoderPreset::Slow,
+            VideoEncoderPreset::Slower => ffmpeg_h264::EncoderPreset::Slower,
+            VideoEncoderPreset::Veryslow => ffmpeg_h264::EncoderPreset::Veryslow,
+            VideoEncoderPreset::Placebo => ffmpeg_h264::EncoderPreset::Placebo,
+        }
+    }
+}
+
+impl From<AudioEncoderPreset> for encoder::AudioEncoderPreset {
+    fn from(value: AudioEncoderPreset) -> Self {
+        match value {
+            AudioEncoderPreset::Quality => encoder::AudioEncoderPreset::Quality,
+            AudioEncoderPreset::Voip => encoder::AudioEncoderPreset::Voip,
+            AudioEncoderPreset::LowestLatency => encoder::AudioEncoderPreset::LowestLatency,
         }
     }
 }

--- a/src/types/register_request.rs
+++ b/src/types/register_request.rs
@@ -141,7 +141,7 @@ pub enum Port {
 #[serde(deny_unknown_fields)]
 pub struct OutputVideoOptions {
     pub resolution: Resolution,
-    pub encoder_preset: EncoderPreset,
+    pub encoder_preset: VideoEncoderPreset,
     pub initial: Component,
     /// (**default=`96`**)
     pub rtp_payload_type: Option<u8>,
@@ -159,6 +159,21 @@ pub struct OutputAudioOptions {
     pub forward_error_correction: Option<bool>,
     /// (**default=`97`**)
     pub rtp_payload_type: Option<u8>,
+    /// (**default="voip"**) Specifies preset for audio output encoder.
+    pub encoder_preset: Option<AudioEncoderPreset>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AudioEncoderPreset {
+    /// Best for broadcast/high-fidelity application where the decoded audio
+    /// should be as close as possible to the input.
+    Quality,
+    /// Best for most VoIP/videoconference applications where listening quality
+    /// and intelligibility matter most.
+    Voip,
+    /// Only use when lowest-achievable latency is what matters most.
+    LowestLatency,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
@@ -174,7 +189,7 @@ pub struct RegisterOutputRequest {
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum EncoderPreset {
+pub enum VideoEncoderPreset {
     Ultrafast,
     Superfast,
     Veryfast,

--- a/src/types/register_request.rs
+++ b/src/types/register_request.rs
@@ -142,6 +142,8 @@ pub struct OutputVideoOptions {
     pub resolution: Resolution,
     pub encoder_preset: EncoderPreset,
     pub initial: Component,
+    /// (**default=`96`**)
+    pub rtp_payload_type: Option<u8>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
@@ -154,6 +156,8 @@ pub struct OutputAudioOptions {
     /// It's specific for Opus codec.
     /// For more information, check out [RFC](https://datatracker.ietf.org/doc/html/rfc6716#section-2.1.7).
     pub forward_error_correction: Option<bool>,
+    /// (**default=`97`**)
+    pub rtp_payload_type: Option<u8>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]


### PR DESCRIPTION
Implements audio encoding and sending to output via RTP.

Audio in the example is 0.5-2s behind video since in the example I use 2 FFmpeg processes spawned separately. I couldn't send both video and audio on a single port via FFmpeg.

TODO:
Add resampling and mixing