### PR TITLE
Dynamically assign ports in tests

### DIFF
--- a/compositor_integration_tests/src/compositor_instance.rs
+++ b/compositor_integration_tests/src/compositor_instance.rs
@@ -1,7 +1,15 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use compositor_render::use_global_wgpu_ctx;
 use reqwest::StatusCode;
-use std::{env, sync::Mutex, thread, time::Duration};
+use std::{
+    env,
+    sync::{
+        atomic::{AtomicU16, Ordering},
+        OnceLock,
+    },
+    thread,
+    time::{Duration, Instant},
+};
 use video_compositor::{
     config::{read_config, LoggerConfig, LoggerFormat},
     logger::{self, FfmpegLogLevel},
@@ -14,8 +22,9 @@ pub struct CompositorInstance {
 }
 
 impl CompositorInstance {
-    pub fn start(api_port: u16) -> Self {
+    pub fn start() -> Self {
         init_compositor_prerequisites();
+        let api_port = get_free_port();
         let mut config = read_config();
         config.api_port = api_port;
 
@@ -24,12 +33,12 @@ impl CompositorInstance {
             .spawn(move || server::run_with_config(config))
             .unwrap();
 
-        thread::sleep(Duration::from_millis(5000));
-
-        CompositorInstance {
+        let instance = CompositorInstance {
             api_port,
             http_client: reqwest::blocking::Client::new(),
-        }
+        };
+        instance.wait_for_start(Duration::from_secs(30)).unwrap();
+        instance
     }
 
     pub fn send_request(&self, request_body: serde_json::Value) -> Result<()> {
@@ -51,25 +60,44 @@ impl CompositorInstance {
 
         Ok(())
     }
-}
 
-static GLOBAL_PREREQUISITES_INITIALIZED: Mutex<bool> = Mutex::new(false);
-
-fn init_compositor_prerequisites() {
-    let mut initialized = GLOBAL_PREREQUISITES_INITIALIZED.lock().unwrap();
-    if *initialized {
-        return;
+    pub fn get_port(&self) -> u16 {
+        get_free_port()
     }
 
-    env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
-    ffmpeg_next::format::network::init();
-    logger::init_logger(LoggerConfig {
-        ffmpeg_logger_level: FfmpegLogLevel::Info,
-        format: LoggerFormat::Compact,
-        level: "info".to_string(),
+    fn wait_for_start(&self, timeout: Duration) -> Result<()> {
+        let start = Instant::now();
+        loop {
+            let response = self
+                .http_client
+                .get(format!("http://127.0.0.1:{}/status", self.api_port))
+                .timeout(Duration::from_secs(1))
+                .send();
+            if response.is_ok() {
+                return Ok(());
+            }
+            if start + timeout < Instant::now() {
+                return Err(anyhow!("Failed to connect to instance."));
+            }
+        }
+    }
+}
+
+fn get_free_port() -> u16 {
+    static LAST_PORT: AtomicU16 = AtomicU16::new(10_000);
+    LAST_PORT.fetch_add(1, Ordering::Relaxed)
+}
+
+fn init_compositor_prerequisites() {
+    static GLOBAL_PREREQUISITES_INITIALIZED: OnceLock<()> = OnceLock::new();
+    GLOBAL_PREREQUISITES_INITIALIZED.get_or_init(|| {
+        env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
+        ffmpeg_next::format::network::init();
+        logger::init_logger(LoggerConfig {
+            ffmpeg_logger_level: FfmpegLogLevel::Info,
+            format: LoggerFormat::Compact,
+            level: "info".to_string(),
+        });
+        use_global_wgpu_ctx();
     });
-
-    use_global_wgpu_ctx();
-
-    *initialized = true;
 }

--- a/compositor_integration_tests/src/tests/audio_mixing.rs
+++ b/compositor_integration_tests/src/tests/audio_mixing.rs
@@ -8,10 +8,13 @@ use crate::{
 };
 
 pub fn audio_mixing() -> Result<()> {
-    let instance = CompositorInstance::start(8030);
+    let instance = CompositorInstance::start();
+    let input_1_port = instance.get_port();
+    let input_2_port = instance.get_port();
+    let output_port = instance.get_port();
 
     let output_receiver = OutputReceiver::start(
-        8031,
+        output_port,
         CommunicationProtocol::Udp,
         Duration::from_secs(10),
         "audio_mixing_output.rtp",
@@ -23,7 +26,7 @@ pub fn audio_mixing() -> Result<()> {
         "output_id": "output_1",
         "transport_protocol": "udp",
         "ip": "127.0.0.1",
-        "port": 8031,
+        "port": output_port,
         "audio": {
             "initial": {
                 "inputs": [
@@ -46,7 +49,7 @@ pub fn audio_mixing() -> Result<()> {
         "entity_type": "rtp_input_stream",
         "transport_protocol": "tcp_server",
         "input_id": "input_1",
-        "port": 8032,
+        "port": input_1_port,
         "audio": {
             "codec": "opus"
         }
@@ -57,7 +60,7 @@ pub fn audio_mixing() -> Result<()> {
         "entity_type": "rtp_input_stream",
         "transport_protocol": "udp",
         "input_id": "input_2",
-        "port": 8033,
+        "port": input_2_port,
         "audio": {
             "codec": "opus"
         }
@@ -65,8 +68,8 @@ pub fn audio_mixing() -> Result<()> {
 
     let audio_input_1 = input_dump_from_disk("8_colors_input_audio.rtp")?;
     let audio_input_2 = input_dump_from_disk("8_colors_input_reversed_audio.rtp")?;
-    let mut audio_1_sender = PacketSender::new(CommunicationProtocol::Tcp, 8032)?;
-    let mut audio_2_sender = PacketSender::new(CommunicationProtocol::Udp, 8033)?;
+    let mut audio_1_sender = PacketSender::new(CommunicationProtocol::Tcp, input_1_port)?;
+    let mut audio_2_sender = PacketSender::new(CommunicationProtocol::Udp, input_2_port)?;
 
     audio_1_sender.send(&audio_input_1)?;
     audio_2_sender.send(&audio_input_2)?;

--- a/compositor_integration_tests/src/tests/muxed_video_audio.rs
+++ b/compositor_integration_tests/src/tests/muxed_video_audio.rs
@@ -8,10 +8,12 @@ use crate::{
 };
 
 pub fn muxed_video_audio() -> Result<()> {
-    let instance = CompositorInstance::start(8000);
+    let instance = CompositorInstance::start();
+    let input_port = instance.get_port();
+    let output_port = instance.get_port();
 
     let output_receiver = OutputReceiver::start(
-        8001,
+        output_port,
         CommunicationProtocol::Udp,
         Duration::from_secs(10),
         "muxed_video_audio_output.rtp",
@@ -23,7 +25,7 @@ pub fn muxed_video_audio() -> Result<()> {
         "output_id": "output_1",
         "transport_protocol": "udp",
         "ip": "127.0.0.1",
-        "port": 8001,
+        "port": output_port,
         "video": {
             "resolution": {
                 "width": 1280,
@@ -53,7 +55,7 @@ pub fn muxed_video_audio() -> Result<()> {
         "entity_type": "rtp_input_stream",
         "transport_protocol": "tcp_server",
         "input_id": "input_1",
-        "port": 8002,
+        "port": input_port,
         "video": {
             "codec": "h264"
         },
@@ -63,7 +65,7 @@ pub fn muxed_video_audio() -> Result<()> {
     }))?;
 
     let packets_dump = input_dump_from_disk("8_colors_input_video_audio.rtp")?;
-    let mut packet_sender = PacketSender::new(CommunicationProtocol::Tcp, 8002)?;
+    let mut packet_sender = PacketSender::new(CommunicationProtocol::Tcp, input_port)?;
     packet_sender.send(&packets_dump)?;
 
     instance.send_request(json!({

--- a/compositor_integration_tests/src/tests/required_inputs.rs
+++ b/compositor_integration_tests/src/tests/required_inputs.rs
@@ -8,14 +8,17 @@ use anyhow::Result;
 use serde_json::json;
 
 pub fn required_inputs() -> Result<()> {
-    let instance = CompositorInstance::start(8010);
+    let instance = CompositorInstance::start();
+    let input_1_port = instance.get_port();
+    let input_2_port = instance.get_port();
+    let output_port = instance.get_port();
 
     instance.send_request(json!({
         "type": "register",
         "entity_type": "output_stream",
         "output_id": "output_1",
         "transport_protocol": "tcp_server",
-        "port": 8011,
+        "port": output_port,
         "video": {
             "resolution": {
                 "width": 1280,
@@ -41,7 +44,7 @@ pub fn required_inputs() -> Result<()> {
     }))?;
 
     let output_receiver = OutputReceiver::start(
-        8011,
+        output_port,
         CommunicationProtocol::Tcp,
         Duration::from_secs(10),
         "required_inputs_output.rtp",
@@ -52,7 +55,7 @@ pub fn required_inputs() -> Result<()> {
         "entity_type": "rtp_input_stream",
         "transport_protocol": "tcp_server",
         "input_id": "input_1",
-        "port": 8012,
+        "port": input_1_port,
         "video": {
             "codec": "h264"
         },
@@ -64,7 +67,7 @@ pub fn required_inputs() -> Result<()> {
         "entity_type": "rtp_input_stream",
         "transport_protocol": "tcp_server",
         "input_id": "input_2",
-        "port": 8013,
+        "port": input_2_port,
         "video": {
             "codec": "h264"
         },
@@ -75,8 +78,8 @@ pub fn required_inputs() -> Result<()> {
         "type": "start",
     }))?;
 
-    let mut input_1_sender = PacketSender::new(CommunicationProtocol::Tcp, 8012)?;
-    let mut input_2_sender = PacketSender::new(CommunicationProtocol::Tcp, 8013)?;
+    let mut input_1_sender = PacketSender::new(CommunicationProtocol::Tcp, input_1_port)?;
+    let mut input_2_sender = PacketSender::new(CommunicationProtocol::Tcp, input_2_port)?;
     let input_1_dump = input_dump_from_disk("8_colors_input_video.rtp")?;
     let input_2_dump = input_dump_from_disk("8_colors_input_reversed_video.rtp")?;
     let (input_2_first_part, input_2_second_part) =

--- a/compositor_integration_tests/src/tests/schedule_update.rs
+++ b/compositor_integration_tests/src/tests/schedule_update.rs
@@ -8,14 +8,17 @@ use anyhow::Result;
 use serde_json::json;
 
 pub fn schedule_update() -> Result<()> {
-    let instance = CompositorInstance::start(8040);
+    let instance = CompositorInstance::start();
+    let input_1_port = instance.get_port();
+    let input_2_port = instance.get_port();
+    let output_port = instance.get_port();
 
     instance.send_request(json!({
         "type": "register",
         "entity_type": "output_stream",
         "output_id": "output_1",
         "transport_protocol": "tcp_server",
-        "port": 8041,
+        "port": output_port,
         "video": {
             "resolution": {
                 "width": 1280,
@@ -72,7 +75,7 @@ pub fn schedule_update() -> Result<()> {
     }))?;
 
     let output_receiver = OutputReceiver::start(
-        8041,
+        output_port,
         CommunicationProtocol::Tcp,
         Duration::from_secs(10),
         "schedule_update_output.rtp",
@@ -83,7 +86,7 @@ pub fn schedule_update() -> Result<()> {
         "entity_type": "rtp_input_stream",
         "transport_protocol": "udp",
         "input_id": "input_1",
-        "port": 8042,
+        "port": input_1_port,
         "video": {
             "codec": "h264"
         },
@@ -94,7 +97,7 @@ pub fn schedule_update() -> Result<()> {
         "entity_type": "rtp_input_stream",
         "transport_protocol": "tcp_server",
         "input_id": "input_2",
-        "port": 8043,
+        "port": input_2_port,
         "video": {
             "codec": "h264"
         },
@@ -104,8 +107,8 @@ pub fn schedule_update() -> Result<()> {
         "type": "start",
     }))?;
 
-    let mut input_1_sender = PacketSender::new(CommunicationProtocol::Udp, 8042)?;
-    let mut input_2_sender = PacketSender::new(CommunicationProtocol::Tcp, 8043)?;
+    let mut input_1_sender = PacketSender::new(CommunicationProtocol::Udp, input_1_port)?;
+    let mut input_2_sender = PacketSender::new(CommunicationProtocol::Tcp, input_2_port)?;
     let input_1_dump = input_dump_from_disk("8_colors_input_video.rtp")?;
     let input_2_dump = input_dump_from_disk("8_colors_input_reversed_video.rtp")?;
 

--- a/compositor_integration_tests/src/tests/unregistering.rs
+++ b/compositor_integration_tests/src/tests/unregistering.rs
@@ -8,9 +8,12 @@ use anyhow::Result;
 use serde_json::json;
 
 pub fn unregistering() -> Result<()> {
-    let instance = CompositorInstance::start(8020);
+    let instance = CompositorInstance::start();
+    let input_port = instance.get_port();
+    let output_port = instance.get_port();
 
-    register_output_with_initial_scene(&instance).expect_err("Image has to be registered first");
+    register_output_with_initial_scene(&instance, output_port)
+        .expect_err("Image has to be registered first");
 
     instance.send_request(json!({
         "type": "register",
@@ -20,10 +23,10 @@ pub fn unregistering() -> Result<()> {
         "url": "https://compositor.live/img/logo.svg"
     }))?;
 
-    register_output_with_initial_scene(&instance)?;
+    register_output_with_initial_scene(&instance, output_port)?;
 
     let output_receiver = OutputReceiver::start(
-        8021,
+        output_port,
         CommunicationProtocol::Tcp,
         Duration::from_secs(10),
         "unregistering_test_output.rtp",
@@ -34,14 +37,14 @@ pub fn unregistering() -> Result<()> {
         "entity_type": "rtp_input_stream",
         "transport_protocol": "udp",
         "input_id": "input_1",
-        "port": 8022,
+        "port": input_port,
         "video": {
             "codec": "h264"
         },
     }))?;
 
     let input_1_dump = input_dump_from_disk("8_colors_input_video.rtp")?;
-    let mut input_1_sender = PacketSender::new(CommunicationProtocol::Udp, 8022)?;
+    let mut input_1_sender = PacketSender::new(CommunicationProtocol::Udp, input_port)?;
 
     instance.send_request(json!({
         "type": "start",
@@ -75,13 +78,13 @@ pub fn unregistering() -> Result<()> {
     Ok(())
 }
 
-fn register_output_with_initial_scene(instance: &CompositorInstance) -> Result<()> {
+fn register_output_with_initial_scene(instance: &CompositorInstance, port: u16) -> Result<()> {
     instance.send_request(json!({
         "type": "register",
         "entity_type": "output_stream",
         "output_id": "output_1",
         "transport_protocol": "tcp_server",
-        "port": 8021,
+        "port": port,
         "video": {
             "resolution": {
                 "width": 1280,


### PR DESCRIPTION
- Dynamically find ports to use without a collision (start from 10000 port and increment)
- Replace sleep after instance creation with periodic check if http serer is up