### PR TITLE
Allow heavy operations in input registration

### DIFF
--- a/build_tools/nix/flake.nix
+++ b/build_tools/nix/flake.nix
@@ -65,6 +65,7 @@
             nodejs_18
             rustfmt
             clippy
+            cargo-watch
             rust-analyzer
             pkgs.mesa.drivers
           ];

--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -40,6 +40,7 @@ mod pipeline_output;
 pub mod rtp;
 mod structs;
 
+use self::pipeline_input::register_pipeline_input;
 use self::pipeline_input::PipelineInput;
 use self::pipeline_output::PipelineOutput;
 pub use self::structs::AudioCodec;
@@ -137,11 +138,11 @@ impl Pipeline {
     }
 
     pub fn register_input(
-        &mut self,
+        pipeline: &Arc<Mutex<Self>>,
         input_id: InputId,
         register_options: RegisterInputOptions,
     ) -> Result<Option<Port>, RegisterInputError> {
-        self.register_pipeline_input(input_id, register_options)
+        register_pipeline_input(pipeline, input_id, register_options)
     }
 
     pub fn unregister_input(&mut self, input_id: &InputId) -> Result<(), UnregisterInputError> {

--- a/compositor_pipeline/src/pipeline/pipeline_input.rs
+++ b/compositor_pipeline/src/pipeline/pipeline_input.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use compositor_render::InputId;
 
 use crate::{error::RegisterInputError, Pipeline};
@@ -16,66 +18,71 @@ pub struct PipelineInput {
     pub(super) video_eos_received: Option<bool>,
 }
 
-impl Pipeline {
-    pub(super) fn register_pipeline_input(
-        &mut self,
-        input_id: InputId,
-        register_options: RegisterInputOptions,
-    ) -> Result<Option<Port>, RegisterInputError> {
-        let RegisterInputOptions {
-            input_options,
-            queue_options,
-        } = register_options;
-        if self.inputs.contains_key(&input_id) {
+pub(super) fn register_pipeline_input(
+    pipeline: &Arc<Mutex<Pipeline>>,
+    input_id: InputId,
+    register_options: RegisterInputOptions,
+) -> Result<Option<Port>, RegisterInputError> {
+    let RegisterInputOptions {
+        input_options,
+        queue_options,
+    } = register_options;
+    let (download_dir, output_sample_rate) = {
+        let guard = pipeline.lock().unwrap();
+        if guard.inputs.contains_key(&input_id) {
             return Err(RegisterInputError::AlreadyRegistered(input_id));
         }
+        (guard.download_dir.clone(), guard.output_sample_rate)
+    };
 
-        let (input, chunks_receiver, decoder_options, port) =
-            input::Input::new(input_options, &self.download_dir)
-                .map_err(|e| RegisterInputError::InputError(input_id.clone(), e))?;
+    let (input, chunks_receiver, decoder_options, port) =
+        input::Input::new(input_options, &download_dir)
+            .map_err(|e| RegisterInputError::InputError(input_id.clone(), e))?;
 
-        let (audio_eos_received, video_eos_received) = (
-            decoder_options.audio.as_ref().map(|_| false),
-            decoder_options.video.as_ref().map(|_| false),
-        );
-        let (decoder, decoded_data_receiver) = decoder::Decoder::new(
-            input_id.clone(),
-            chunks_receiver,
-            decoder_options,
-            self.output_sample_rate,
-        )
-        .map_err(|e| RegisterInputError::DecoderError(input_id.clone(), e))?;
+    let (audio_eos_received, video_eos_received) = (
+        decoder_options.audio.as_ref().map(|_| false),
+        decoder_options.video.as_ref().map(|_| false),
+    );
+    let (decoder, decoded_data_receiver) = decoder::Decoder::new(
+        input_id.clone(),
+        chunks_receiver,
+        decoder_options,
+        output_sample_rate,
+    )
+    .map_err(|e| RegisterInputError::DecoderError(input_id.clone(), e))?;
 
-        let pipeline_input = PipelineInput {
-            input,
-            decoder,
-            audio_eos_received,
-            video_eos_received,
-        };
+    let pipeline_input = PipelineInput {
+        input,
+        decoder,
+        audio_eos_received,
+        video_eos_received,
+    };
 
-        if pipeline_input.audio_eos_received.is_some() {
-            for (_, output) in self.outputs.iter_mut() {
-                if let Some(ref mut cond) = output.audio_end_condition {
-                    cond.on_input_registered(&input_id);
-                }
+    let mut guard = pipeline.lock().unwrap();
+
+    if pipeline_input.audio_eos_received.is_some() {
+        for (_, output) in guard.outputs.iter_mut() {
+            if let Some(ref mut cond) = output.audio_end_condition {
+                cond.on_input_registered(&input_id);
             }
         }
-
-        if pipeline_input.video_eos_received.is_some() {
-            for (_, output) in self.outputs.iter_mut() {
-                if let Some(ref mut cond) = output.video_end_condition {
-                    cond.on_input_registered(&input_id);
-                }
-            }
-        }
-
-        self.inputs.insert(input_id.clone(), pipeline_input);
-        self.queue
-            .add_input(&input_id, decoded_data_receiver, queue_options);
-        self.renderer.register_input(input_id);
-
-        Ok(port)
     }
+
+    if pipeline_input.video_eos_received.is_some() {
+        for (_, output) in guard.outputs.iter_mut() {
+            if let Some(ref mut cond) = output.video_end_condition {
+                cond.on_input_registered(&input_id);
+            }
+        }
+    }
+
+    guard.inputs.insert(input_id.clone(), pipeline_input);
+    guard
+        .queue
+        .add_input(&input_id, decoded_data_receiver, queue_options);
+    guard.renderer.register_input(input_id);
+
+    Ok(port)
 }
 
 impl PipelineInput {

--- a/src/api/register_request.rs
+++ b/src/api/register_request.rs
@@ -10,7 +10,7 @@ fn handle_register_input(
     input_id: InputId,
     register_options: RegisterInputOptions,
 ) -> Result<ResponseHandler, ApiError> {
-    match api.pipeline().register_input(input_id, register_options)? {
+    match Pipeline::register_input(&api.pipeline, input_id, register_options)? {
         Some(Port(port)) => Ok(ResponseHandler::Response(Response::RegisteredPort { port })),
         None => Ok(ResponseHandler::Ok),
     }


### PR DESCRIPTION
Closes #432 

If creating decoder or initializing input takes some time it will no longer block main processing pipeline