### PR TITLE
[docs] Fix inlining `PortOrPortRange` type

### DIFF
--- a/src/bin/generate_docs/docs_config.rs
+++ b/src/bin/generate_docs/docs_config.rs
@@ -11,7 +11,7 @@ impl Default for DocsConfig {
     fn default() -> Self {
         Self {
             ignored_definitions: vec!["Component"],
-            always_inlined_definitions: vec!["Port", "Resolution", "Audio", "Video"],
+            always_inlined_definitions: vec!["PortOrPortRange", "Resolution", "Audio", "Video"],
             never_inlined_definitions: vec![],
             variant_discriminators: [("AudioEncoderOptions", "type")].into(),
         }


### PR DESCRIPTION
Port type was renamed to PortOrPortRange