### PR TITLE
Add option to provide raw FFmpeg options

### DIFF
--- a/docs/pages/api/outputs/rtp.md
+++ b/docs/pages/api/outputs/rtp.md
@@ -28,6 +28,7 @@ Register a new RTP output stream.
 type Video = {
   resolution: { width: number; height: number };
   encoder_preset?: VideoEncoderPreset;
+  ffmpeg_options?: Map<String, String>;
   send_eos_when?: EosCondition;
   initial: Component;
 }
@@ -48,6 +49,7 @@ type VideoEncoderPreset =
 
 - `resolution` - Output resolution in pixels.
 - `encoder_preset` - (**default=`"fast"`**) Preset for an encoder. See `FFmpeg` [docs](https://trac.ffmpeg.org/wiki/Encode/H.264#Preset) to learn more.
+- `ffmepg_options` - Raw FFmpeg encoder options. See [docs](https://ffmpeg.org/ffmpeg-codecs.html) for more.
 - `send_eos_when` - Defines when output stream should end if some of the input streams are finished. If output includes both audio and video streams, then EOS needs to be sent on both.
 - `initial` - Root of a component tree/scene that should be rendered for the output. Use [`update_output` request](../routes.md#update-output) to update this value after registration. [Learn more](../../concept/component.md).
 

--- a/schemas/register.schema.json
+++ b/schemas/register.schema.json
@@ -531,6 +531,16 @@
         "encoder_preset": {
           "$ref": "#/definitions/VideoEncoderPreset"
         },
+        "ffmpeg_options": {
+          "description": "Raw FFmpeg encoder options. See [docs](https://ffmpeg.org/ffmpeg-codecs.html) for more.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "initial": {
           "$ref": "#/definitions/Component"
         },

--- a/src/types/from_register_request.rs
+++ b/src/types/from_register_request.rs
@@ -263,6 +263,7 @@ impl TryFrom<RegisterOutputRequest> for pipeline::RegisterOutputOptions {
                         preset: v.encoder_preset.into(),
                         resolution: v.resolution.into(),
                         output_id: output_id.clone().into(),
+                        raw_options: v.ffmpeg_options.unwrap_or_default().into_iter().collect(),
                     }),
                     end_condition: v.send_eos_when.unwrap_or_default().try_into()?,
                 })

--- a/src/types/register_request.rs
+++ b/src/types/register_request.rs
@@ -1,4 +1,5 @@
 use core::f64;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use schemars::JsonSchema;
@@ -124,6 +125,8 @@ pub enum Port {
 pub struct OutputVideoOptions {
     pub resolution: Resolution,
     pub encoder_preset: VideoEncoderPreset,
+    /// Raw FFmpeg encoder options. See [docs](https://ffmpeg.org/ffmpeg-codecs.html) for more.
+    pub ffmpeg_options: Option<HashMap<String, String>>,
     pub initial: Component,
     /// Condition for termination of output stream based on the input streams states.
     pub send_eos_when: Option<OutputEndCondition>,


### PR DESCRIPTION
I'm not sure about the field name, other options I considered:
- `extra_options`
- `ffmpeg_extra_options`
- `raw_ffmpeg_options`
- `ffmpeg_overrides`