### PR TITLE
Inherit width/height in absolute positioning

### DIFF
--- a/compositor_render/src/scene.rs
+++ b/compositor_render/src/scene.rs
@@ -107,7 +107,7 @@ impl StatefulComponent {
             StatefulComponent::Text(text) => Some(text.width()),
             StatefulComponent::Layout(layout) => match layout.position(pts) {
                 Position::Static { width, .. } => width,
-                Position::Absolute(position) => Some(position.width),
+                Position::Absolute(position) => position.width,
             },
         }
     }
@@ -121,7 +121,7 @@ impl StatefulComponent {
             StatefulComponent::Text(text) => Some(text.height()),
             StatefulComponent::Layout(layout) => match layout.position(pts) {
                 Position::Static { height, .. } => height,
-                Position::Absolute(position) => Some(position.height),
+                Position::Absolute(position) => position.height,
             },
         }
     }

--- a/compositor_render/src/scene/layout.rs
+++ b/compositor_render/src/scene/layout.rs
@@ -162,16 +162,18 @@ impl StatefulLayoutComponent {
         parent_size: Size,
         pts: Duration,
     ) -> NestedLayout {
+        let width = position.width.unwrap_or(parent_size.width);
+        let height = position.height.unwrap_or(parent_size.height);
+
         let top = match position.position_vertical {
             VerticalPosition::TopOffset(top) => top,
-            VerticalPosition::BottomOffset(bottom) => parent_size.height - bottom - position.height,
+            VerticalPosition::BottomOffset(bottom) => parent_size.height - bottom - height,
         };
         let left = match position.position_horizontal {
             HorizontalPosition::LeftOffset(left) => left,
-            HorizontalPosition::RightOffset(right) => parent_size.width - right - position.width,
+            HorizontalPosition::RightOffset(right) => parent_size.width - right - width,
         };
-        let width = position.width;
-        let height = position.height;
+
         let rotation_degrees = position.rotation_degrees;
         let content = Self::layout_content(child, 0);
         let crop = None;
@@ -235,8 +237,8 @@ impl SizedLayoutComponent {
                 height: height.unwrap_or(self.size.height),
             },
             Position::Absolute(position) => Size {
-                width: position.width,
-                height: position.height,
+                width: position.width.unwrap_or(self.size.width),
+                height: position.height.unwrap_or(self.size.height),
             },
         }
         .into()

--- a/compositor_render/src/scene/scene_state.rs
+++ b/compositor_render/src/scene/scene_state.rs
@@ -210,7 +210,7 @@ impl IntermediateNode {
                     Position::Static { width, height } => (width, height),
                     // Technically absolute positioning is a bug here, but I think throwing error
                     // in this case would be to invasive. It's better to just ignore those values.
-                    Position::Absolute(position) => (Some(position.width), Some(position.height)),
+                    Position::Absolute(position) => (position.width, position.height),
                 };
                 if let (Some(width), Some(height)) = (width, height) {
                     Ok(Size { width, height })

--- a/compositor_render/src/scene/types.rs
+++ b/compositor_render/src/scene/types.rs
@@ -49,8 +49,8 @@ pub struct Size {
 
 #[derive(Debug, Clone, Copy)]
 pub struct AbsolutePosition {
-    pub width: f32,
-    pub height: f32,
+    pub width: Option<f32>,
+    pub height: Option<f32>,
     pub position_horizontal: HorizontalPosition,
     pub position_vertical: VerticalPosition,
     pub rotation_degrees: f32,

--- a/snapshot_tests/tiles/video_call_with_labels.scene.json
+++ b/snapshot_tests/tiles/video_call_with_labels.scene.json
@@ -1,0 +1,115 @@
+{
+    "video": {
+        "root": {
+            "type": "tiles",
+            "margin": 10,
+            "children": [
+                {
+                    "type": "view",
+                    "background_color_rgba": "#555555FF",
+                    "children": [
+                        {
+                            "type": "rescaler",
+                            "child": {
+                                "type": "input_stream",
+                                "input_id": "input_1"
+                            }
+                        },
+                        {
+                            "type": "view",
+                            "height": 40,
+                            "left": 0,
+                            "bottom": 0,
+                            "children": [
+                                {
+                                    "type": "view"
+                                },
+                                {
+                                    "type": "text",
+                                    "text": "InputStream 1 🚀",
+                                    "font_size": 25,
+                                    "align": "center",
+                                    "color_rgba": "#FFFFFFFF",
+                                    "background_color_rgba": "#FF0000FF"
+                                },
+                                {
+                                    "type": "view"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "view",
+                    "background_color_rgba": "#555555FF",
+                    "children": [
+                        {
+                            "type": "rescaler",
+                            "child": {
+                                "type": "input_stream",
+                                "input_id": "input_2"
+                            }
+                        },
+                        {
+                            "type": "view",
+                            "height": 40,
+                            "left": 0,
+                            "bottom": 0,
+                            "children": [
+                                {
+                                    "type": "view"
+                                },
+                                {
+                                    "type": "text",
+                                    "text": "InputStream 2 🚀",
+                                    "font_size": 25,
+                                    "align": "center",
+                                    "color_rgba": "#FFFFFFFF",
+                                    "background_color_rgba": "#FF0000FF"
+                                },
+                                {
+                                    "type": "view"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "view",
+                    "background_color_rgba": "#555555FF",
+                    "children": [
+                        {
+                            "type": "rescaler",
+                            "child": {
+                                "type": "input_stream",
+                                "input_id": "input_3"
+                            }
+                        },
+                        {
+                            "type": "view",
+                            "height": 40,
+                            "left": 0,
+                            "bottom": 0,
+                            "children": [
+                                {
+                                    "type": "view"
+                                },
+                                {
+                                    "type": "text",
+                                    "text": "InputStream 3 🚀",
+                                    "font_size": 25,
+                                    "align": "center",
+                                    "color_rgba": "#FFFFFFFF",
+                                    "background_color_rgba": "#FF0000FF"
+                                },
+                                {
+                                    "type": "view"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/src/bin/update_snapshots/main.rs
+++ b/src/bin/update_snapshots/main.rs
@@ -19,6 +19,7 @@ use crate::{
 
 fn main() {
     println!("Updating snapshots:");
+    tracing_subscriber::fmt().init();
     compositor_render::use_global_wgpu_ctx();
 
     let tests: Vec<_> = snapshot_tests();

--- a/src/snapshot_tests/tests.rs
+++ b/src/snapshot_tests/tests.rs
@@ -1004,6 +1004,12 @@ fn tiles_snapshot_tests() -> Vec<TestCase> {
             inputs: vec![input1.clone(), input2.clone(), input3.clone()],
             ..Default::default()
         },
+        TestCase{
+            name: "tiles/video_call_with_labels",
+            scene_updates: Updates::Scene(include_str!("../../snapshot_tests/tiles/video_call_with_labels.scene.json"), DEFAULT_RESOLUTION),
+            inputs: vec![portrait_input1.clone(), portrait_input2.clone(), portrait_input3.clone()],
+            ..Default::default()
+        }
     ])
 }
 

--- a/src/types/from_component.rs
+++ b/src/types/from_component.rs
@@ -37,10 +37,6 @@ impl TryFrom<View> for scene::ViewComponent {
     type Error = TypeError;
 
     fn try_from(view: View) -> Result<Self, Self::Error> {
-        const WIDTH_REQUIRED_MSG: &str =
-            "\"View\" component with absolute positioning requires \"width\" to be specified.";
-        const HEIGHT_REQUIRED_MSG: &str =
-            "\"View\" component with absolute positioning requires \"height\" to be specified.";
         const VERTICAL_REQUIRED_MSG: &str =
             "\"View\" component with absolute positioning requires either \"top\" or \"bottom\" coordinate.";
         const VERTICAL_ONLY_ONE_MSG: &str = "Fields \"top\" and \"bottom\" are mutually exclusive, you can only specify one on a \"View\" component.";
@@ -66,12 +62,8 @@ impl TryFrom<View> for scene::ViewComponent {
                 (Some(_), Some(_)) => return Err(TypeError::new(HORIZONTAL_ONLY_ONE_MSG)),
             };
             Position::Absolute(scene::AbsolutePosition {
-                width: (view
-                    .width
-                    .ok_or_else(|| TypeError::new(WIDTH_REQUIRED_MSG))?),
-                height: (view
-                    .height
-                    .ok_or_else(|| TypeError::new(HEIGHT_REQUIRED_MSG))?),
+                width: view.width.map(Into::into),
+                height: view.height.map(Into::into),
                 position_horizontal,
                 position_vertical,
                 rotation_degrees: view.rotation.unwrap_or(0.0),
@@ -117,10 +109,6 @@ impl TryFrom<Rescaler> for scene::RescalerComponent {
     type Error = TypeError;
 
     fn try_from(rescaler: Rescaler) -> Result<Self, Self::Error> {
-        const WIDTH_REQUIRED_MSG: &str =
-            "\"Rescaler\" component with absolute positioning requires \"width\" to be specified.";
-        const HEIGHT_REQUIRED_MSG: &str =
-            "\"Rescaler\" component with absolute positioning requires \"height\" to be specified.";
         const VERTICAL_REQUIRED_MSG: &str =
             "\"Rescaler\" component with absolute positioning requires either \"top\" or \"bottom\" coordinate.";
         const VERTICAL_ONLY_ONE_MSG: &str = "Fields \"top\" and \"bottom\" are mutually exclusive, you can only specify one on a \"Rescaler\" component.";
@@ -146,12 +134,8 @@ impl TryFrom<Rescaler> for scene::RescalerComponent {
                 (Some(_), Some(_)) => return Err(TypeError::new(HORIZONTAL_ONLY_ONE_MSG)),
             };
             Position::Absolute(scene::AbsolutePosition {
-                width: (rescaler
-                    .width
-                    .ok_or_else(|| TypeError::new(WIDTH_REQUIRED_MSG))?),
-                height: (rescaler
-                    .height
-                    .ok_or_else(|| TypeError::new(HEIGHT_REQUIRED_MSG))?),
+                width: rescaler.width.map(Into::into),
+                height: rescaler.height.map(Into::into),
                 position_horizontal,
                 position_vertical,
                 rotation_degrees: rescaler.rotation.unwrap_or(0.0),


### PR DESCRIPTION
When creating absolutely positioned element inherit the width/height of a parent if it's not provided.

I'll update docs in a follow up.

https://github.com/membraneframework-labs/video_compositor_snapshot_tests/pull/35