### PR TITLE
[ci] Fix macos x86_64 publish job

### DIFF
--- a/.github/workflows/package_for_release.yml
+++ b/.github/workflows/package_for_release.yml
@@ -79,7 +79,7 @@ jobs:
                 path: artifacts/video_compositor_linux_aarch64.tar.gz
 
     macos_x86_64:
-        runs-on: macos-latest
+        runs-on: macos-12
         steps:
             - name: 🛠 Install system dependencies
               run: brew install ffmpeg


### PR DESCRIPTION
github actions changed what `macos-latest` means and it now uses M1 instance