### PR TITLE
Log missing frames + lower stream fallback to 500 ms

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -105,12 +105,12 @@ fn read_config() -> Result<Config, String> {
         Err(_) => false,
     };
 
-    const DEFAULT_STREAM_FALLBACK_TIMEOUT: Duration = Duration::from_millis(2000);
+    const DEFAULT_STREAM_FALLBACK_TIMEOUT: Duration = Duration::from_millis(500);
     let stream_fallback_timeout = match env::var("LIVE_COMPOSITOR_STREAM_FALLBACK_TIMEOUT_MS") {
         Ok(timeout_ms) => match timeout_ms.parse::<f64>() {
             Ok(timeout_ms) => Duration::from_secs_f64(timeout_ms / 1000.0),
             Err(_) => {
-                error!("Invalid value provided for \"LIVE_COMPOSITOR_STREAM_FALLBACK_TIMEOUT_MS\". Falling back to default value 2000ms.");
+                error!("Invalid value provided for \"LIVE_COMPOSITOR_STREAM_FALLBACK_TIMEOUT_MS\". Falling back to default value 500ms.");
                 DEFAULT_STREAM_FALLBACK_TIMEOUT
             }
         },


### PR DESCRIPTION
When debuging slow membrane pipeline it was hard to identify the bottelnecek because we were not sure if compositor receives data or not.

- Add log when we are pusing samples/frames to renderer or mixer before all inputs are ready
- Lower fallback timeout from 2000ms to 500ms. (Unrelated to this issue, I just think this value is to large, it should significantlly larger than any reasonable distance between frames, but small enough so user does not notice the freeze)