### PR TITLE
Do not mix sample batches older than queue start

### DIFF
--- a/compositor_pipeline/src/pipeline/decoder/audio/resampler.rs
+++ b/compositor_pipeline/src/pipeline/decoder/audio/resampler.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use log::{debug, error};
 use rubato::{FftFixedOut, Resampler as _};
+use tracing::trace;
 
 use crate::{audio_mixer::InputSamples, error::DecoderInitError};
 
@@ -154,6 +155,7 @@ impl FftResampler {
             }
         }
 
+        trace!(?resampled, "FFT resampler produced samples.");
         resampled
     }
 

--- a/compositor_pipeline/src/queue/utils.rs
+++ b/compositor_pipeline/src/queue/utils.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use compositor_render::{event_handler::emit_event, Frame, InputId};
-use log::warn;
+use tracing::warn;
 
 use crate::audio_mixer::InputSamples;
 use crate::event::Event;


### PR DESCRIPTION
When starting the compositor sample batch can start before the queue starts and after that. Because the PTS of samples can't be negative number the batch range of (-10ms, 10ms) would be converted to `(0, 10ms)` but still contain 20ms worth of samples. As a result, the mixer is detecting overlapping samples and printing warnings.

Additionally, add some logs + fix incorrect spans