### PR TITLE
Add instane_id to the compositore and return it in `GET /status`

### DIFF
--- a/docs/pages/api/routes.md
+++ b/docs/pages/api/routes.md
@@ -128,4 +128,12 @@ Removes entities previously registered with [register input](#register-input-str
 
 ## Endpoint `GET /status`
 
+```typescript
+type Response = {
+  instance_id: string
+}
+```
+
 Status/health check endpoint. Returns `200 OK`.
+
+- `instance_id` - ID that can be provided using `LIVE_COMPOSITOR_INSTANCE_ID` environment variable. Defaults to random value in the format `live_compositor_{RANDOM_VALUE}`.

--- a/docs/pages/deployment/configuration.md
+++ b/docs/pages/deployment/configuration.md
@@ -6,6 +6,10 @@
 
 API port. Defaults to 8001.
 
+### `LIVE_COMPOSITOR_INSTANCE_ID`
+
+ID that will be returned in `GET /status` request. Can be used to identify if we are connecting to the correct compositor instance.
+
 ### `LIVE_COMPOSITOR_OUTPUT_FRAMERATE`
 
 Output framerate for all output streams. This value can be a number or string in the `NUM/DEN` format, where both `NUM` and `DEN` are unsigned integers.

--- a/src/api.rs
+++ b/src/api.rs
@@ -70,6 +70,7 @@ pub enum QueryRequest {
 #[serde(untagged)]
 pub enum Response {
     Ok {},
+    Status { instance_id: String },
     RegisteredPort { port: u16 },
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,11 +3,13 @@ use std::{env, path::PathBuf, str::FromStr, sync::OnceLock, time::Duration};
 use compositor_pipeline::queue::QueueOptions;
 use compositor_render::{web_renderer::WebRendererInitOptions, Framerate};
 use log::error;
+use rand::Rng;
 
 use crate::logger::FfmpegLogLevel;
 
 #[derive(Debug)]
 pub struct Config {
+    pub instance_id: String,
     pub api_port: u16,
     pub logger: LoggerConfig,
     pub stream_fallback_timeout: Duration,
@@ -59,6 +61,11 @@ fn read_config() -> Result<Config, String> {
             .parse::<u16>()
             .map_err(|_| "LIVE_COMPOSITOR_API_PORT has to be valid port number")?,
         Err(_) => 8081,
+    };
+
+    let instance_id = match env::var("LIVE_COMPOSITOR_INSTANCE_ID") {
+        Ok(instance_id) => instance_id,
+        Err(_) => format!("live_compositor_{}", rand::thread_rng().gen::<u32>()),
     };
 
     let ffmpeg_logger_level = match env::var("LIVE_COMPOSITOR_FFMPEG_LOGGER_LEVEL") {
@@ -151,6 +158,7 @@ fn read_config() -> Result<Config, String> {
     };
 
     let config = Config {
+        instance_id,
         api_port,
         logger: LoggerConfig {
             ffmpeg_logger_level,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -2,7 +2,8 @@ use tiny_http::Method;
 use tracing::{debug, trace};
 
 use crate::{
-    api::{Api, ResponseHandler},
+    api::{Api, Response, ResponseHandler},
+    config::config,
     error::ApiError,
 };
 
@@ -12,7 +13,9 @@ pub fn handle_request(
 ) -> Result<ResponseHandler, ApiError> {
     match (request.method(), request.url()) {
         (Method::Post, "/--/api") => handle_api_request(api, request),
-        (Method::Get, "/status") => Ok(ResponseHandler::Ok),
+        (Method::Get, "/status") => Ok(ResponseHandler::Response(Response::Status {
+            instance_id: config().instance_id.clone(),
+        })),
         _ => Err(ApiError::new(
             "NOT FOUND",
             "Unknown endpoint".to_string(),


### PR DESCRIPTION
This value will be used in the plugin to verify that we are connecting to the correct instance. With the current plugin implementation, it's possible to connect by mistake to the existing compositor instance.