### PR TITLE
Implement missing branches - remove leftover panicing `todo!()`-s

### DIFF
--- a/compositor_render/src/scene.rs
+++ b/compositor_render/src/scene.rs
@@ -146,8 +146,8 @@ impl StatefulComponent {
             StatefulComponent::InputStream(_) => vec![],
             StatefulComponent::Shader(shader) => shader.children.iter_mut().collect(),
             StatefulComponent::WebView(web) => web.children.iter_mut().collect(),
-            StatefulComponent::Image(_) => todo!(),
-            StatefulComponent::Text(_) => todo!(),
+            StatefulComponent::Image(_) => vec![],
+            StatefulComponent::Text(_) => vec![],
             StatefulComponent::Layout(layout) => layout.children_mut(),
         }
     }

--- a/compositor_render/src/transformations/image_renderer.rs
+++ b/compositor_render/src/transformations/image_renderer.rs
@@ -295,7 +295,7 @@ impl AnimatedAsset {
     fn new(ctx: &WgpuCtx, data: Bytes, format: ImageFormat) -> Result<Self, AnimatedError> {
         let decoded_frames = match format {
             ImageFormat::Gif => GifDecoder::new(&data[..])?.into_frames(),
-            _ => todo!(),
+            other => return Err(AnimatedError::UnsupportedImageFormat(other)),
         };
 
         let mut animation_duration: Duration = Duration::ZERO;
@@ -470,4 +470,7 @@ pub enum AnimatedError {
 
     #[error("Failed to parse image: {0}")]
     FailedToParse(#[from] image::ImageError),
+    
+    #[error("Unsupported animated image format: {0:?}")]
+    UnsupportedImageFormat(ImageFormat),
 }

--- a/compositor_render/src/transformations/image_renderer.rs
+++ b/compositor_render/src/transformations/image_renderer.rs
@@ -470,7 +470,7 @@ pub enum AnimatedError {
 
     #[error("Failed to parse image: {0}")]
     FailedToParse(#[from] image::ImageError),
-    
+
     #[error("Unsupported animated image format: {0:?}")]
     UnsupportedImageFormat(ImageFormat),
 }


### PR DESCRIPTION
I'll add `todo!()` CI check in the next PR