### PR TITLE
Fix integration tests sometimes failing

### DIFF
--- a/compositor_integration_tests/src/compositor_instance.rs
+++ b/compositor_integration_tests/src/compositor_instance.rs
@@ -61,6 +61,7 @@ fn init_compositor_prerequisites() {
         return;
     }
 
+    env::set_var("LIVE_COMPOSITOR_NEVER_DROP_OUTPUT_FRAMES", "1");
     env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
     ffmpeg_next::format::network::init();
     logger::init_logger(LoggerConfig {

--- a/compositor_integration_tests/src/compositor_instance.rs
+++ b/compositor_integration_tests/src/compositor_instance.rs
@@ -91,7 +91,6 @@ fn get_free_port() -> u16 {
 fn init_compositor_prerequisites() {
     static GLOBAL_PREREQUISITES_INITIALIZED: OnceLock<()> = OnceLock::new();
     GLOBAL_PREREQUISITES_INITIALIZED.get_or_init(|| {
-        env::set_var("LIVE_COMPOSITOR_NEVER_DROP_OUTPUT_FRAMES", "1");
         env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
         ffmpeg_next::format::network::init();
         logger::init_logger(LoggerConfig {

--- a/compositor_integration_tests/src/tests/audio_mixing.rs
+++ b/compositor_integration_tests/src/tests/audio_mixing.rs
@@ -13,7 +13,7 @@ pub fn audio_mixing() -> Result<()> {
     let output_receiver = OutputReceiver::start(
         8031,
         CommunicationProtocol::Udp,
-        Duration::from_secs(10),
+        Duration::from_secs(20),
         "audio_mixing_output.rtp",
     )?;
 

--- a/compositor_integration_tests/src/tests/muxed_video_audio.rs
+++ b/compositor_integration_tests/src/tests/muxed_video_audio.rs
@@ -13,7 +13,7 @@ pub fn muxed_video_audio() -> Result<()> {
     let output_receiver = OutputReceiver::start(
         8001,
         CommunicationProtocol::Udp,
-        Duration::from_secs(10),
+        Duration::from_secs(20),
         "muxed_video_audio_output.rtp",
     )?;
 
@@ -26,10 +26,10 @@ pub fn muxed_video_audio() -> Result<()> {
         "port": 8001,
         "video": {
             "resolution": {
-                "width": 1280,
-                "height": 720,
+                "width": 640,
+                "height": 360,
             },
-            "encoder_preset": "medium",
+            "encoder_preset": "ultrafast",
             "initial": {
                 "id": "input_1",
                 "type": "input_stream",

--- a/compositor_integration_tests/src/tests/required_inputs.rs
+++ b/compositor_integration_tests/src/tests/required_inputs.rs
@@ -18,10 +18,10 @@ pub fn required_inputs() -> Result<()> {
         "port": 8011,
         "video": {
             "resolution": {
-                "width": 1280,
-                "height": 720,
+                "width": 640,
+                "height": 360,
             },
-            "encoder_preset": "medium",
+            "encoder_preset": "ultrafast",
             "initial": {
                 "type": "tiles",
                 "padding": 3,
@@ -43,7 +43,7 @@ pub fn required_inputs() -> Result<()> {
     let output_receiver = OutputReceiver::start(
         8011,
         CommunicationProtocol::Tcp,
-        Duration::from_secs(10),
+        Duration::from_secs(20),
         "required_inputs_output.rtp",
     )?;
 

--- a/compositor_integration_tests/src/tests/schedule_update.rs
+++ b/compositor_integration_tests/src/tests/schedule_update.rs
@@ -18,10 +18,10 @@ pub fn schedule_update() -> Result<()> {
         "port": 8041,
         "video": {
             "resolution": {
-                "width": 1280,
-                "height": 720,
+                "width": 640,
+                "height": 360,
             },
-            "encoder_preset": "medium",
+            "encoder_preset": "ultrafast",
             "initial": {
                 "type": "tiles",
                 "id": "tiles_1",
@@ -74,7 +74,7 @@ pub fn schedule_update() -> Result<()> {
     let output_receiver = OutputReceiver::start(
         8041,
         CommunicationProtocol::Tcp,
-        Duration::from_secs(10),
+        Duration::from_secs(20),
         "schedule_update_output.rtp",
     )?;
 

--- a/compositor_integration_tests/src/tests/unregistering.rs
+++ b/compositor_integration_tests/src/tests/unregistering.rs
@@ -25,7 +25,7 @@ pub fn unregistering() -> Result<()> {
     let output_receiver = OutputReceiver::start(
         8021,
         CommunicationProtocol::Tcp,
-        Duration::from_secs(10),
+        Duration::from_secs(20),
         "unregistering_test_output.rtp",
     )?;
 
@@ -84,10 +84,10 @@ fn register_output_with_initial_scene(instance: &CompositorInstance) -> Result<(
         "port": 8021,
         "video": {
             "resolution": {
-                "width": 1280,
-                "height": 720,
+                "width": 640,
+                "height": 360,
             },
-            "encoder_preset": "medium",
+            "encoder_preset": "ultrafast",
             "initial": {
                 "type": "tiles",
                 "padding": 3,


### PR DESCRIPTION
- ~Added `LIVE_COMPOSITOR_NEVER_DROP_OUTPUT_FRAMES` env~
- Made output receiver dump longer
- Lowered resolution
- Changed `encoder_preset` to `ultrafast`

Snapshots PR: https://github.com/membraneframework-labs/video_compositor_snapshot_tests/pull/30