### PR TITLE
Handle initial offset for mixed offline/online streams

### DIFF
--- a/compositor_pipeline/src/queue/audio_queue.rs
+++ b/compositor_pipeline/src/queue/audio_queue.rs
@@ -6,7 +6,10 @@ use std::{
 
 use crate::audio_mixer::types::AudioSamplesBatch;
 
-use super::{utils::InputProcessor, InputOptions, PipelineEvent, QueueAudioOutput};
+use super::{
+    utils::{Clock, InputProcessor},
+    InputOptions, PipelineEvent, QueueAudioOutput,
+};
 use compositor_render::InputId;
 use crossbeam_channel::{Receiver, TryRecvError};
 
@@ -29,13 +32,14 @@ impl AudioQueue {
         input_id: &InputId,
         receiver: Receiver<PipelineEvent<AudioSamplesBatch>>,
         opts: InputOptions,
+        clock: Clock,
     ) {
         self.inputs.insert(
             input_id.clone(),
             AudioQueueInput {
                 queue: VecDeque::new(),
                 receiver,
-                input_samples_processor: InputProcessor::new(self.buffer_duration),
+                input_samples_processor: InputProcessor::new(self.buffer_duration, clock),
                 required: opts.required,
                 offset: opts.offset,
                 eos_sent: false,

--- a/compositor_pipeline/src/queue/video_queue.rs
+++ b/compositor_pipeline/src/queue/video_queue.rs
@@ -9,6 +9,7 @@ use std::mem;
 use std::time::Duration;
 use std::time::Instant;
 
+use super::utils::Clock;
 use super::utils::InputProcessor;
 use super::InputOptions;
 use super::PipelineEvent;
@@ -32,6 +33,7 @@ impl VideoQueue {
         input_id: &InputId,
         receiver: Receiver<PipelineEvent<Frame>>,
         opts: InputOptions,
+        clock: Clock,
     ) {
         self.inputs.insert(
             input_id.clone(),
@@ -39,7 +41,7 @@ impl VideoQueue {
                 queue: VecDeque::new(),
                 receiver,
                 listeners: vec![],
-                input_frames_processor: InputProcessor::new(self.buffer_duration),
+                input_frames_processor: InputProcessor::new(self.buffer_duration, clock),
                 required: opts.required,
                 offset: opts.offset,
                 eos_sent: false,


### PR DESCRIPTION
### Why

If queue is behind real-time (or far into the future) offset of incoming streams (if not provided explicitly) is calculated based on the real time. As a result:
- If queue is behind real-time then the initial frame will be calculated based on real-time, so the PTS of the frame will be larger than PTS of what queue that is already processing. This will result in the first frame frozen at the beginning
- If a queue is faster than real-time then the initial frame will be calculated in the past which will cause the initial stream to be dropped.

Technically the above behavior is not wrong, but it's also not useful.

### When this is happening

This can happen if you have required and not required inputs, where some of the inputs do not have the offset defined. Of course, if you do not process in real-time then sending requests and registering inputs without an offset does not make sense, but one particular case when this is useful is using require for initial sync, so the stream is processed in real time, but it's behind few seconds

### New behavior

When recording start time for each input we do not use `Instance:now()` instead we shift that value by the queue delay. Queue delay is calculated each time we push an audio or video chunk based on `queue.start_time` and currently processed pts.