### PR TITLE
Fix EOS for rtp output payloader

### DIFF
--- a/compositor_pipeline/src/pipeline/output/rtp/payloader.rs
+++ b/compositor_pipeline/src/pipeline/output/rtp/payloader.rs
@@ -140,13 +140,13 @@ impl Payloader {
         }
     }
 
-    pub(super) fn audio_eos(&mut self) -> Option<Result<Bytes, PayloadingError>> {
+    pub(super) fn audio_eos(&mut self) -> Result<Bytes, PayloadingError> {
         self.audio
             .as_mut()
             .map(|audio| {
                 let ctx = audio.context_mut();
                 if ctx.received_eos {
-                    return None;
+                    return Err(PayloadingError::AudioEOSAlreadySent);
                 }
                 ctx.received_eos = true;
 
@@ -154,18 +154,18 @@ impl Payloader {
                     sources: vec![ctx.ssrc],
                     reason: Bytes::from("Unregister output stream"),
                 };
-                Some(packet.marshal().map_err(PayloadingError::MarshalError))
+                packet.marshal().map_err(PayloadingError::MarshalError)
             })
-            .unwrap_or(Some(Err(PayloadingError::NoAudioPayloader)))
+            .unwrap_or(Err(PayloadingError::NoAudioPayloader))
     }
 
-    pub(super) fn video_eos(&mut self) -> Option<Result<Bytes, PayloadingError>> {
+    pub(super) fn video_eos(&mut self) -> Result<Bytes, PayloadingError> {
         self.video
             .as_mut()
             .map(|video| {
                 let ctx = video.context_mut();
                 if ctx.received_eos {
-                    return None;
+                    return Err(PayloadingError::VideoEOSAlreadySent);
                 }
                 ctx.received_eos = true;
 
@@ -173,9 +173,9 @@ impl Payloader {
                     sources: vec![ctx.ssrc],
                     reason: Bytes::from("Unregister output stream"),
                 };
-                Some(packet.marshal().map_err(PayloadingError::MarshalError))
+                packet.marshal().map_err(PayloadingError::MarshalError)
             })
-            .unwrap_or(Some(Err(PayloadingError::NoVideoPayloader)))
+            .unwrap_or(Err(PayloadingError::NoVideoPayloader))
     }
 }
 


### PR DESCRIPTION
Most likely fixes https://swmansion.slack.com/archives/C06GLUH09FE/p1710407272484879

```
{"timestamp":"2024-03-14T09:01:58.629417Z","level":"ERROR","fields":{"message":"Failed to payload a packet: Tried to payload audio with non audio payloader."},"target":"compositor_pipeline::pipeline::output::rtp::tcp_server","span":{"output_id":"video_output_1","name":"RTP sender"},"spans":[{"output_id":"video_output_1","name":"RTP sender"}]}
{"timestamp":"2024-03-14T09:01:58.629419Z","level":"ERROR","fields":{"message":"Failed to payload a packet: Tried to payload audio with non audio payloader."},"target":"compositor_pipeline::pipeline::output::rtp::tcp_server","span":{"output_id":"video_output_1","name":"RTP sender"},"spans":[{"output_id":"video_output_1","name":"RTP sender"}]}
{"timestamp":"2024-03-14T09:01:58.629422Z","level":"ERROR","fields":{"message":"Failed to payload a packet: Tried to payload audio with non audio payloader."},"target":"compositor_pipeline::pipeline::output::rtp::tcp_server","span":{"output_id":"video_output_1","name":"RTP sender"},"spans":[{"output_id":"video_output_1","name":"RTP sender"}]}
{"timestamp":"2024-03-14T09:01:58.629424Z","level":"ERROR","fields":{"message":"Failed to payload a packet: Tried to payload audio with non audio payloader."},"target":"compositor_pipeline::pipeline::output::rtp::tcp_server","span":{"output_id":"video_output_1","name":"RTP sender"},"spans":[{"output_id":"video_output_1","name":"RTP sender"}]}
```