### PR TITLE
Add `LIVE_COMPOSITOR_RUN_LATE_SCHEDULED_EVENTS` config option

### DIFF
--- a/compositor_pipeline/src/queue.rs
+++ b/compositor_pipeline/src/queue.rs
@@ -48,6 +48,11 @@ pub struct Queue {
     /// Define if queue should process frames if all inputs are ready.
     ahead_of_time_processing: bool,
 
+    /// Defines behavior when event is scheduled too late:
+    /// true - Event will be executed immediately.
+    /// false - Event will be discarded.
+    run_late_scheduled_events: bool,
+
     start_sender: Mutex<Option<Sender<QueueStartEvent>>>,
     scheduled_event_sender: Sender<ScheduledEvent>,
 }
@@ -108,6 +113,7 @@ pub struct InputOptions {
 pub struct QueueOptions {
     pub ahead_of_time_processing: bool,
     pub output_framerate: Framerate,
+    pub run_late_scheduled_events: bool,
 }
 
 pub struct ScheduledEvent {
@@ -144,6 +150,7 @@ impl Queue {
             scheduled_event_sender,
             start_sender: Mutex::new(Some(queue_start_sender)),
             ahead_of_time_processing: opts.ahead_of_time_processing,
+            run_late_scheduled_events: opts.run_late_scheduled_events,
         });
 
         QueueThread::new(

--- a/docs/pages/deployment/configuration.md
+++ b/docs/pages/deployment/configuration.md
@@ -8,7 +8,7 @@ API port. Defaults to 8001.
 
 ### `LIVE_COMPOSITOR_OUTPUT_FRAMERATE`
 
-Output framerate for all output streams. This value can be a number or string in the `NUM/DEN` format , where both `NUM` and `DEN` are unsigned integers.
+Output framerate for all output streams. This value can be a number or string in the `NUM/DEN` format, where both `NUM` and `DEN` are unsigned integers.
 
 ### `LIVE_COMPOSITOR_OUTPUT_SAMPLE_RATE`
 
@@ -76,5 +76,11 @@ If enabled, the LiveCompositor server will try to generate output frames ahead o
 
 When to enable this option:
 - If you want to process input streams faster than in real time.
+
+Defaults to `false`. Valid values: `true`, `false`, `1`, `0`.
+
+### `LIVE_COMPOSITOR_RUN_LATE_SCHEDULED_EVENTS`
+
+Parts of the compositor API support a `schedule_time_ms` field to apply certain actions at a specific time. If enabled, the event will still be executed, even if it was scheduled too late. Otherwise, it will be discarded.
 
 Defaults to `false`. Valid values: `true`, `false`, `1`, `0`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -145,6 +145,11 @@ fn read_config() -> Result<Config, String> {
         Err(_) => DEFAULT_OUTPUT_SAMPLE_RATE,
     };
 
+    let run_late_scheduled_events = match env::var("LIVE_COMPOSITOR_RUN_LATE_SCHEDULED_EVENTS") {
+        Ok(enable) => bool_env_from_str(&enable).unwrap_or(false),
+        Err(_) => false,
+    };
+
     let config = Config {
         api_port,
         logger: LoggerConfig {
@@ -155,6 +160,7 @@ fn read_config() -> Result<Config, String> {
         queue_options: QueueOptions {
             ahead_of_time_processing,
             output_framerate: framerate,
+            run_late_scheduled_events,
         },
         stream_fallback_timeout,
         force_gpu,


### PR DESCRIPTION
The current default behavior was a bug in my opinion, events that are scheduled in the past should be discarded. Additionally, this PR leaves previous behavior under the configuration env.

I'm open to suggestions for better env name