### PR TITLE
Support offline processing without any inputs

### DIFF
--- a/compositor_pipeline/src/queue.rs
+++ b/compositor_pipeline/src/queue.rs
@@ -48,6 +48,9 @@ pub struct Queue {
 
     /// Define if queue should process frames if all inputs are ready.
     ahead_of_time_processing: bool,
+    /// If true do not drop output frames even if queue is behind the
+    /// real time clock.
+    never_drop_output_frames: bool,
 
     /// Defines behavior when event is scheduled too late:
     /// true - Event will be executed immediately.
@@ -117,6 +120,7 @@ pub struct QueueOptions {
     pub ahead_of_time_processing: bool,
     pub output_framerate: Framerate,
     pub run_late_scheduled_events: bool,
+    pub never_drop_output_frames: bool,
 }
 
 pub struct ScheduledEvent {
@@ -154,6 +158,7 @@ impl Queue {
             scheduled_event_sender,
             start_sender: Mutex::new(Some(queue_start_sender)),
             ahead_of_time_processing: opts.ahead_of_time_processing,
+            never_drop_output_frames: opts.never_drop_output_frames,
             run_late_scheduled_events: opts.run_late_scheduled_events,
 
             clock: Clock::new(),

--- a/compositor_pipeline/src/queue/queue_thread.rs
+++ b/compositor_pipeline/src/queue/queue_thread.rs
@@ -244,8 +244,8 @@ impl VideoQueueProcessor {
 
         let frames_batch = internal_queue.get_frames_batch(next_buffer_pts, self.queue_start_time);
 
-        let is_required =
-            internal_queue.has_required_inputs_for_pts(next_buffer_pts, self.queue_start_time);
+        let is_required = self.queue.never_drop_output_frames
+            || internal_queue.has_required_inputs_for_pts(next_buffer_pts, self.queue_start_time);
         drop(internal_queue);
 
         // potentially infinitely blocking if output is not consumed
@@ -309,8 +309,9 @@ impl AudioQueueProcessor {
         }
 
         let samples = internal_queue.pop_samples_set(next_buffer_pts_range, self.queue_start_time);
-        let is_required = internal_queue
-            .has_required_inputs_for_pts(next_buffer_pts_range.0, self.queue_start_time);
+        let is_required = self.queue.never_drop_output_frames
+            || internal_queue
+                .has_required_inputs_for_pts(next_buffer_pts_range.0, self.queue_start_time);
         drop(internal_queue);
 
         self.send_output_batch(samples, is_required);

--- a/docs/pages/deployment/configuration.md
+++ b/docs/pages/deployment/configuration.md
@@ -77,13 +77,25 @@ Enable GPU support inside the embedded Chromium instance.
 
 Defaults to `true`. Valid values: `true`, `false`, `1`, `0`.
 
+### `LIVE_COMPOSITOR_OFFLINE_PROCESSING_ENABLE`
+
+If enabled, sets `LIVE_COMPOSITOR_AHEAD_OF_TIME_PROCESSING_ENABLE` and `LIVE_COMPOSITOR_NEVER_DROP_OUTPUT_FRAMES` options to `true`. If those values are also defined then they take priority over this value.
+
+Defaults to `false`. Valid values: `true`, `false`, `1`, `0`.
+
 ### `LIVE_COMPOSITOR_AHEAD_OF_TIME_PROCESSING_ENABLE`
 
-If enabled, the LiveCompositor server will try to generate output frames ahead of time if all inputs are available.
+If enabled, the LiveCompositor server will try to generate output frames/samples ahead of time if all inputs are available.
 
 When to enable this option:
 
 - If you want to process input streams faster than in real time.
+
+Defaults to `false`. Valid values: `true`, `false`, `1`, `0`.
+
+### `LIVE_COMPOSITOR_NEVER_DROP_OUTPUT_FRAMES`
+
+If enabled, the LiveCompositor server will not drop frames/samples from output stream even if rendering or encoding is not fast enough to process it in real time.
 
 Defaults to `false`. Valid values: `true`, `false`, `1`, `0`.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -145,11 +145,22 @@ fn read_config() -> Result<Config, String> {
         Err(_) => true,
     };
 
+    let offline_processing: bool = match env::var("LIVE_COMPOSITOR_OFFLINE_PROCESSING_ENABLE") {
+        Ok(enable) => bool_env_from_str(&enable).unwrap_or(false),
+        Err(_) => false,
+    };
+
     let ahead_of_time_processing: bool =
         match env::var("LIVE_COMPOSITOR_AHEAD_OF_TIME_PROCESSING_ENABLE") {
-            Ok(enable) => bool_env_from_str(&enable).unwrap_or(false),
+            Ok(enable) => bool_env_from_str(&enable).unwrap_or(offline_processing),
             Err(_) => false,
         };
+
+    let never_drop_output_frames: bool = match env::var("LIVE_COMPOSITOR_NEVER_DROP_OUTPUT_FRAMES")
+    {
+        Ok(enable) => bool_env_from_str(&enable).unwrap_or(offline_processing),
+        Err(_) => false,
+    };
 
     let run_late_scheduled_events = match env::var("LIVE_COMPOSITOR_RUN_LATE_SCHEDULED_EVENTS") {
         Ok(enable) => bool_env_from_str(&enable).unwrap_or(false),
@@ -168,6 +179,7 @@ fn read_config() -> Result<Config, String> {
             ahead_of_time_processing,
             output_framerate: framerate,
             run_late_scheduled_events,
+            never_drop_output_frames,
         },
         stream_fallback_timeout,
         force_gpu,


### PR DESCRIPTION
With the current setup if you have:
- ahead of time processing enabled
- there is no inputs
- and machine is not able to encode/render frames in real time

then queue will drop some output frames