### PR TITLE
Switch to our fork of the mp4 library, which supports avc3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,8 +1447,7 @@ dependencies = [
 [[package]]
 name = "mp4"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ef834d5ed55e494a2ae350220314dc4aacd1c43a9498b00e320e0ea352a5c3"
+source = "git+https://github.com/membraneframework-labs/mp4-rust.git?branch=avc3-box#a1cd3dd4e5505850b970ac55fc6bab36fe0a79b0"
 dependencies = [
  "byteorder",
  "bytes",

--- a/compositor_pipeline/Cargo.toml
+++ b/compositor_pipeline/Cargo.toml
@@ -18,7 +18,7 @@ socket2 = "0.5.5"
 rtcp = "0.10.0"
 opus = "0.3.0"
 rand = { workspace = true }
-mp4 = "0.14.0"
+mp4 = { git = "https://github.com/membraneframework-labs/mp4-rust.git", branch = "avc3-box" }
 reqwest = { workspace = true }
 symphonia = { version = "0.5.3", default-features = false, features = ["isomp4", "aac"] }
 tracing = { workspace = true }

--- a/compositor_pipeline/src/pipeline/input/mp4.rs
+++ b/compositor_pipeline/src/pipeline/input/mp4.rs
@@ -151,27 +151,21 @@ fn spawn_video_reader(input_path: &Path, input_id: InputId) -> Result<VideoReade
     let size = input_file.metadata()?.size();
     let reader = mp4::Mp4Reader::read_header(input_file, size)?;
 
-    let Some((&track_id, track, avc1)) = reader.tracks().iter().find_map(|(id, track)| {
+    let Some((&track_id, track, avc)) = reader.tracks().iter().find_map(|(id, track)| {
         let track_type = track.track_type().ok()?;
 
         let media_type = track.media_type().ok()?;
 
+        let avc = track.avc1_or_3_inner();
+
         if track_type != mp4::TrackType::Video
             || media_type != mp4::MediaType::H264
-            || track.trak.mdia.minf.stbl.stsd.avc1.is_none()
+            || avc.is_none()
         {
             return None;
         }
 
-        track
-            .trak
-            .mdia
-            .minf
-            .stbl
-            .stsd
-            .avc1
-            .as_ref()
-            .map(|avc1| (id, track, avc1))
+        avc.map(|avc| (id, track, avc))
     }) else {
         return Ok(Default::default());
     };
@@ -180,13 +174,13 @@ fn spawn_video_reader(input_path: &Path, input_id: InputId) -> Result<VideoReade
 
     // sps and pps have to be extracted from the container, interleaved with [0, 0, 0, 1],
     // concatenated and prepended to the first frame.
-    let sps = avc1
+    let sps = avc
         .avcc
         .sequence_parameter_sets
         .iter()
         .flat_map(|s| [0, 0, 0, 1].iter().chain(s.bytes.iter()));
 
-    let pps = avc1
+    let pps = avc
         .avcc
         .picture_parameter_sets
         .iter()
@@ -196,7 +190,7 @@ fn spawn_video_reader(input_path: &Path, input_id: InputId) -> Result<VideoReade
 
     let sample_count = track.sample_count();
     let timescale = track.timescale();
-    let length_size = avc1.avcc.length_size_minus_one + 1;
+    let length_size = avc.avcc.length_size_minus_one + 1;
 
     let thread = std::thread::Builder::new()
         .name(format!("mp4 video reader {input_id}"))


### PR DESCRIPTION
The fragmented mp4s generated by membrane (and probably a big part of the fragmented mp4s) use the `avc3` box instead of the `avc1` box, which is more popular for non-fragmented mp4s. The mp4 library doesn't support `avc3`, even though the syntax of the `avc3` box is identical to the `avc1` box, the only things that are different are the name and the semantics (`avc3` means that `NALU`s containing stream metadata can be embedded in the bytestream, which we handle correctly already). I forked the library and added support for `avc3`.