### PR TITLE
Do not warn on closed channel

### DIFF
--- a/compositor_pipeline/src/pipeline.rs
+++ b/compositor_pipeline/src/pipeline.rs
@@ -16,7 +16,7 @@ use compositor_render::RendererOptions;
 use compositor_render::{error::UpdateSceneError, Renderer};
 use compositor_render::{EventLoop, InputId, OutputId, RendererId, RendererSpec};
 use crossbeam_channel::{bounded, Receiver};
-use tracing::{error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::audio_mixer::AudioMixer;
 use crate::audio_mixer::MixingStrategy;
@@ -348,7 +348,7 @@ fn run_renderer_thread(
             };
 
             if frame_sender.send(PipelineEvent::Data(frame)).is_err() {
-                warn!(?output_id, "Failed to send output frames. Channel closed.");
+                debug!(?output_id, "Failed to send output frames. Channel closed.");
             }
 
             if send_eos {
@@ -407,7 +407,7 @@ fn run_audio_mixer_thread(
             };
 
             if samples_sender.send(PipelineEvent::Data(batch)).is_err() {
-                warn!(?output_id, "Failed to send mixed audio. Channel closed.");
+                debug!(?output_id, "Failed to send mixed audio. Channel closed.");
             }
 
             if send_eos {


### PR DESCRIPTION
When output receives eos based on `should_send_eos` condition the renderer is still active and producing frame. As a result this case is producing very noisy logs.

I'm changing that to debug for now to unblock next rc release, but in follow up I'll rework that code to warn if channel is closed but EOS was not sent yet.