### PR TITLE
Fix server startup

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -24,7 +24,7 @@ pub fn run() {
     thread::Builder::new()
         .name("HTTP server startup thread".to_string())
         .spawn(move || {
-            let (_, should_close_receiver) = crossbeam_channel::bounded(1);
+            let (_should_close_sender, should_close_receiver) = crossbeam_channel::bounded(1);
             if let Err(err) = run_api(state, should_close_receiver) {
                 error!(%err);
                 process::exit(1);


### PR DESCRIPTION
If you use `_` in rust then the value will be dropped immediately, so in this case server is crashing on startup because channel was closed