### PR TITLE
Split RTP-depayloaded packets using the marker bit.

### DIFF
--- a/compositor_pipeline/src/pipeline/input/rtp/depayloader.rs
+++ b/compositor_pipeline/src/pipeline/input/rtp/depayloader.rs
@@ -69,7 +69,6 @@ pub enum VideoDepayloader {
     H264 {
         depayloader: H264Packet,
         buffer: Vec<Bytes>,
-        last_timestamp: u32,
     },
 }
 
@@ -79,7 +78,6 @@ impl VideoDepayloader {
             VideoCodec::H264 => VideoDepayloader::H264 {
                 depayloader: H264Packet::default(),
                 buffer: vec![],
-                last_timestamp: 0,
             },
         }
     }
@@ -92,7 +90,6 @@ impl VideoDepayloader {
             VideoDepayloader::H264 {
                 depayloader,
                 buffer,
-                last_timestamp,
             } => {
                 let kind = EncodedChunkKind::Video(VideoCodec::H264);
                 let h264_chunk = depayloader.depacketize(&packet.payload)?;
@@ -101,24 +98,23 @@ impl VideoDepayloader {
                     return Ok(None);
                 }
 
-                if *last_timestamp == 0 {
-                    *last_timestamp = packet.header.timestamp;
-                }
-
-                if packet.header.timestamp == *last_timestamp {
+                if !packet.header.marker {
+                    // not at access unit border, buffer the packet
                     buffer.push(h264_chunk);
                     return Ok(None);
                 }
 
+                let mut data = buffer.concat();
+                data.extend(h264_chunk);
+
                 let new_chunk = EncodedChunk {
-                    data: buffer.concat().into(),
-                    pts: Duration::from_secs_f64(*last_timestamp as f64 / 90000.0),
+                    data: data.into(),
+                    pts: Duration::from_secs_f64(packet.header.timestamp as f64 / 90000.0),
                     dts: None,
                     kind,
                 };
 
-                *buffer = vec![h264_chunk];
-                *last_timestamp = packet.header.timestamp;
+                *buffer = Vec::new();
 
                 Ok(Some(new_chunk))
             }


### PR DESCRIPTION
This also turns off the ffmpeg decoder option that allowed delivering non-au-aligned data.