### PR TITLE
Fix integration tests sometimes failing

### DIFF
--- a/compositor_integration_tests/src/tests/simple.rs
+++ b/compositor_integration_tests/src/tests/simple.rs
@@ -64,7 +64,7 @@ pub fn simple_test() -> Result<()> {
     compare_dumps(
         &output_dump_from_disk,
         &new_output_dump,
-        &[Duration::from_secs(1), Duration::from_secs(2)],
+        &[Duration::from_millis(500), Duration::from_millis(1500)],
         20.0,
     )?;
 

--- a/compositor_integration_tests/src/validation.rs
+++ b/compositor_integration_tests/src/validation.rs
@@ -60,7 +60,10 @@ fn compare_video_dumps(
         let diff_v = calculate_diff(&expected.data.v_plane, &actual.data.v_plane);
 
         if diff_y > allowed_error || diff_u > allowed_error || diff_v > allowed_error {
-            return Err(anyhow::anyhow!("Frame mismatch"));
+            let pts = pts.as_micros();
+            return Err(anyhow::anyhow!(
+                "Frame mismatch. PTS: {pts}, Diff Y: {diff_y}, Diff U: {diff_u}, Diff V: {diff_v}"
+            ));
         }
     }
 


### PR DESCRIPTION
I couldn't reproduce the problem locally but I believe it's caused by wrongly chosen timestamps.

The test video consists of images where each image appears for 1 second. I used timestamps that were at the transition between images